### PR TITLE
TJ-1224 limit API calls to nexus areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.3 (2016-09-21)
+* Limit API calls for tax calculations to nexus areas.
+
 # 1.2.2 (2016-08-29)
 * Fix issue where uncached shipping tax was not displayed
 

--- a/includes/class-wc-taxjar-ajax.php
+++ b/includes/class-wc-taxjar-ajax.php
@@ -18,7 +18,7 @@ class WC_Taxjar_AJAX {
   }
 
   public function wc_taxjar_update_nexus_cache() {
-    $taxjar_nexus = new WC_Taxjar_Nexus;
+    $taxjar_nexus = new WC_Taxjar_Nexus(new WC_Taxjar_Integration);
     $taxjar_nexus->get_or_update_cached_nexus(true);
     die();
   }

--- a/includes/class-wc-taxjar-ajax.php
+++ b/includes/class-wc-taxjar-ajax.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * TaxJar AJAX
+ *
+ * @package  WC_Taxjar_Integration
+ * @author   TaxJar
+ */
+
+if ( ! defined( 'ABSPATH' ) )  {
+  exit; // Prevent direct access to script
+}
+
+class WC_Taxjar_AJAX {
+
+  public function __construct( ) {
+    add_action( 'wp_ajax_wc_taxjar_update_nexus_cache', array( $this, 'wc_taxjar_update_nexus_cache' ) );
+  }
+
+  public function wc_taxjar_update_nexus_cache() {
+    $taxjar_nexus = new WC_Taxjar_Nexus;
+    $taxjar_nexus->get_or_update_cached_nexus(true);
+    die();
+  }
+
+} // WC_Taxjar_AJAX
+
+new WC_Taxjar_AJAX();

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -302,7 +302,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 
     $taxjar_nexus = new WC_Taxjar_Nexus($this);
     if (!$taxjar_nexus->has_nexus_check($to_country, $to_state)) {
-      $this->_log( ':::: TaxJar User does not have nexus ::::' );
+      $this->_log( ':::: Order not shipping to nexus area ::::' );
       return false;
     }
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -835,7 +835,8 @@ class WC_Taxjar_Integration extends WC_Integration {
         'ajax_url'         => admin_url( 'admin-ajax.php' ),
         'update_api_nonce' => wp_create_nonce( 'update-api-key' ),
         'current_user'     => get_current_user_id(),
-        'integration_uri'  => $this->integration_uri
+        'integration_uri'  => $this->integration_uri,
+        'api_token'        => $this->post_or_setting('api_token')
       )
     );
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -294,8 +294,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 
     // Strict conditions to be met before API call can be conducted
     if(
-         empty( $to_state )
-      || empty( $to_country )
+        empty( $to_country )
       || empty( $to_zip )
       || $customer->is_vat_exempt()
     ) return false;
@@ -708,7 +707,7 @@ class WC_Taxjar_Integration extends WC_Integration {
   *
   * @return array
   */
-  private function get_store_settings( ) {
+  public function get_store_settings( ) {
     $default_wc_settings     = explode( ':', get_option('woocommerce_default_country') );
     $taxjar_zip_code_setting = $this->settings['store_zip'];
     $taxjar_city_setting     = $this->settings['store_city'];

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -25,7 +25,7 @@ class WC_Taxjar_Integration extends WC_Integration {
     $this->integration_uri    = $this->app_uri. 'account/apps/add/woo';
     $this->regions_uri        = $this->app_uri. 'account#states';
     $this->uri                = 'https://api.taxjar.com/v2/';
-    $this->ua                 = 'TaxJarWordPressPlugin/1.2.2/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . $woocommerce->version . '; ' . get_bloginfo( 'url' );
+    $this->ua                 = 'TaxJarWordPressPlugin/1.2.3/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . $woocommerce->version . '; ' . get_bloginfo( 'url' );
     $this->debug              = filter_var( $this->get_option( 'debug' ), FILTER_VALIDATE_BOOLEAN );
     $this->download_orders    = new WC_Taxjar_Download_Orders($this);
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -300,6 +300,13 @@ class WC_Taxjar_Integration extends WC_Integration {
       || $customer->is_vat_exempt()
     ) return false;
 
+    $taxjar_nexus = new WC_Taxjar_Nexus($this);
+    if (!$taxjar_nexus->has_nexus_check($to_country, $to_state)) {
+      $this->_log( ':::: TaxJar User does not have nexus ::::' );
+      return false;
+    }
+
+
     // Setup Vars for API call
     $to_zip           = explode( ',' , $to_zip );
     $to_zip           = array_shift( $to_zip );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -168,6 +168,13 @@ class WC_Taxjar_Integration extends WC_Integration {
       $this->form_fields = array_merge( $this->form_fields,
         array(
           'taxjar_download' => $this->download_orders->get_form_settings_field(),
+          'store_state' => array(
+            'title'             => __( 'Ship From State', 'wc-taxjar' ),
+            'type'              => 'hidden',
+            'description'       => __( 'We have automatically detected your ship from state as being ' . $default_wc_settings[1] . '.<br>You can change this setting at <a href="' . get_admin_url(null, 'admin.php?page=wc-settings').'">Woo->Settings->General->Base Location</a>', 'wc-taxjar' ),
+            'class'             => 'input-text disabled regular-input',
+            'disabled'          => 'disabled',
+          ),
           'store_zip' => array(
             'title'             => __( 'Ship From Zip Code', 'wc-taxjar' ),
             'type'              => 'text',
@@ -182,17 +189,10 @@ class WC_Taxjar_Integration extends WC_Integration {
             'desc_tip'          => true,
             'default'           => ''
           ),
-          'store_state' => array(
-            'title'             => __( 'Ship From State', 'wc-taxjar' ),
-            'type'              => 'hidden',
-            'description'       => __( 'We have automatically detected your ship from state as being ' . $default_wc_settings[1] . '.', 'wc-taxjar' ),
-            'class'             => 'input-text disabled regular-input',
-            'disabled'          => 'disabled',
-          ),
           'store_country' => array(
             'title'             => __( 'Ship From Country', 'wc-taxjar' ),
             'type'              => 'hidden',
-            'description'       => __( 'We have automatically detected your ship from country as being ' . $default_wc_settings[0] . '.', 'wc-taxjar' ),
+            'description'       => __( 'We have automatically detected your ship from country as being ' . $default_wc_settings[0] . '.<br>You can change this setting at <a href="' . get_admin_url(null, 'admin.php?page=wc-settings').'">Woo->Settings->General->Base Location</a>', 'wc-taxjar' ),
             'class'             => 'input-text disabled regular-input',
             'disabled'          => 'disabled'
           ),

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -168,6 +168,13 @@ class WC_Taxjar_Integration extends WC_Integration {
       $this->form_fields = array_merge( $this->form_fields,
         array(
           'taxjar_download' => $this->download_orders->get_form_settings_field(),
+          'store_city' => array(
+            'title'             => __( 'Ship From City', 'wc-taxjar' ),
+            'type'              => 'text',
+            'description'       => __( 'Enter the city where your store ships from.', 'wc-taxjar' ),
+            'desc_tip'          => true,
+            'default'           => ''
+          ),
           'store_state' => array(
             'title'             => __( 'Ship From State', 'wc-taxjar' ),
             'type'              => 'hidden',
@@ -179,13 +186,6 @@ class WC_Taxjar_Integration extends WC_Integration {
             'title'             => __( 'Ship From Zip Code', 'wc-taxjar' ),
             'type'              => 'text',
             'description'       => __( 'Enter the zip code from which your store ships products.', 'wc-taxjar' ),
-            'desc_tip'          => true,
-            'default'           => ''
-          ),
-          'store_city' => array(
-            'title'             => __( 'Ship From City', 'wc-taxjar' ),
-            'type'              => 'text',
-            'description'       => __( 'Enter the city where your store ships from.', 'wc-taxjar' ),
             'desc_tip'          => true,
             'default'           => ''
           ),
@@ -711,7 +711,10 @@ class WC_Taxjar_Integration extends WC_Integration {
     $default_wc_settings     = explode( ':', get_option('woocommerce_default_country') );
     $taxjar_zip_code_setting = $this->settings['store_zip'];
     $taxjar_city_setting     = $this->settings['store_city'];
-    $store_settings          = array( 'taxjar_zip_code_setting' => $taxjar_zip_code_setting , 'store_state_setting' => $default_wc_settings[1], 'store_country_setting' => $default_wc_settings[0], 'taxjar_city_setting' => $taxjar_city_setting );
+    $store_settings          = array( 'taxjar_zip_code_setting' => $taxjar_zip_code_setting, 'store_state_setting' => null, 'store_country_setting' => $default_wc_settings[0], 'taxjar_city_setting' => $taxjar_city_setting );
+    if ( isset( $default_wc_settings[1] ) ) {
+      $store_settings['store_state_setting'] = $default_wc_settings[1];
+    }
     return $store_settings;
   }
 

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -50,7 +50,7 @@ class WC_Taxjar_Nexus {
     );
   }
 
-  public function has_nexus_check( $country, $state = nil ) {
+  public function has_nexus_check( $country, $state = null ) {
     $store_settings   = $this->integration->get_store_settings();
     $from_country     = $store_settings[ 'store_country_setting' ];
     $from_state       = $store_settings[ 'store_state_setting' ];

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -22,7 +22,6 @@ class WC_Taxjar_Nexus {
     $desc_text = '';
 
     $desc_text .= '<h3>Nexus Information</h3>';
-    $desc_text .= "<button class='js-wc-taxjar-sync-nexus-addresses'>Sync Nexus Addresses</button><br>";
 
     if( count($this->nexus) > 0 ) {
       $desc_text .= '<p>Sales tax will be calculated on orders delivered into the following regions: </p>';
@@ -37,12 +36,11 @@ class WC_Taxjar_Nexus {
           }
         }
       }
-
-      $desc_text .= "<br><br><a href='" . $this->integration->regions_uri . "' target='_blank'>Add or update nexus locations</a>";
     } else {
       $desc_text .= "<p>TaxJar needs your business locations in order to calculate sales tax properly. Please add them <a href='" . $this->integration->regions_uri . "' target='_blank'>here</a>.<p>";
     }
 
+    $desc_text .= "<p><br><button class='button js-wc-taxjar-sync-nexus-addresses'>Sync Nexus Addresses</button>&nbsp; or &nbsp;<a href='" . $this->integration->regions_uri . "' target='_blank'>Manage Nexus Locations</a></p>";
 
 
     return array(

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -22,6 +22,7 @@ class WC_Taxjar_Nexus {
     $desc_text = '';
 
     $desc_text .= '<h3>Nexus Information</h3>';
+    $desc_text .= "<button class='js-wc-taxjar-sync-nexus-addresses'>Sync Nexus Addresses</button><br>";
 
     if( count($this->nexus) > 0 ) {
       $desc_text .= '<p>Sales tax will be calculated on orders delivered into the following regions: </p>';
@@ -42,7 +43,7 @@ class WC_Taxjar_Nexus {
       $desc_text .= "<p>TaxJar needs your business locations in order to calculate sales tax properly. Please add them <a href='" . $this->integration->regions_uri . "' target='_blank'>here</a>.<p>";
     }
 
-    $desc_text .= "<p><a href='#' class='js-wc-taxjar-sync-nexus-addresses'>Sync Nexus Addresses</a></p>";
+
 
     return array(
       'title'             => '',
@@ -69,7 +70,7 @@ class WC_Taxjar_Nexus {
   public function get_or_update_cached_nexus( $force_update = false ) {
     $nexus_list = get_transient( 'wc_taxjar_nexus_list' );
 
-    if ( $force_update || $nexus_list === false || count($nexus_list) == 0) {
+    if ( $force_update || $nexus_list === false) { //  || count($nexus_list) == 0
     	$nexus_list = $this->get_nexus_from_api();
     	set_transient( 'wc_taxjar_nexus_list', $nexus_list, 1 * DAY_IN_SECONDS);
       $this->integration->_log( ':::: Nexus addresses updated ::::' );
@@ -81,7 +82,6 @@ class WC_Taxjar_Nexus {
 
   private function get_nexus_from_api( ) {
     $url = $this->integration->uri . 'nexus/regions';
-    $this->integration->_log( ':::: TaxJar getting nexus list from API ::::' );
 
     $response = wp_remote_get( $url, array(
       'headers' =>    array(

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -15,7 +15,7 @@ class WC_Taxjar_Nexus {
 
   public function __construct( $integration ) {
     $this->integration = $integration;
-    $this->nexus = $this->get_nexus();
+    $this->nexus = $this->get_or_update_cached_nexus();
   }
 
   public function get_form_settings_field( ) {
@@ -27,20 +27,22 @@ class WC_Taxjar_Nexus {
       $desc_text .= '<p>Sales tax will be calculated on orders delivered into the following regions: </p>';
 
       foreach ($this->nexus as $key => $nexus) {
-        $desc_text .= '<br>';  
+        $desc_text .= '<br>';
         if ( isset( $nexus->region ) && isset ( $nexus->country ) ) {
           $desc_text .= sprintf( "%s, %s", $nexus->region, $nexus->country );
         } else {
           if ( isset ( $nexus->country ) ) {
             $desc_text .= $nexus->country;
           }
-        } 
+        }
       }
 
-      $desc_text .= "<br><br><a href='" . $this->integration->regions_uri . "' target='_blank'>Add or update nexus locations</a>";
+      $desc_text .= "<br><br><a href='" . $this->integration->regions_uri . "' target='_blank'>Add or update nexus locations</a> - ";
     } else {
       $desc_text .= "<p>TaxJar needs your business locations in order to calculate sales tax properly. Please add them <a href='" . $this->integration->regions_uri . "' target='_blank'>here</a>.<p>";
     }
+
+    $desc_text .= "<p><a href='#'>Sync Nexus Addresses</a></p>";
 
     return array(
       'title'             => '',
@@ -49,8 +51,35 @@ class WC_Taxjar_Nexus {
     );
   }
 
-  private function get_nexus( ) {
-    $url      = $this->integration->uri . 'nexus/regions';
+  public function has_nexus_check( $country, $state = nil ) {
+    echo $country . " " . $state;
+    foreach ( $this->get_or_update_cached_nexus() as $key => $nexus ) {
+      if ( $country == 'US' && isset( $nexus->region_code ) && isset ( $nexus->country_code ) ) {
+        if ($country == $nexus->country_code && $state == $nexus->region_code) {
+          return true;
+        }
+      } else {
+        if ( isset ( $nexus->country_code ) && $country == $nexus->country_code ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  public function get_or_update_cached_nexus( $force_update = false ) {
+    $nexus_list = get_transient( 'wc_taxjar_nexus_list' );
+    if ( $force_update || $nexus_list === false ) {
+    	$nexus_list = $this->get_nexus_from_api();
+    	set_transient( 'wc_taxjar_nexus_list', $nexus_list, 1 * DAY_IN_SECONDS);
+    }
+    return $nexus_list;
+  }
+
+  private function get_nexus_from_api( ) {
+    $url = $this->integration->uri . 'nexus/regions';
+    $this->integration->_log( ':::: TaxJar getting nexus list from API ::::' );
+
     $response = wp_remote_get( $url, array(
       'headers' =>    array(
                         'Authorization' => 'Token token="' . $this->integration->post_or_setting('api_token') .'"',
@@ -66,6 +95,5 @@ class WC_Taxjar_Nexus {
 
     return array();
   }
-
 
 } // WC_Taxjar_Nexus

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -51,13 +51,27 @@ class WC_Taxjar_Nexus {
   }
 
   public function has_nexus_check( $country, $state = nil ) {
-    foreach ( $this->get_or_update_cached_nexus() as $key => $nexus ) {
-      if ( $country == 'US' && isset( $nexus->region_code ) && isset ( $nexus->country_code ) ) {
+    $store_settings   = $this->integration->get_store_settings();
+    $from_country     = $store_settings[ 'store_country_setting' ];
+    $from_state       = $store_settings[ 'store_state_setting' ];
+
+    $nexus_areas = $this->get_or_update_cached_nexus();
+
+    array_push(
+      $nexus_areas,
+      (object) array(
+        "country_code" => $store_settings[ 'store_country_setting' ],
+        "region_code" => $store_settings[ 'store_state_setting' ],
+      )
+    );
+
+    foreach ( $nexus_areas as $key => $nexus ) {
+      if ( isset ( $nexus->country_code ) && isset( $nexus->region_code ) ) {
         if ($country == $nexus->country_code && $state == $nexus->region_code) {
           return true;
         }
-      } else {
-        if ( isset ( $nexus->country_code ) && $country == $nexus->country_code ) {
+      } elseif ( isset ( $nexus->country_code ) ) {
+        if ( $country == $nexus->country_code ) {
           return true;
         }
       }

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -66,7 +66,7 @@ class WC_Taxjar_Nexus {
     );
 
     foreach ( $nexus_areas as $key => $nexus ) {
-      if ( isset ( $nexus->country_code ) && isset( $nexus->region_code ) ) {
+      if ( isset ( $nexus->country_code ) && isset( $nexus->region_code ) && $nexus->country_code == 'US' ) {
         if ($country == $nexus->country_code && $state == $nexus->region_code) {
           return true;
         }

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -37,12 +37,12 @@ class WC_Taxjar_Nexus {
         }
       }
 
-      $desc_text .= "<br><br><a href='" . $this->integration->regions_uri . "' target='_blank'>Add or update nexus locations</a> - ";
+      $desc_text .= "<br><br><a href='" . $this->integration->regions_uri . "' target='_blank'>Add or update nexus locations</a>";
     } else {
       $desc_text .= "<p>TaxJar needs your business locations in order to calculate sales tax properly. Please add them <a href='" . $this->integration->regions_uri . "' target='_blank'>here</a>.<p>";
     }
 
-    $desc_text .= "<p><a href='#'>Sync Nexus Addresses</a></p>";
+    $desc_text .= "<p><a href='#' class='js-wc-taxjar-sync-nexus-addresses'>Sync Nexus Addresses</a></p>";
 
     return array(
       'title'             => '',
@@ -52,7 +52,6 @@ class WC_Taxjar_Nexus {
   }
 
   public function has_nexus_check( $country, $state = nil ) {
-    echo $country . " " . $state;
     foreach ( $this->get_or_update_cached_nexus() as $key => $nexus ) {
       if ( $country == 'US' && isset( $nexus->region_code ) && isset ( $nexus->country_code ) ) {
         if ($country == $nexus->country_code && $state == $nexus->region_code) {
@@ -72,6 +71,7 @@ class WC_Taxjar_Nexus {
     if ( $force_update || $nexus_list === false ) {
     	$nexus_list = $this->get_nexus_from_api();
     	set_transient( 'wc_taxjar_nexus_list', $nexus_list, 1 * DAY_IN_SECONDS);
+      $this->integration->_log( ':::: Nexus addresses updated ::::' );
     }
     return $nexus_list;
   }

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -68,10 +68,13 @@ class WC_Taxjar_Nexus {
 
   public function get_or_update_cached_nexus( $force_update = false ) {
     $nexus_list = get_transient( 'wc_taxjar_nexus_list' );
-    if ( $force_update || $nexus_list === false ) {
+
+    if ( $force_update || $nexus_list === false || count($nexus_list) == 0) {
     	$nexus_list = $this->get_nexus_from_api();
     	set_transient( 'wc_taxjar_nexus_list', $nexus_list, 1 * DAY_IN_SECONDS);
       $this->integration->_log( ':::: Nexus addresses updated ::::' );
+    } else {
+      $this->integration->_log( ':::: Using nexus addresses from cache ::::' );
     }
     return $nexus_list;
   }

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -4,14 +4,29 @@ jQuery(document).ready(function(){
   * Javascript module for TaxJar admin settings page
   */
 	var TaxJarAdmin = (function($, m) {
-		var performingRequest = false;
-
     var init = function() {
       $('[name="woocommerce_taxjar-integration_api_token"]').on('blur', clean_api_key)
+      $('.js-wc-taxjar-sync-nexus-addresses').on('click', sync_nexus_addresses)
     };
 
     var clean_api_key = function() {
       $(this).attr('value', $(this).attr('value').replace(/ /g,''))
+    };
+
+    var sync_nexus_addresses = function(e) {
+      e.preventDefault();
+      $.ajax({
+				method:   'POST',
+				dataType: 'json',
+				url:      woocommerce_taxjar_admin.ajax_url,
+				data:     {
+					action:      'wc_taxjar_update_nexus_cache',
+					security:    woocommerce_taxjar_admin.update_api_nonce,
+				},
+			}).done(function(){
+        alert('Nexus Addresses Synced');
+        location.reload();
+			});
     };
 
     return {

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -20,8 +20,9 @@ jQuery(document).ready(function(){
 				dataType: 'json',
 				url:      woocommerce_taxjar_admin.ajax_url,
 				data:     {
-					action:      'wc_taxjar_update_nexus_cache',
-					security:    woocommerce_taxjar_admin.update_api_nonce,
+					action:     'wc_taxjar_update_nexus_cache',
+					security:   woocommerce_taxjar_admin.update_api_nonce,
+          'woocommerce_taxjar-integration_api_token':  woocommerce_taxjar_admin.api_token
 				},
 			}).done(function(){
         alert('Nexus Addresses Synced');

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -6,19 +6,19 @@ jQuery(document).ready(function(){
 	var TaxJarAdmin = (function($, m) {
 		var performingRequest = false;
 
-  var init = function() {
-    $('[name="woocommerce_taxjar-integration_api_token"]').on('blur', clean_api_key)
-  };
+    var init = function() {
+      $('[name="woocommerce_taxjar-integration_api_token"]').on('blur', clean_api_key)
+    };
 
-  var clean_api_key = function() {
-    $(this).attr('value', $(this).attr('value').replace(/ /g,''))
-  };
+    var clean_api_key = function() {
+      $(this).attr('value', $(this).attr('value').replace(/ /g,''))
+    };
 
-  return {
-    init: init
-  };
+    return {
+      init: init
+    };
 
-}(jQuery, TaxJarAdmin || {}));
+  }(jQuery, TaxJarAdmin || {}));
 
-TaxJarAdmin.init();
+  TaxJarAdmin.init();
 });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: tonkapark, taxjar
 Tags: woocommerce, taxes, tax calculation, free tax calculation, sales tax, taxjar
 Requires at least: 4.0
 Tested up to: 4.5.3
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 License: GPLv2 or later
 
 Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: tonkapark, taxjar
 Tags: woocommerce, taxes, tax calculation, free tax calculation, sales tax, taxjar
 Requires at least: 4.0
-Tested up to: 4.5.3
+Tested up to: 4.6.1
 Stable tag: 1.2.3
 License: GPLv2 or later
 

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
  * Author: TaxJar
  * Author URI: http://www.taxjar.com
- * Version: 1.2.2
+ * Version: 1.2.3
  *
  */
 

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -39,6 +39,7 @@ class WC_Taxjar {
     if ( class_exists( 'WC_Integration' ) ) {
       // Include our integration class and WP_User for wp_delete_user()
       include_once ABSPATH.'wp-admin/includes/user.php';
+      include_once 'includes/class-wc-taxjar-ajax.php';
       include_once 'includes/class-wc-taxjar-nexus.php';
       include_once 'includes/class-wc-taxjar-download-orders.php';
       include_once 'includes/class-wc-taxjar-connection.php';

--- a/tests/specs/test-class-taxjar-nexus.php
+++ b/tests/specs/test-class-taxjar-nexus.php
@@ -1,0 +1,40 @@
+<?php
+class TJ_WC_Class_Nexus extends WP_UnitTestCase {
+
+  function test_get_or_update_cached_nexus() {
+    $tj = new WC_Taxjar_Integration();
+    $tj_nexus = new WC_Taxjar_Nexus($tj);
+
+    delete_transient('wc_taxjar_nexus_list');
+    $this->assertEquals(get_transient('wc_taxjar_nexus_list'), false);
+    $tj_nexus->get_or_update_cached_nexus();
+    $this->assertTrue(count(get_transient('wc_taxjar_nexus_list')) > 0);
+  }
+
+  function test_has_nexus_check_uses_base_address() {
+    update_option('woocommerce_default_country', 'US:XO');
+    $tj = new WC_Taxjar_Integration();
+    $tj_nexus = new WC_Taxjar_Nexus($tj);
+    $this->assertTrue($tj_nexus->has_nexus_check('US', 'XO'));
+  }
+
+  function test_has_nexus_check_uses_nexus_list() {
+    $tj = new WC_Taxjar_Integration();
+    $tj_nexus = new WC_Taxjar_Nexus($tj);
+    $this->assertTrue($tj_nexus->has_nexus_check('US', 'CO'));
+  }
+
+  function test_works_when_only_using_counry() {
+    update_option('woocommerce_default_country', 'DE:');
+    $tj = new WC_Taxjar_Integration();
+    $tj_nexus = new WC_Taxjar_Nexus($tj);
+    $this->assertTrue($tj_nexus->has_nexus_check('DE'));
+  }
+
+  function test_returns_false_if_not_shipping_to_nexus_area() {
+    update_option('woocommerce_default_country', 'US:CO');
+    $tj = new WC_Taxjar_Integration();
+    $tj_nexus = new WC_Taxjar_Nexus($tj);
+    $this->assertFalse($tj_nexus->has_nexus_check('US', 'XO'));
+  }
+}


### PR DESCRIPTION
Hi all,

This PR caches the nexus region response and references to ensure that an order's ship to country/state are actually in the nexus list before making an API call for a tax calculation.  I have done quite a bit of testing on this and will do more tonight and tomorrow but wanted to get a PR up for people to start reviewing.