### PR TITLE
Line Item Taxability & Improved API Request Caching

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -501,7 +501,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$id = $product->get_id();
 			$quantity = $values['quantity'];
 			$unit_price = $product->get_price();
-			$discount = $unit_price - $wc_cart_object->get_discounted_price( $values, $unit_price );
+			$discount = ( $unit_price - $wc_cart_object->get_discounted_price( $values, $unit_price ) ) * $quantity;
 			$tax_code = '';
 
 			if ( ! $product->is_taxable() ) {

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -51,7 +51,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 			// Calculate Taxes
 			add_action( 'woocommerce_calculate_totals', array( $this, 'use_taxjar_total' ), 20 );
-			add_filter( 'woocommerce_ajax_calc_line_taxes', array( $this, 'admin_ajax_calculate_taxes' ), 99, 4 );
 
 			// Settings Page
 			add_action( 'woocommerce_sections_tax',  array( $this, 'output_sections_before' ),  9 );
@@ -515,36 +514,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 		$wc_cart_object->shipping_taxes = array(
 			$this->rate_id => $this->shipping_collectable,
 		);
-	}
-
-	public function admin_ajax_calculate_taxes( $items, $order_id, $country, $post ) {
-		global $woocommerce;
-
-		$post = is_array( $post ) ? $post : array();
-
-		extract( array_replace_recursive( array(
-			'country' => null,
-			'state' => null,
-			'postcode' => null,
-			'city' => null,
-		), $post ), EXTR_SKIP );
-
-		if ( empty( $country ) || empty( $state ) || empty( $postcode ) || empty( $city ) ) {
-			return false;
-		}
-
-		$order = wc_get_order( $order_id );
-
-		$this->taxjar_api_call( array(
-			'to_city' => $city,
-			'to_state' => $state,
-			'to_country' => $country,
-			'to_zip' => $postcode,
-			'amount' => $order->order_total,
-			'shipping_amount' => null,
-		) );
-
-		return $items;
 	}
 
 	/**

--- a/includes/tlc-transients/class-tlc-transient-update-server.php
+++ b/includes/tlc-transients/class-tlc-transient-update-server.php
@@ -1,0 +1,25 @@
+<?php
+
+class TLC_Transient_Update_Server {
+	public function __construct() {
+		add_action( 'init', array( $this, 'init' ), 9999 );
+	}
+
+	public function init() {
+		if ( isset( $_POST['_tlc_update'] )
+				&& ( 0 === strpos( $_POST['_tlc_update'], 'tlc_lock_' ) )
+				&& isset( $_POST['key'] )
+		) {
+			$update = get_transient( 'tlc_up__' . md5( $_POST['key'] ) );
+			if ( $update && $update[0] == $_POST['_tlc_update'] ) {
+				tlc_transient( $update[1] )
+						->expires_in( $update[2] )
+						->extend_on_fail( $update[5] )
+						->updates_with( $update[3], (array) $update[4] )
+						->set_lock( $update[0] )
+						->fetch_and_cache();
+			}
+			exit();
+		}
+	}
+}

--- a/includes/tlc-transients/class-tlc-transient.php
+++ b/includes/tlc-transients/class-tlc-transient.php
@@ -1,0 +1,146 @@
+<?php
+
+class TLC_Transient {
+	public $key;
+	public $raw_key;
+	private $lock;
+	private $callback;
+	private $params;
+	private $expiration = 0;
+	private $extend_on_fail = 0;
+	private $force_background_updates = false;
+
+	public function __construct( $key ) {
+		$this->raw_key = $key;
+		$this->key     = md5( $key );
+	}
+
+	public function get() {
+		$data = $this->raw_get();
+		if ( false === $data ) {
+			// Hard expiration
+			if ( $this->force_background_updates ) {
+				// In this mode, we never do a just-in-time update
+				// We return false, and schedule a fetch on shutdown
+				$this->schedule_background_fetch();
+				return false;
+			}
+			else {
+				// Bill O'Reilly mode: "We'll do it live!"
+				return $this->fetch_and_cache();
+			}
+		}
+		else {
+			// Soft expiration
+			if ( $data[0] !== 0 && $data[0] < time() )
+				$this->schedule_background_fetch();
+			return $data[1];
+		}
+	}
+
+	private function raw_get() {
+		return get_transient( 'tlc__' . $this->key );
+	}
+
+	private function schedule_background_fetch() {
+		if ( ! $this->has_update_lock() ) {
+			set_transient( 'tlc_up__' . $this->key, array( $this->new_update_lock(), $this->raw_key, $this->expiration, $this->callback, $this->params, $this->extend_on_fail ), 300 );
+			add_action( 'shutdown', array( $this, 'spawn_server' ) );
+		}
+		return $this;
+	}
+
+	private function has_update_lock() {
+		return (bool) $this->get_update_lock();
+	}
+
+	private function get_update_lock() {
+		$lock = get_transient( 'tlc_up__' . $this->key );
+		if ( $lock )
+			return $lock[0];
+		else
+			return false;
+	}
+
+	private function new_update_lock() {
+		$this->lock = uniqid( 'tlc_lock_', true );
+		return $this->lock;
+	}
+
+	public function fetch_and_cache() {
+		// If you don't supply a callback, we can't update it for you!
+		if ( empty( $this->callback ) )
+			return false;
+		if ( $this->has_update_lock() && ! $this->owns_update_lock() )
+			return; // Race... let the other process handle it
+		try {
+			$data = call_user_func_array( $this->callback, $this->params );
+			$this->set( $data );
+		} catch ( Exception $e ) {
+			if ( $this->extend_on_fail > 0 ) {
+				$data = $this->raw_get();
+				if ( $data ) {
+					$data             = $data[1];
+					$old_expiration   = $this->expiration;
+					$this->expiration = $this->extend_on_fail;
+					$this->set( $data );
+					$this->expiration = $old_expiration;
+				}
+			}
+			else {
+				$data = false;
+			}
+		}
+		$this->release_update_lock();
+		return $data;
+	}
+
+	private function owns_update_lock() {
+		return $this->lock == $this->get_update_lock();
+	}
+
+	public function set( $data ) {
+		// We set the timeout as part of the transient data.
+		// The actual transient has a far-future TTL. This allows for soft expiration.
+		$expiration           = ( $this->expiration > 0 ) ? time() + $this->expiration : 0;
+		$transient_expiration = ( $this->expiration > 0 ) ? $this->expiration + 31536000 : 0; // 31536000 = 60*60*24*365 ~= one year
+		set_transient( 'tlc__' . $this->key, array( $expiration, $data ), $transient_expiration );
+		return $this;
+	}
+
+	private function release_update_lock() {
+		delete_transient( 'tlc_up__' . $this->key );
+	}
+
+	public function spawn_server() {
+		$server_url = home_url( '/?tlc_transients_request' );
+		wp_remote_post( $server_url, array( 'body' => array( '_tlc_update' => $this->lock, 'key' => $this->raw_key ), 'timeout' => 0.01, 'blocking' => false, 'sslverify' => apply_filters( 'https_local_ssl_verify', true ) ) );
+	}
+
+	public function updates_with( $callback, $params = array() ) {
+		$this->callback = $callback;
+		if ( is_array( $params ) )
+			$this->params = $params;
+		return $this;
+	}
+
+	public function expires_in( $seconds ) {
+		$this->expiration = (int) $seconds;
+		return $this;
+	}
+
+	public function extend_on_fail( $seconds ) {
+		$this->extend_on_fail = (int) $seconds;
+		return $this;
+	}
+
+	public function set_lock( $lock ) {
+		$this->lock = $lock;
+		return $this;
+	}
+
+	public function background_only() {
+		$this->force_background_updates = true;
+		return $this;
+	}
+}

--- a/includes/tlc-transients/functions.php
+++ b/includes/tlc-transients/functions.php
@@ -1,0 +1,9 @@
+<?php
+
+// API so you don't have to use "new"
+if ( !function_exists( 'tlc_transient' ) ) {
+	function tlc_transient( $key ) {
+		$transient = new TLC_Transient( $key );
+		return $transient;
+	}
+}

--- a/includes/tlc-transients/tlc-transients.php
+++ b/includes/tlc-transients/tlc-transients.php
@@ -1,0 +1,33 @@
+<?php
+
+if ( ! class_exists( 'TLC_Transient_Update_Server' ) )
+	require_once dirname( __FILE__ ) . '/class-tlc-transient-update-server.php';
+
+new TLC_Transient_Update_Server;
+
+if ( ! class_exists( 'TLC_Transient' ) )
+	require_once dirname( __FILE__ ) . '/class-tlc-transient.php';
+
+require_once dirname( __FILE__ ) . '/functions.php';
+
+// Example:
+/*
+function sample_fetch_and_append( $url, $append ) {
+	$f  = wp_remote_retrieve_body( wp_remote_get( $url, array( 'timeout' => 30 ) ) );
+	$f .= $append;
+	return $f;
+}
+
+function test_tlc_transient() {
+	$t = tlc_transient( 'foo' )
+		->expires_in( 30 )
+		->background_only()
+		->updates_with( 'sample_fetch_and_append', array( 'http://coveredwebservices.com/tools/long-running-request.php', ' appendfooparam ' ) )
+		->get();
+	var_dump( $t );
+	if ( !$t )
+		echo "The request is false, because it isn't yet in the cache. It'll be there in about 10 seconds. Keep refreshing!";
+}
+
+add_action( 'wp_footer', 'test_tlc_transient' );
+*/

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,10 +33,13 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
     // load woocommerce core
     require_once $this->plugin_dir . 'woocommerce/woocommerce.php';
 
-    //load taxjar core
+    // load taxjar core
     require_once $this->plugin_dir . 'taxjar-woocommerce-plugin/taxjar-woocommerce.php';
 
-    //load framework
+	// load tlc-transients
+	require_once $this->plugin_dir . 'taxjar-woocommerce-plugin/includes/tlc-transients/tlc-transients.php';
+
+    // load framework
     require_once $this->tests_dir . '/framework/woocommerce-helper.php';
     require_once $this->tests_dir . '/framework/customer-helper.php';
     require_once $this->tests_dir . '/framework/product-helper.php';

--- a/tests/framework/customer-helper.php
+++ b/tests/framework/customer-helper.php
@@ -1,12 +1,14 @@
 <?php
 
 class TaxJar_Customer_helper {
-  public static function get_test_customer($country = 'US', $state = 'CO', $zip = '80111', $city = 'Greenwood Village') {
+
+  public static function get_test_customer( $country = 'US', $state = 'CO', $zip = '80111', $city = 'Greenwood Village' ) {
     global $woocommerce;
-    
+
     $customer = new WC_Customer();
-    $customer->set_shipping_location($country, $state, $zip, $city);
+    $customer->set_shipping_location( $country, $state, $zip, $city );
 
     return $customer;
   }
+
 }

--- a/tests/framework/product-helper.php
+++ b/tests/framework/product-helper.php
@@ -3,24 +3,26 @@
 class TaxJar_Helper_Product {
 
   public static function get_test_product() {
-    $products = get_posts(array('post_type' => 'product'));
-    if( count($products) == 0) {
-      TaxJar_Helper_Product::create_test_product();
-      $products = get_posts(array('post_type' => 'product'));
+    $products = get_posts( array(
+		'post_type' => 'product',
+	) );
+
+    if ( 0 == count( $products ) ) {
+		TaxJar_Helper_Product::create_simple_product();
+      	$products = get_posts( array(
+			'post_type' => 'product',
+		) );
     }
 
     $factory = new WC_Product_Factory();
-    return $factory->get_product($products[0]->ID);
+    return $factory->get_product( $products[0]->ID );
   }
 
-  private static function create_test_product() {
+  private static function create_simple_product() {
     $post = array(
-      'post_author' => 1,
-      'post_content' => '',
-      'post_status' => "publish",
-      'post_title' => 'fasdf product',
-      'post_parent' => '',
-      'post_type' => "product",
+      'post_title' => 'Dummy Product',
+      'post_type' => 'product',
+      'post_status' => 'publish',
     );
 
     $post_id = wp_insert_post( $post );
@@ -30,16 +32,17 @@ class TaxJar_Helper_Product {
       'product'
     );
 
-    wp_set_object_terms($post_id, 'simple', 'product_type');
+    update_post_meta( $post_id, '_price', '10' );
+	update_post_meta( $post_id, '_regular_price', '10' );
+	update_post_meta( $post_id, '_sale_price', '' );
+	update_post_meta( $post_id, '_sku', 'DUMMY SKU' );
+    update_post_meta( $post_id, '_manage_stock', 'no' );
+	update_post_meta( $post_id, '_tax_status', 'taxable' );
+    update_post_meta( $post_id, '_downloadable', 'no' );
+    update_post_meta( $post_id, '_virtual', 'no' );
+    update_post_meta( $post_id, '_stock_status', 'instock' );
 
-    update_post_meta( $post_id, '_visibility', 'visible' );
-    update_post_meta( $post_id, '_stock_status', 'instock');
-    update_post_meta( $post_id, 'total_sales', '0');
-    update_post_meta( $post_id, '_downloadable', 'no');
-    update_post_meta( $post_id, '_virtual', 'no');
-    update_post_meta( $post_id, '_regular_price', "10" );
-    update_post_meta( $post_id, '_price', "10" );
-    update_post_meta( $post_id, '_sold_individually', "no" );
-    update_post_meta( $post_id, '_manage_stock', "no" );
+    wp_set_object_terms( $post_id, 'simple', 'product_type' );
   }
+
 }

--- a/tests/framework/woocommerce-helper.php
+++ b/tests/framework/woocommerce-helper.php
@@ -1,6 +1,7 @@
 <?php
 
 class TaxJar_Woocommerce_helper {
+
   public static function prepare_woocommerce() {
     global $woocommerce;
 
@@ -13,4 +14,5 @@ class TaxJar_Woocommerce_helper {
     $woocommerce->customer = TaxJar_Customer_helper::get_test_customer();
     $woocommerce->cart->add_to_cart( TaxJar_Helper_Product::get_test_product()->get_id() );
   }
+
 }

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -19,6 +19,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
     $woocommerce->shipping->shipping_total = 5;
 
     do_action( 'woocommerce_calculate_totals', $woocommerce->cart );
+
     $this->assertEquals( $woocommerce->cart->tax_total, 0.4, '', 0.001 );
     $this->assertEquals( $woocommerce->cart->shipping_tax_total, 0.2, '', 0.001 );
     $this->assertEquals( array_values( $woocommerce->cart->shipping_taxes )[0], 0.2, '', 0.001 );


### PR DESCRIPTION
This PR passes line items to SmartCalcs rather than the overall amount, so everything plays nicely with WooCommerce Subscriptions. The subscription plugin calls `woocommerce_calculate_totals` with only the subscription-based products, making another request to SmartCalcs.

In addition, this allows us to exempt line items if they aren't taxable and paves the way for product taxability. Tax should also be saved for each individual line item.

Lastly, drops the old `woocommerce_ajax_calc_line_taxes` filter.

<img width="454" alt="screen shot 2017-06-15 at 12 14 29 pm" src="https://user-images.githubusercontent.com/1137184/27197817-8bf6f920-51c4-11e7-8dcd-d46c545c1266.png">