### PR TITLE
Hotfix for shipping tax calculations

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -512,7 +512,7 @@ class WC_Taxjar_Integration extends WC_Integration {
     ) );
 
     // Store the rate ID and the amount on the cart's totals
-    $wc_cart_object->tax_total = $this->item_collectable + $this->shipping_collectable;
+    $wc_cart_object->tax_total = $this->item_collectable;
     $wc_cart_object->taxes = array($this->rate_id => $this->item_collectable);
     $wc_cart_object->shipping_taxes = array($this->rate_id => $this->shipping_collectable);
   }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,13 +43,14 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
   }
 
   public function setup() {
-    update_option('woocommerce_taxjar-integration_settings', 
+    update_option('woocommerce_taxjar-integration_settings',
       array(
-        'api_token' => $this->api_token, 
-        'enabled' => 'yes', 
+        'api_token' => $this->api_token,
+        'enabled' => 'yes',
         'taxjar_download' => 'yes',
         'store_zip' => '80111',
-        'store_city' => 'Greenwood Village'
+        'store_city' => 'Greenwood Village',
+        'debug' => 'yes'
       )
     );
 

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -3,12 +3,27 @@ class TJ_WC_Actions extends WP_UnitTestCase {
   function test_use_taxjar_total() {
     global $woocommerce;
     TaxJar_Woocommerce_helper::prepare_woocommerce();
+
     $tj = new WC_Taxjar_Integration();
 
-    $this->assertTrue($woocommerce->cart->tax_total == 0);
+    $this->assertTrue($woocommerce->cart->get_taxes_total() == 0);
 
-    do_action('woocommerce_calculate_totals', $woocommerce->cart);    
+    do_action('woocommerce_calculate_totals', $woocommerce->cart);
 
-    $this->assertTrue($woocommerce->cart->tax_total != 0);
+    $this->assertTrue($woocommerce->cart->get_taxes_total() != 0);
+  }
+
+  function test_the_correct_taxes_are_set() {
+    global $woocommerce;
+    TaxJar_Woocommerce_helper::prepare_woocommerce();
+    $tj = new WC_Taxjar_Integration();
+
+    $woocommerce->shipping->shipping_total = 5;
+
+    do_action('woocommerce_calculate_totals', $woocommerce->cart);
+
+    $this->assertEquals($woocommerce->cart->tax_total, 0.73, '', 0.001);
+    $this->assertEquals(array_values($woocommerce->cart->shipping_taxes)[0], 0.36, '', 0.001);
+    $this->assertEquals($woocommerce->cart->get_taxes_total(), 1.09, '', 0.001);
   }
 }

--- a/tests/specs/test-filters.php
+++ b/tests/specs/test-filters.php
@@ -7,13 +7,14 @@ class TJ_WC_Filters extends WP_UnitTestCase {
   function test_append_base_address_to_customer_taxable_address() {
     global $woocommerce;
     TaxJar_Woocommerce_helper::prepare_woocommerce();
+
     $tj = new WC_Taxjar_Integration();
     $woocommerce->session->set('chosen_shipping_methods', array('local_pickup'));
 
     $address = array('US', 'CO', '81210', 'Denver');
     $address = apply_filters('woocommerce_customer_taxable_address', $address);
 
-    $this->assertTrue($address[2] == $tj->settings['store_zip']);
-    $this->assertTrue($address[3] == $tj->settings['store_city']);
+    $this->assertEquals(strtoupper($address[2]), strtoupper($tj->settings['store_zip']));
+    $this->assertEquals(strtoupper($address[3]), strtoupper($tj->settings['store_city']));
   }
 }


### PR DESCRIPTION
Fixed a simple math bug that was causing an error in displaying the correct tax amount on checkout page.

Added a new spec to prove the bug and fix.