### PR TITLE
Fix Subscription Calculations at Checkout

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -465,6 +465,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$id = $product->get_id();
 			$quantity = $cart_item['quantity'];
 			$unit_price = $product->get_price();
+			$line_subtotal = $cart_item['line_subtotal'];
 			$discount = ( $unit_price - $wc_cart_object->get_discounted_price( $cart_item, $unit_price ) ) * $quantity;
 			$tax_class = explode( '-', $product->get_tax_class() );
 			$tax_code = '';
@@ -477,7 +478,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 				$tax_code = $tax_class[1];
 			}
 
-			if ( $unit_price ) {
+			if ( $unit_price && $line_subtotal ) {
 				array_push($line_items, array(
 					'id' => $id,
 					'quantity' => $quantity,


### PR DESCRIPTION
This PR will only calculate tax on subscriptions when a recurring payment occurs. If a subscription has a trial period, the line subtotal is $0. Check both the unit price **and** line subtotal before adding line items to an API calculation.