### PR TITLE
Product Taxability

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -457,10 +457,15 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$quantity = $values['quantity'];
 			$unit_price = $product->get_price();
 			$discount = ( $unit_price - $wc_cart_object->get_discounted_price( $values, $unit_price ) ) * $quantity;
+			$tax_class = explode( '-', $product->get_tax_class() );
 			$tax_code = '';
 
 			if ( ! $product->is_taxable() ) {
 				$tax_code = '99999';
+			}
+
+			if ( isset( $tax_class[1] ) && is_numeric( $tax_class[1] ) ) {
+				$tax_code = $tax_class[1];
 			}
 
 			if ( $unit_price ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,79 +1,81 @@
 <?php
-
 class TaxJar_WC_Unit_Tests_Bootstrap {
-  protected static $instance = null;
 
-  public $wp_tests_dir;
-  public $tests_dir;
-  public $plugins_dir;
-  public $test_wp_dir;
-  public $api_token;
+	protected static $instance = null;
 
-  public function __construct() {
+	public $wp_tests_dir;
+	public $tests_dir;
+	public $plugins_dir;
+	public $test_wp_dir;
+	public $api_token;
 
-    ini_set( 'display_errors','on' );
-    error_reporting( E_ALL );
+	public function __construct() {
+		ini_set( 'display_errors', 'on' );
+		error_reporting( E_ALL );
 
-    $this->tests_dir    = dirname( __FILE__ );
-    $this->plugin_dir   = __DIR__ . '/../../';
-    $this->wp_tests_dir = '/tmp/wordpress-tests-lib/';
+		$this->tests_dir    = dirname( __FILE__ );
+		$this->plugin_dir   = __DIR__ . '/../../';
+		$this->wp_tests_dir = '/tmp/wordpress-tests-lib/';
 
-    $this->api_token = getenv ( 'TAXJAR_API_TOKEN' );
+		$this->api_token = getenv( 'TAXJAR_API_TOKEN' );
 
-    $this->includes();
+		$this->includes();
 
-    $this->setup();
-  }
+		$this->setup();
+	}
 
-  public function includes() {
-    // load the WP testing environment
-    require_once( $this->wp_tests_dir . 'includes/functions.php' );
-    require_once( $this->wp_tests_dir . 'includes/bootstrap.php' );
+	public function includes() {
+		// load the WP testing environment
+		require_once $this->wp_tests_dir . 'includes/functions.php';
+		require_once $this->wp_tests_dir . 'includes/bootstrap.php';
 
-    // load woocommerce core
-    require_once $this->plugin_dir . 'woocommerce/woocommerce.php';
+		// load woocommerce core
+		require_once $this->plugin_dir . 'woocommerce/woocommerce.php';
 
-    // load taxjar core
-    require_once $this->plugin_dir . 'taxjar-woocommerce-plugin/taxjar-woocommerce.php';
+		// load taxjar core
+		require_once $this->plugin_dir . 'taxjar-woocommerce-plugin/taxjar-woocommerce.php';
 
-	// load tlc-transients
-	require_once $this->plugin_dir . 'taxjar-woocommerce-plugin/includes/tlc-transients/tlc-transients.php';
+		// load tlc-transients
+		require_once $this->plugin_dir . 'taxjar-woocommerce-plugin/includes/tlc-transients/tlc-transients.php';
 
-    // load framework
-    require_once $this->tests_dir . '/framework/woocommerce-helper.php';
-    require_once $this->tests_dir . '/framework/customer-helper.php';
-    require_once $this->tests_dir . '/framework/product-helper.php';
-  }
+		// load framework
+		require_once $this->tests_dir . '/framework/woocommerce-helper.php';
+		require_once $this->tests_dir . '/framework/coupon-helper.php';
+		require_once $this->tests_dir . '/framework/customer-helper.php';
+		require_once $this->tests_dir . '/framework/product-helper.php';
+	}
 
-  public function setup() {
-    update_option('woocommerce_taxjar-integration_settings',
-      array(
-        'api_token' => $this->api_token,
-        'enabled' => 'yes',
-        'taxjar_download' => 'yes',
-        'store_zip' => '80111',
-        'store_city' => 'Greenwood Village',
-        'debug' => 'yes'
-      )
-    );
+	public function setup() {
+		update_option( 'woocommerce_taxjar-integration_settings',
+			array(
+				'api_token' => $this->api_token,
+				'enabled' => 'yes',
+				'taxjar_download' => 'yes',
+				'store_zip' => '80111',
+				'store_city' => 'Greenwood Village',
+				'debug' => 'yes',
+			)
+		);
 
-    update_option('woocommerce_default_country', 'US:CO');
-    update_option('woocommerce_calc_shipping', 'yes');
+		update_option( 'woocommerce_default_country', 'US:CO' );
+		update_option( 'woocommerce_calc_shipping', 'yes' );
+		update_option( 'woocommerce_coupons_enabled', 'yes' );
 
-    $wc_install = new WC_Install;
-    $wc_install->install();
+		$wc_install = new WC_Install;
+		$wc_install->install();
 
-    do_action('plugins_loaded');
-    do_action('woocommerce_init');
-  }
+		do_action( 'plugins_loaded' );
+		do_action( 'woocommerce_init' );
+	}
 
-  public static function instance() {
-    if ( is_null( self::$instance ) ) {
-      self::$instance = new self();
-    }
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
 
-    return self::$instance;
-  }
+		return self::$instance;
+	}
+
 }
 
 TaxJar_WC_Unit_Tests_Bootstrap::instance();

--- a/tests/framework/coupon-helper.php
+++ b/tests/framework/coupon-helper.php
@@ -1,0 +1,23 @@
+<?php
+class TaxJar_Coupon_Helper {
+
+	public static function create_coupon( $opts = array() ) {
+		global $woocommerce;
+
+		$defaults = array(
+			'code' => 'HIRO',
+			'amount' => '10',
+			'discount_type' => 'fixed_cart',
+		);
+		$params = extract( array_replace_recursive( $defaults, $opts ) );
+
+		$coupon = new WC_Coupon();
+		$coupon->set_code( $code );
+		$coupon->set_amount( $amount );
+		$coupon->set_discount_type( $discount_type );
+		$coupon->save();
+
+		return $coupon;
+	}
+
+}

--- a/tests/framework/customer-helper.php
+++ b/tests/framework/customer-helper.php
@@ -1,14 +1,21 @@
 <?php
+class TaxJar_Customer_Helper {
 
-class TaxJar_Customer_helper {
+	public static function create_customer( $opts = array() ) {
+		global $woocommerce;
 
-  public static function get_test_customer( $country = 'US', $state = 'CO', $zip = '80111', $city = 'Greenwood Village' ) {
-    global $woocommerce;
+		$defaults = array(
+			'country' => 'US',
+			'state' => 'CO',
+			'zip' => '80111',
+			'city' => 'Greenwood Village'
+		);
+		$params = extract( array_replace_recursive( $defaults, $opts ) );
 
-    $customer = new WC_Customer();
-    $customer->set_shipping_location( $country, $state, $zip, $city );
+		$customer = new WC_Customer();
+		$customer->set_shipping_location( $country, $state, $zip, $city );
 
-    return $customer;
-  }
+		return $customer;
+	}
 
 }

--- a/tests/framework/product-helper.php
+++ b/tests/framework/product-helper.php
@@ -1,48 +1,106 @@
 <?php
+class TaxJar_Product_Helper {
 
-class TaxJar_Helper_Product {
+	public static function create_product( $type = 'simple', $opts = array() ) {
+		switch ($type) {
+			case 'subscription':
+				return TaxJar_Product_Helper::create_subscription_product( $opts );
+			default:
+				return TaxJar_Product_Helper::create_simple_product( $opts );
+		}
+	}
 
-  public static function get_test_product() {
-    $products = get_posts( array(
-		'post_type' => 'product',
-	) );
+	private static function create_simple_product( $opts = array() ) {
+		$defaults = array(
+			'price' => '10',
+			'sku' => 'SIMPLE1',
+			'tax_class' => '',
+			'tax_status' => 'taxable',
+			'downloadable' => 'no',
+			'virtual' => 'no',
+		);
 
-    if ( 0 == count( $products ) ) {
-		TaxJar_Helper_Product::create_simple_product();
-      	$products = get_posts( array(
+		$post = array(
+			'post_title' => 'Dummy Product',
 			'post_type' => 'product',
+			'post_status' => 'publish',
+		);
+		$post_meta = array_replace_recursive( $defaults, $opts );
+		$post_meta['regular_price'] = $post_meta['price'];
+
+		$post_id = wp_insert_post( $post );
+
+		register_taxonomy(
+			'product_type',
+			'product'
+		);
+
+		update_post_meta( $post_id, '_price', $post_meta['price'] );
+		update_post_meta( $post_id, '_regular_price', $post_meta['regular_price'] );
+		update_post_meta( $post_id, '_sale_price', '' );
+		update_post_meta( $post_id, '_sku', $post_meta['sku'] );
+		update_post_meta( $post_id, '_manage_stock', 'no' );
+		update_post_meta( $post_id, '_tax_class', $post_meta['tax_class'] );
+		update_post_meta( $post_id, '_tax_status', $post_meta['tax_status'] );
+		update_post_meta( $post_id, '_downloadable', $post_meta['downloadable'] );
+		update_post_meta( $post_id, '_virtual', $post_meta['virtual'] );
+		update_post_meta( $post_id, '_stock_status', 'instock' );
+
+		wp_set_object_terms( $post_id, 'simple', 'product_type' );
+
+		$products = get_posts( array(
+			'post_type' => 'product',
+			'_sku' => $post_meta['sku'],
 		) );
-    }
 
-    $factory = new WC_Product_Factory();
-    return $factory->get_product( $products[0]->ID );
-  }
+		$factory = new WC_Product_Factory();
+		return $factory->get_product( $products[0]->ID );
+	}
 
-  private static function create_simple_product() {
-    $post = array(
-      'post_title' => 'Dummy Product',
-      'post_type' => 'product',
-      'post_status' => 'publish',
-    );
+	private static function create_subscription_product( $opts = array() ) {
+		$defaults = array(
+			'price' => '19.99',
+			'sku' => 'SUBSCRIPTION1',
+			'tax_class' => '',
+			'tax_status' => 'taxable',
+			'downloadable' => 'no',
+			'virtual' => 'yes',
+		);
 
-    $post_id = wp_insert_post( $post );
+		$post = array(
+			'post_title' => 'Dummy Subscription',
+			'post_type' => 'product',
+			'post_status' => 'publish',
+		);
+		$post_meta = array_replace_recursive( $defaults, $opts );
+		$post_meta['regular_price'] = $post_meta['price'];
 
-    register_taxonomy(
-      'product_type',
-      'product'
-    );
+		$post_id = wp_insert_post( $post );
 
-    update_post_meta( $post_id, '_price', '10' );
-	update_post_meta( $post_id, '_regular_price', '10' );
-	update_post_meta( $post_id, '_sale_price', '' );
-	update_post_meta( $post_id, '_sku', 'DUMMY SKU' );
-    update_post_meta( $post_id, '_manage_stock', 'no' );
-	update_post_meta( $post_id, '_tax_status', 'taxable' );
-    update_post_meta( $post_id, '_downloadable', 'no' );
-    update_post_meta( $post_id, '_virtual', 'no' );
-    update_post_meta( $post_id, '_stock_status', 'instock' );
+		register_taxonomy(
+			'product_type',
+			'product'
+		);
 
-    wp_set_object_terms( $post_id, 'simple', 'product_type' );
-  }
+		update_post_meta( $post_id, '_price', $post_meta['price'] );
+		update_post_meta( $post_id, '_regular_price', $post_meta['regular_price'] );
+		update_post_meta( $post_id, '_sale_price', '' );
+		update_post_meta( $post_id, '_sku', $post_meta['sku'] );
+		update_post_meta( $post_id, '_manage_stock', 'no' );
+		update_post_meta( $post_id, '_tax_class', $post_meta['tax_class'] );
+		update_post_meta( $post_id, '_tax_status', $post_meta['tax_status'] );
+		update_post_meta( $post_id, '_downloadable', $post_meta['downloadable'] );
+		update_post_meta( $post_id, '_virtual', $post_meta['virtual'] );
+		update_post_meta( $post_id, '_stock_status', 'instock' );
 
+		wp_set_object_terms( $post_id, 'subscription', 'product_type' );
+
+		$products = get_posts( array(
+			'post_type' => 'product',
+			'_sku' => $post_meta['sku'],
+		) );
+
+		$factory = new WC_Product_Factory();
+		return $factory->get_product( $products[0]->ID );
+	}
 }

--- a/tests/framework/woocommerce-helper.php
+++ b/tests/framework/woocommerce-helper.php
@@ -1,18 +1,33 @@
 <?php
+class TaxJar_Woocommerce_Helper {
 
-class TaxJar_Woocommerce_helper {
+	public static function prepare_woocommerce() {
+		global $woocommerce;
 
-  public static function prepare_woocommerce() {
-    global $woocommerce;
+		$woocommerce->product_factory = new WC_Product_Factory();
+		$woocommerce->order_factory = new WC_Order_Factory();
+		$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
+		$woocommerce->session  = new $session_class();
+		$woocommerce->cart = new WC_Cart();
 
-    $woocommerce->product_factory = new WC_Product_Factory();
-    $woocommerce->order_factory = new WC_Order_Factory();
-    $session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
-    $woocommerce->session  = new $session_class();
-    $woocommerce->cart = new WC_Cart();
+		// Start with an empty cart
+		$woocommerce->cart->empty_cart();
+		$woocommerce->shipping->shipping_total = 0;
 
-    $woocommerce->customer = TaxJar_Customer_helper::get_test_customer();
-    $woocommerce->cart->add_to_cart( TaxJar_Helper_Product::get_test_product()->get_id() );
-  }
+		// Reset shipping origin
+		TaxJar_Woocommerce_Helper::set_shipping_origin( array(
+			'store_zip' => '80111',
+			'store_city' => 'Greenwood Village',
+		) );
+
+		// Create a default customer shipping address
+		$woocommerce->customer = TaxJar_Customer_Helper::create_customer();
+	}
+
+	public static function set_shipping_origin( $opts = array() ) {
+		$current_settings = get_option( 'woocommerce_taxjar-integration_settings' );
+		$new_settings = array_replace_recursive( $current_settings, $opts );
+		update_option( 'woocommerce_taxjar-integration_settings', $new_settings );
+	}
 
 }

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -1,28 +1,146 @@
 <?php
 class TJ_WC_Actions extends WP_UnitTestCase {
-  function test_use_taxjar_total() {
-    global $woocommerce;
-    TaxJar_Woocommerce_helper::prepare_woocommerce();
 
-    $tj = new WC_Taxjar_Integration();
+	function setUp() {
+		global $woocommerce;
+		TaxJar_Woocommerce_Helper::prepare_woocommerce();
+		$tj = new WC_Taxjar_Integration();
 
-    do_action( 'woocommerce_calculate_totals', $woocommerce->cart );
+		$this->wc = $woocommerce;
+	}
 
-    $this->assertTrue( $woocommerce->cart->get_taxes_total() != 0 );
-  }
+	function test_taxjar_calculate_totals() {
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		$this->wc->cart->add_to_cart( $product );
+		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		$this->assertTrue( $this->wc->cart->get_taxes_total() != 0 );
+	}
 
-  function test_the_correct_taxes_are_set() {
-    global $woocommerce;
-    TaxJar_Woocommerce_helper::prepare_woocommerce();
-    $tj = new WC_Taxjar_Integration();
+	function test_correct_taxes_with_shipping() {
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 
-    $woocommerce->shipping->shipping_total = 5;
+		$this->wc->shipping->shipping_total = 5;
+		$this->wc->cart->add_to_cart( $product );
 
-    do_action( 'woocommerce_calculate_totals', $woocommerce->cart );
+		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
 
-    $this->assertEquals( $woocommerce->cart->tax_total, 0.4, '', 0.001 );
-    $this->assertEquals( $woocommerce->cart->shipping_tax_total, 0.2, '', 0.001 );
-    $this->assertEquals( array_values( $woocommerce->cart->shipping_taxes )[0], 0.2, '', 0.001 );
-    $this->assertEquals( $woocommerce->cart->get_taxes_total(), 0.6, '', 0.001 );
-  }
+		$this->assertEquals( $this->wc->cart->tax_total, 0.4, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->shipping_tax_total, 0.2, '', 0.001 );
+		$this->assertEquals( array_values( $this->wc->cart->shipping_taxes )[0], 0.2, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.6, '', 0.001 );
+
+		$this->wc->cart->calculate_totals();
+
+		foreach ( $this->wc->cart->get_cart() as $cart_item_key => $item ) {
+			$this->assertEquals( $item['line_tax'], 0.4, '', 0.001 );
+		}
+	}
+
+	function test_correct_taxes_for_multiple_products() {
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		$extra_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'price' => '25',
+			'sku' => 'SIMPLE2',
+		) )->get_id();
+
+		$this->wc->cart->add_to_cart( $product );
+		$this->wc->cart->add_to_cart( $extra_product, 2 );
+
+		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 2.4, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
+
+		$this->wc->cart->calculate_totals();
+
+		foreach ( $this->wc->cart->get_cart() as $cart_item_key => $item ) {
+			$product = $item['data'];
+			$sku = $product->get_sku();
+
+			if ( 'SIMPLE2' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 2, '', 0.001 );
+			}
+
+			if ( 'SIMPLE1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 0.4, '', 0.001 );
+			}
+		}
+	}
+
+	function test_correct_taxes_for_exempt_products() {
+		$exempt_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'tax_status' => 'none',
+		) )->get_id();
+
+		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 0, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0, '', 0.001 );
+	}
+
+	function test_correct_taxes_for_product_exemptions() {
+		TaxJar_Woocommerce_Helper::set_shipping_origin( array(
+			'store_zip' => '10001',
+			'store_city' => 'New York City',
+		) );
+
+		// NY shipping address
+		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+			'state' => 'NY',
+			'zip' => '10001',
+			'city' => 'New York City',
+		) );
+
+		$taxable_product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		$exempt_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'price' => '25',
+			'sku' => 'EXEMPT1',
+			'tax_class' => 'clothing-20010',
+		) )->get_id();
+
+		$this->wc->cart->add_to_cart( $taxable_product );
+		$this->wc->cart->add_to_cart( $exempt_product, 2 );
+
+		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 0.89, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.89, '', 0.001 );
+
+		$this->wc->cart->calculate_totals();
+
+		foreach ( $this->wc->cart->get_cart() as $cart_item_key => $item ) {
+			$product = $item['data'];
+			$sku = $product->get_sku();
+
+			if ( 'EXEMPT1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 0, '', 0.001 );
+			}
+
+			if ( 'SIMPLE1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 0.8875, '', 0.001 );
+			}
+		}
+	}
+
+	function test_correct_taxes_for_discounts() {
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		$product2 = TaxJar_Product_Helper::create_product( 'simple', array(
+			'price' => '30',
+			'sku' => 'SIMPLE2',
+		) )->get_id();
+		$coupon = TaxJar_Coupon_Helper::create_coupon( array(
+			'amount' => '10',
+			'discount_type' => 'fixed_cart',
+		) )->get_code();
+
+		$this->wc->cart->add_to_cart( $product );
+		$this->wc->cart->add_to_cart( $product2, 2 );
+		$this->wc->cart->add_discount( $coupon );
+
+		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 2.4, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
+	}
+
 }

--- a/tests/specs/test-activation.php
+++ b/tests/specs/test-activation.php
@@ -1,10 +1,11 @@
 <?php
 class TJ_WC_Activation extends WP_UnitTestCase {
 
-  function test_objects_are_accessable() {
-    global $woocommerce;
+	function test_objects_are_accessable() {
+		global $woocommerce;
 
-    $this->assertTrue( null != $woocommerce );
-    $this->assertTrue( class_exists( 'WC_Taxjar' ) );
-  }
+		$this->assertTrue( null != $woocommerce );
+		$this->assertTrue( class_exists( 'WC_Taxjar' ) );
+	}
+
 }

--- a/tests/specs/test-class-taxjar-nexus.php
+++ b/tests/specs/test-class-taxjar-nexus.php
@@ -1,53 +1,56 @@
 <?php
 class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 
-  function setUp() {
-    $this->tj = new WC_Taxjar_Integration();
-    $this->tj_nexus = new WC_Taxjar_Nexus( $this->tj );
-    parent::setUp();
-  }
+	function setUp() {
+		$this->tj = new WC_Taxjar_Integration();
+		$this->tj_nexus = new WC_Taxjar_Nexus( $this->tj );
+		$this->cache_key = 'tlc__' . md5( 'get_nexus_from_cache' );
 
-  function test_get_or_update_cached_nexus() {
-    delete_transient( 'wc_taxjar_nexus_list' );
-    $this->assertEquals( get_transient( 'wc_taxjar_nexus_list' ), false );
-    $this->tj_nexus->get_or_update_cached_nexus();
-    $this->assertTrue( count( get_transient( 'wc_taxjar_nexus_list' ) ) > 0 );
-  }
+		parent::setUp();
+	}
 
-  function test_get_or_update_cached_nexus_uses_correct_timeout() {
-    delete_transient( 'wc_taxjar_nexus_list' );
-    $this->assertEquals( get_transient( 'wc_taxjar_nexus_list' ), false );
-    $this->tj_nexus->get_or_update_cached_nexus();
-    $transient = get_transient( 'timeout_wc_taxjar_nexus_list' );
-    $this->assertEquals( $transient, time() + 0.5 * DAY_IN_SECONDS );
-  }
+	function test_get_or_update_cached_nexus() {
+		delete_transient( $this->cache_key );
+		$this->assertEquals( get_transient( $this->cache_key ), false );
+		$this->tj_nexus->get_or_update_cached_nexus();
+		$this->assertTrue( count( get_transient( $this->cache_key ) ) > 0 );
+	}
 
-  function test_or_get_update_cached_nexus_expiration() {
-    delete_transient( 'wc_taxjar_nexus_list' );
-    $this->assertEquals( get_transient( 'wc_taxjar_nexus_list' ), false );
-    set_transient( 'wc_taxjar_nexus_list', array(), -0.5 * DAY_IN_SECONDS );
-    $this->tj_nexus->get_or_update_cached_nexus();
-    $transient = get_transient( 'timeout_wc_taxjar_nexus_list' );
-    $this->assertEquals( $transient, time() + 0.5 * DAY_IN_SECONDS );
-    $this->assertTrue( count( get_transient( 'wc_taxjar_nexus_list' ) ) > 0 );
-  }
+	function test_get_or_update_cached_nexus_uses_correct_timeout() {
+		delete_transient( $this->cache_key );
+		$this->assertEquals( get_transient( $this->cache_key ), false );
+		$this->tj_nexus->get_or_update_cached_nexus();
+		$transient = get_transient( $this->cache_key );
+		$this->assertEquals( $transient[0], time() + 0.5 * DAY_IN_SECONDS );
+	}
 
-  function test_has_nexus_check_uses_base_address() {
-    update_option( 'woocommerce_default_country', 'US:XO' );
-    $this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'XO' ) );
-  }
+	function test_or_get_update_cached_nexus_expiration() {
+		delete_transient( $this->cache_key );
+		$this->assertEquals( get_transient( $this->cache_key ), false );
+		set_transient( $this->cache_key, array(), -0.5 * DAY_IN_SECONDS );
+		$this->tj_nexus->get_or_update_cached_nexus();
+		$transient = get_transient( $this->cache_key );
+		$this->assertEquals( $transient[0], time() + 0.5 * DAY_IN_SECONDS );
+		$this->assertTrue( count( get_transient( $this->cache_key ) ) > 0 );
+	}
 
-  function test_has_nexus_check_uses_nexus_list() {
-    $this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'CO' ) );
-  }
+	function test_has_nexus_check_uses_base_address() {
+		update_option( 'woocommerce_default_country', 'US:XO' );
+		$this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'XO' ) );
+	}
 
-  function test_works_when_only_using_counry() {
-    update_option( 'woocommerce_default_country', 'DE:' );
-    $this->assertTrue( $this->tj_nexus->has_nexus_check( 'DE' ) );
-  }
+	function test_has_nexus_check_uses_nexus_list() {
+		$this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'CO' ) );
+	}
 
-  function test_returns_false_if_not_shipping_to_nexus_area() {
-    update_option( 'woocommerce_default_country', 'US:CO' );
-    $this->assertFalse( $this->tj_nexus->has_nexus_check( 'US', 'XO' ) );
-  }
+	function test_works_when_only_using_counry() {
+		update_option( 'woocommerce_default_country', 'DE:' );
+		$this->assertTrue( $this->tj_nexus->has_nexus_check( 'DE' ) );
+	}
+
+	function test_returns_false_if_not_shipping_to_nexus_area() {
+		update_option( 'woocommerce_default_country', 'US:CO' );
+		$this->assertFalse( $this->tj_nexus->has_nexus_check( 'US', 'XO' ) );
+	}
+
 }

--- a/tests/specs/test-filters.php
+++ b/tests/specs/test-filters.php
@@ -1,20 +1,22 @@
 <?php
 class TJ_WC_Filters extends WP_UnitTestCase {
-  public function setUp() {
-    $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-  }
 
-  function test_append_base_address_to_customer_taxable_address() {
-    global $woocommerce;
-    TaxJar_Woocommerce_helper::prepare_woocommerce();
+	public function setUp() {
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+	}
 
-    $tj = new WC_Taxjar_Integration();
-    $woocommerce->session->set( 'chosen_shipping_methods', array( 'local_pickup' ) );
+	function test_append_base_address_to_customer_taxable_address() {
+		global $woocommerce;
+		TaxJar_Woocommerce_Helper::prepare_woocommerce();
 
-    $address = array( 'US', 'CO', '81210', 'Denver' );
-    $address = apply_filters( 'woocommerce_customer_taxable_address', $address );
+		$tj = new WC_Taxjar_Integration();
+		$woocommerce->session->set( 'chosen_shipping_methods', array( 'local_pickup' ) );
 
-    $this->assertEquals( strtoupper( $address[2] ), strtoupper( $tj->settings['store_zip'] ) );
-    $this->assertEquals( strtoupper( $address[3] ), strtoupper( $tj->settings['store_city'] ) );
-  }
+		$address = array( 'US', 'CO', '81210', 'Denver' );
+		$address = apply_filters( 'woocommerce_customer_taxable_address', $address );
+
+		$this->assertEquals( strtoupper( $address[2] ), strtoupper( $tj->settings['store_zip'] ) );
+		$this->assertEquals( strtoupper( $address[3] ), strtoupper( $tj->settings['store_city'] ) );
+	}
+
 }

--- a/tests/specs/test-settings.php
+++ b/tests/specs/test-settings.php
@@ -1,12 +1,11 @@
 <?php
 class TJ_WC_Settings extends WP_UnitTestCase {
 
-  function test_taxjar_settings() {
-    $tj = new WC_Taxjar_Integration();
-    $this->assertNotNull( $tj->api_token );
-    $this->assertTrue( 'yes' == $tj->enabled );
-    $this->assertTrue( 'yes' == $tj->download_orders->taxjar_download );
-  }
+	function test_taxjar_settings() {
+		$tj = new WC_Taxjar_Integration();
+		$this->assertNotNull( $tj->api_token );
+		$this->assertTrue( 'yes' == $tj->enabled );
+		$this->assertTrue( 'yes' == $tj->download_orders->taxjar_download );
+	}
+
 }
-
-


### PR DESCRIPTION
This PR supports product exemptions based on user-defined tax classes and codes:

<img width="536" alt="screen shot 2017-06-16 at 9 16 25 am" src="https://user-images.githubusercontent.com/1137184/27235516-f564ce62-5275-11e7-8a65-89eb9c8a0e10.png">

For example, if a product is assigned to the "Clothing - 20010" tax class:

<img width="667" alt="screen shot 2017-06-16 at 9 17 13 am" src="https://user-images.githubusercontent.com/1137184/27235544-06802cbe-5276-11e7-8a6b-35e3085882a6.png">

Sales tax won't be collected in certain jurisdictions of NY for products assigned to this tax class:

<img width="1183" alt="screen shot 2017-06-16 at 9 11 55 am" src="https://user-images.githubusercontent.com/1137184/27235577-1be8b7d8-5276-11e7-8caf-16b7e3bc0079.png">

**Important**: These tax classes are user-defined and it's up to the user to find the correct tax code in our documentation. Woo's additional tax classes is just a `textarea` box.





