### PR TITLE
properly handle when shipping is disabled in WooCommerce

### DIFF
--- a/includes/class-wc-taxjar-download-orders.php
+++ b/includes/class-wc-taxjar-download-orders.php
@@ -44,21 +44,21 @@ class WC_Taxjar_Download_Orders {
         if ( $keys ) {
           $consumer_key     = $keys['consumer_key'];
           $consumer_secret  = $keys['consumer_secret'];
-          $store_url        = site_url();
+          $store_url        = home_url();
           $success = $this->link_provider( $consumer_key, $consumer_secret, $store_url );
 
           if ( $success ) {
             return 'yes';
-          }        
+          }
         }
-    
+
         if ( !$success ) {
           $this->taxjar_download = false;
           $this->integration->errors[] = 'shop_not_linked';
           return 'no';
         }
       } else {
-        $this->unlink_provider( site_url() );
+        $this->unlink_provider( home_url() );
         return 'no';
       }
     }

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -308,6 +308,7 @@ class WC_Taxjar_Integration extends WC_Integration {
     $from_state       = $store_settings[ 'store_state_setting' ];
     $from_zip         = $store_settings[ 'taxjar_zip_code_setting' ];
     $from_city        = $store_settings[ 'taxjar_city_setting' ];
+    $shipping_amount  = is_null($shipping_amount) ? 0.0 : $shipping_amount;
 
     $this->_log( ':::: TaxJar API called ::::' );
 


### PR DESCRIPTION
Hi all,

This PR contains a fix for an API error that was being raised when shipping is disabled.  I also changed the connection code to use home_url() rather than site_url().  This has been tested by completing orders in the following scenarios:

- Purchased a physical product with shipping turned off.
- Purchased a virtual product which has shipping disabled.
- Purchased a physical product with shipping turned on.

I tested this using the latest version of WordPress (4.5.3) and the latest version of WooCommerce (2.6.1)
