### PR TITLE
Backend Order Calculations for Woo 2.6 & 3.0

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -528,9 +528,9 @@ class WC_Taxjar_Integration extends WC_Integration {
 		$line_items = array();
 
 		if ( method_exists( $order, 'get_shipping_total' ) ) {
-			$shipping = $order->get_shipping_total();
+			$shipping = $order->get_shipping_total(); // Woo 3.0+
 		} else {
-			$shipping = $order->get_total_shipping();
+			$shipping = $order->get_total_shipping(); // Woo 2.6
 		}
 
 		foreach ( $order->get_items() as $item ) {

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -596,16 +596,21 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'line_items' => $line_items,
 		) );
 
+		// Add tax rates manually for Woo 3.0+
+		// Woo 2.6 adds the rates automatically
 		foreach ( $order->get_items() as $item ) {
 			if ( is_object( $item ) ) { // Woo 3.0+
 				$product_id = $item->get_product_id();
-				if ( isset( $this->line_items[ $product_id ] ) ) {
-					$item->set_total_tax( $this->line_items[ $product_id ]->tax_collectable );
-				}
-			} else { // Woo 2.6
-				$product_id = $item['product_id'];
-				if ( isset( $this->line_items[ $product_id ] ) ) {
-					$item['line_tax'] = $this->line_items[ $product_id ]->tax_collectable;
+			}
+
+			if ( isset( $this->rate_ids[ $product_id ] ) ) {
+				$rate_id = $this->rate_ids[ $product_id ];
+
+				if ( class_exists( 'WC_Order_Item_Tax' ) ) { // Woo 3.0+
+					$item_tax = new WC_Order_Item_Tax();
+					$item_tax->set_rate( $rate_id );
+					$item_tax->set_order_id( $order_id );
+					$item_tax->save();
 				}
 			}
 		}

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -498,7 +498,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'to_zip' => $to_zip,
 			'shipping_amount' => $woocommerce->shipping->shipping_total,
 			'line_items' => $line_items,
-			'customer' => $woocommerce->customer,
 		) );
 
 		// Store the rate ID and the amount on the cart's totals

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -384,7 +384,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 	} // End calculate_tax().
 
 	/**
-	 * Add a native tax rate to WooCommerce
+	 * Add or update a native WooCommerce tax rate
 	 *
 	 * @return void
 	 */
@@ -463,7 +463,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 	}
 
 	/**
-	 * Ensure use of the TaxJar amount_to_collect and API data
+	 * Calculate tax / totals using TaxJar at checkout
 	 *
 	 * @return void
 	 */
@@ -537,6 +537,11 @@ class WC_Taxjar_Integration extends WC_Integration {
 		}
 	}
 
+	/**
+	 * Calculate tax / totals using TaxJar for backend orders
+	 *
+	 * @return void
+	 */
 	public function calculate_backend_totals( $order_id ) {
 		$order = wc_get_order( $order_id );
 		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;


### PR DESCRIPTION
WooCommerce 3.0 removed the previous hook we were using for handling backend order calculations via the "Calculate Tax" / "Recalculate" button: `woocommerce_ajax_calc_line_taxes`. Luckily, there's another hook available called `woocommerce_before_save_order_items` for both 2.6 and 3.0. More info on this here: https://wordpress.org/support/topic/woocommerce-3-0-missing-hook-woocommerce_ajax_calc_line_taxes/

<img width="394" alt="screen shot 2017-06-23 at 6 38 53 pm" src="https://user-images.githubusercontent.com/1137184/27504653-4373ea8e-5843-11e7-9e33-de0b71b3ca4b.png">

This PR also improves native rate handling for multiple product tax classes for exemptions. If two different tax classes are used in an order, multiple tax columns will be added:

<img width="1195" alt="screen shot 2017-08-11 at 2 11 23 pm" src="https://user-images.githubusercontent.com/1137184/29234616-2e819de8-7ead-11e7-97ca-52e3a20b55cb.png">

<img width="253" alt="screen shot 2017-08-11 at 2 13 44 pm" src="https://user-images.githubusercontent.com/1137184/29234619-331df770-7ead-11e7-968b-1e847bf4bcc8.png">

**Versions Tested:**

- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6.2
- [x] Woo 2.6.1
- [x] Woo 2.6.0
