### PR TITLE
Add fallback for empty/false/otherwise wrong nexus list

### DIFF
--- a/includes/class-wc-taxjar-download-orders.php
+++ b/includes/class-wc-taxjar-download-orders.php
@@ -370,7 +370,7 @@ class WC_Taxjar_Download_Orders {
 
     if ( version_compare( $woocommerce->version, '2.4.0', '>=' ) ) {
       global $current_user;
-      get_currentuserinfo();
+      wp_get_current_user();
 
       $this->delete_wc_taxjar_keys();
       return $this->generate_v2_api_keys( $current_user->ID );

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -57,6 +57,10 @@ class WC_Taxjar_Nexus {
 
     $nexus_areas = $this->get_or_update_cached_nexus();
 
+    if ( count($nexus_list) == 0 ) {
+      return true;
+    }
+
     array_push(
       $nexus_areas,
       (object) array(
@@ -82,13 +86,14 @@ class WC_Taxjar_Nexus {
   public function get_or_update_cached_nexus( $force_update = false ) {
     $nexus_list = get_transient( 'wc_taxjar_nexus_list' );
 
-    if ( $force_update || $nexus_list === false) { //  || count($nexus_list) == 0
+    if ( $force_update || $nexus_list === false || ( $nexus_list != null && count( $nexus_list ) == 0 ) ) {
     	$nexus_list = $this->get_nexus_from_api();
-    	set_transient( 'wc_taxjar_nexus_list', $nexus_list, 1 * DAY_IN_SECONDS);
+    	set_transient( 'wc_taxjar_nexus_list', $nexus_list, 0.5 * DAY_IN_SECONDS );
       $this->integration->_log( ':::: Nexus addresses updated ::::' );
     } else {
       $this->integration->_log( ':::: Using nexus addresses from cache ::::' );
     }
+
     return $nexus_list;
   }
 

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -57,7 +57,7 @@ class WC_Taxjar_Nexus {
 
     $nexus_areas = $this->get_or_update_cached_nexus();
 
-    if ( count($nexus_list) == 0 ) {
+    if ( count( $nexus_areas ) == 0 ) {
       return true;
     }
 

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -86,7 +86,7 @@ class WC_Taxjar_Nexus {
   public function get_or_update_cached_nexus( $force_update = false ) {
     $nexus_list = get_transient( 'wc_taxjar_nexus_list' );
 
-    if ( $force_update || $nexus_list === false || ( $nexus_list != null && count( $nexus_list ) == 0 ) ) {
+    if ( $force_update || $nexus_list === false || $nexus_list === null || ( is_array( $nexus_list ) && count( $nexus_list ) == 0 ) ) {
     	$nexus_list = $this->get_nexus_from_api();
     	set_transient( 'wc_taxjar_nexus_list', $nexus_list, 0.5 * DAY_IN_SECONDS );
       $this->integration->_log( ':::: Nexus addresses updated ::::' );

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -87,8 +87,8 @@ class WC_Taxjar_Nexus {
     $nexus_list = get_transient( 'wc_taxjar_nexus_list' );
 
     if ( $force_update || $nexus_list === false || $nexus_list === null || ( is_array( $nexus_list ) && count( $nexus_list ) == 0 ) ) {
-    	$nexus_list = $this->get_nexus_from_api();
-    	set_transient( 'wc_taxjar_nexus_list', $nexus_list, 0.5 * DAY_IN_SECONDS );
+      $nexus_list = $this->get_nexus_from_api();
+      set_transient( 'wc_taxjar_nexus_list', $nexus_list, 0.5 * DAY_IN_SECONDS );
       $this->integration->_log( ':::: Nexus addresses updated ::::' );
     } else {
       $this->integration->_log( ':::: Using nexus addresses from cache ::::' );

--- a/tests/specs/test-class-taxjar-nexus.php
+++ b/tests/specs/test-class-taxjar-nexus.php
@@ -22,6 +22,16 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
     $this->assertEquals($transient, time() + 0.5 * DAY_IN_SECONDS );
   }
 
+  function test_or_get_update_cached_nexus_expiration() {
+    delete_transient('wc_taxjar_nexus_list');
+    $this->assertEquals(get_transient('wc_taxjar_nexus_list'), false);
+    set_transient('wc_taxjar_nexus_list', array(), -0.5 * DAY_IN_SECONDS);
+    $this->tj_nexus->get_or_update_cached_nexus();
+    $transient = get_transient('timeout_wc_taxjar_nexus_list');
+    $this->assertEquals($transient, time() + 0.5 * DAY_IN_SECONDS );
+    $this->assertTrue(count(get_transient('wc_taxjar_nexus_list')) > 0);
+  }
+
   function test_has_nexus_check_uses_base_address() {
     update_option('woocommerce_default_country', 'US:XO');
     $this->assertTrue($this->tj_nexus->has_nexus_check('US', 'XO'));

--- a/tests/specs/test-class-taxjar-nexus.php
+++ b/tests/specs/test-class-taxjar-nexus.php
@@ -1,45 +1,43 @@
 <?php
 class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 
-  function test_get_or_update_cached_nexus() {
-    $tj = new WC_Taxjar_Integration();
-    $tj_nexus = new WC_Taxjar_Nexus($tj);
+  function setUp() {
+    $this->tj = new WC_Taxjar_Integration();
+    $this->tj_nexus = new WC_Taxjar_Nexus($this->tj);
+    parent::setUp();
+  }
 
+  function test_get_or_update_cached_nexus() {
     delete_transient('wc_taxjar_nexus_list');
     $this->assertEquals(get_transient('wc_taxjar_nexus_list'), false);
-    $tj_nexus->get_or_update_cached_nexus();
+    $this->tj_nexus->get_or_update_cached_nexus();
     $this->assertTrue(count(get_transient('wc_taxjar_nexus_list')) > 0);
+  }
 
-    set_transient( 'wc_taxjar_nexus_list', [] );
-    $this->assertEquals(get_transient('wc_taxjar_nexus_list'), []);
-    $tj_nexus->get_or_update_cached_nexus();
-    $this->assertTrue(count(get_transient('wc_taxjar_nexus_list')) > 0);
+  function test_get_or_update_cached_nexus_uses_correct_timeout() {
+    delete_transient('wc_taxjar_nexus_list');
+    $this->assertEquals(get_transient('wc_taxjar_nexus_list'), false);
+    $this->tj_nexus->get_or_update_cached_nexus();
+    $transient = get_transient('timeout_wc_taxjar_nexus_list');
+    $this->assertEquals($transient, time() + 0.5 * DAY_IN_SECONDS );
   }
 
   function test_has_nexus_check_uses_base_address() {
     update_option('woocommerce_default_country', 'US:XO');
-    $tj = new WC_Taxjar_Integration();
-    $tj_nexus = new WC_Taxjar_Nexus($tj);
-    $this->assertTrue($tj_nexus->has_nexus_check('US', 'XO'));
+    $this->assertTrue($this->tj_nexus->has_nexus_check('US', 'XO'));
   }
 
   function test_has_nexus_check_uses_nexus_list() {
-    $tj = new WC_Taxjar_Integration();
-    $tj_nexus = new WC_Taxjar_Nexus($tj);
-    $this->assertTrue($tj_nexus->has_nexus_check('US', 'CO'));
+    $this->assertTrue($this->tj_nexus->has_nexus_check('US', 'CO'));
   }
 
   function test_works_when_only_using_counry() {
     update_option('woocommerce_default_country', 'DE:');
-    $tj = new WC_Taxjar_Integration();
-    $tj_nexus = new WC_Taxjar_Nexus($tj);
-    $this->assertTrue($tj_nexus->has_nexus_check('DE'));
+    $this->assertTrue($this->tj_nexus->has_nexus_check('DE'));
   }
 
   function test_returns_false_if_not_shipping_to_nexus_area() {
     update_option('woocommerce_default_country', 'US:CO');
-    $tj = new WC_Taxjar_Integration();
-    $tj_nexus = new WC_Taxjar_Nexus($tj);
-    $this->assertFalse($tj_nexus->has_nexus_check('US', 'XO'));
+    $this->assertFalse($this->tj_nexus->has_nexus_check('US', 'XO'));
   }
 }

--- a/tests/specs/test-class-taxjar-nexus.php
+++ b/tests/specs/test-class-taxjar-nexus.php
@@ -9,6 +9,11 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
     $this->assertEquals(get_transient('wc_taxjar_nexus_list'), false);
     $tj_nexus->get_or_update_cached_nexus();
     $this->assertTrue(count(get_transient('wc_taxjar_nexus_list')) > 0);
+
+    set_transient( 'wc_taxjar_nexus_list', [] );
+    $this->assertEquals(get_transient('wc_taxjar_nexus_list'), []);
+    $tj_nexus->get_or_update_cached_nexus();
+    $this->assertTrue(count(get_transient('wc_taxjar_nexus_list')) > 0);
   }
 
   function test_has_nexus_check_uses_base_address() {


### PR DESCRIPTION
This PR does a few things:

- Change `get_currentuserinfo()` to `wp_get_current_user()`. The former is being deprecated.

- Account for more return types of the `wc_taxjar_nexus_list` transient. Previously, it would use the transient value even if the transient value was "falsy" - like an empty array.

- Add tests for the various transient checks, including a shorter cache timeout period.