### PR TITLE
WooCommerce 2.5 compatibility

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -482,12 +482,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 
   public function clear_wc_tax_cache( $to_country, $to_state, $source_city, $source_zip ) {
     global $woocommerce;
-    $valid_postcodes = $this->_get_wildcard_postcodes( wc_clean( $source_zip ) );
 
     if ( version_compare( $woocommerce->version, '2.5.0', '>=' ) )  {
-      $cache_key         = WC_Cache_Helper::get_cache_prefix( 'taxes' ) . 'wc_tax_rates_' . md5( sprintf( '%s+%s+%s+%s+%s', $to_country, $to_state, $source_city, implode( ',', $valid_postcodes), '' ) );
+      $cache_key         = WC_Cache_Helper::get_cache_prefix( 'taxes' ) . 'wc_tax_rates_' . md5( sprintf( '%s+%s+%s+%s+%s', $to_country, $to_state, $source_city, wc_clean( $source_zip ), '' ) );
       wp_cache_delete( $cache_key, 'taxes' );
     } else {
+      $valid_postcodes = $this->_get_wildcard_postcodes( wc_clean( $source_zip ) );
       $rates_transient_key = 'wc_tax_rates_' . md5( sprintf( '%s+%s+%s+%s+%s', $to_country, $to_state, $source_city, implode( ',', $valid_postcodes), '' ) );
       delete_transient( $rates_transient_key );
     }

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -25,7 +25,7 @@ class WC_Taxjar_Integration extends WC_Integration {
     $this->integration_uri    = $this->app_uri. 'account/apps/add/woo';
     $this->regions_uri        = $this->app_uri. 'account#states';
     $this->uri                = 'https://api.taxjar.com/v2/';
-    $this->ua                 = 'TaxJarWordPressPlugin/1.1.8/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . $woocommerce->version . '; ' . get_bloginfo( 'url' );
+    $this->ua                 = 'TaxJarWordPressPlugin/1.1.9/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . $woocommerce->version . '; ' . get_bloginfo( 'url' );
     $this->debug              = filter_var( $this->get_option( 'debug' ), FILTER_VALIDATE_BOOLEAN );
     $this->download_orders    = new WC_Taxjar_Download_Orders($this);
 
@@ -334,7 +334,7 @@ class WC_Taxjar_Integration extends WC_Integration {
     $taxjar_response = false;
 
     // Make sure we don't have a cached rate
-    if ( false === ( $cache_value = get_transient( $cache_key ) ) ) {
+    if ( false === ( $cache_value = wp_cache_get( $cache_key, 'taxjar' ) ) ) {
       // Log this request
       $this->_log( "Requesting: " . $url );
 
@@ -380,7 +380,7 @@ class WC_Taxjar_Integration extends WC_Integration {
         $this->_log( "Cache Value: ". $cache_value );
 
         // Set Cache
-        set_transient( $cache_key, $cache_value, $this->cache_time );
+        wp_cache_set( $cache_key, $cache_value, 'taxjar', $this->cache_time );
 
       } else {
         // Log Response Error
@@ -438,9 +438,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			);
 
 			// Clear the cached rates
-      $valid_postcodes = $this->_get_wildcard_postcodes( wc_clean( $source_zip ) );
-      $rates_transient_key = 'wc_tax_rates_' . md5( sprintf( '%s+%s+%s+%s+%s', $to_country, $to_state, $source_city, implode( ',', $valid_postcodes), '' ) );
-      delete_transient( $rates_transient_key );
+      $this->clear_wc_tax_cache( $to_country, $to_state, $source_city, $source_zip );
 
 			$this->_log( $source_city );
 			$wc_rates = WC_Tax::find_rates( array(
@@ -482,6 +480,18 @@ class WC_Taxjar_Integration extends WC_Integration {
 
   }
 
+  public function clear_wc_tax_cache( $to_country, $to_state, $source_city, $source_zip ) {
+    global $woocommerce;
+    $valid_postcodes = $this->_get_wildcard_postcodes( wc_clean( $source_zip ) );
+
+    if ( version_compare( $woocommerce->version, '2.5.0', '>=' ) )  {
+      $cache_key         = WC_Cache_Helper::get_cache_prefix( 'taxes' ) . 'wc_tax_rates_' . md5( sprintf( '%s+%s+%s+%s+%s', $to_country, $to_state, $source_city, implode( ',', $valid_postcodes), '' ) );
+      wp_cache_delete( $cache_key, 'taxes' );
+    } else {
+      $rates_transient_key = 'wc_tax_rates_' . md5( sprintf( '%s+%s+%s+%s+%s', $to_country, $to_state, $source_city, implode( ',', $valid_postcodes), '' ) );
+      delete_transient( $rates_transient_key );
+    }
+  }
 
   /**
   * Ensure use of the TaxJar amount_to_collect and API data

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
  * Author: TaxJar
  * Author URI: http://www.taxjar.com
- * Version: 1.1.8
+ * Version: 1.1.9
  *
  */
 


### PR DESCRIPTION
WooCommerce 2.5 changed how rates were cached, moving from transients to wp_cache.  This branch adds support for removing new cached rates if integrated with WooCommerce V2.5 or the previous functionality if on integrated with an older version.

To keep up with best practiced I have also updated how API responses are cached to now use wp_cache.