### PR TITLE
Fix "limit usage to X items" discounts in WooCommerce 3.1

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -486,6 +486,14 @@ class WC_Taxjar_Integration extends WC_Integration {
 		$line_items = array();
 		$cart_taxes = array();
 
+		foreach ( $wc_cart_object->coupons as $coupon ) {
+			$limit_usage_qty = get_post_meta( $coupon->get_id(), 'limit_usage_to_x_items', true );
+
+			if ( $limit_usage_qty ) {
+				$coupon->set_limit_usage_to_x_items( $limit_usage_qty );
+			}
+		}
+
 		foreach ( $wc_cart_object->get_cart() as $cart_item_key => $cart_item ) {
 			$product = $cart_item['data'];
 			$id = $product->get_id();

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -487,10 +487,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 		$cart_taxes = array();
 
 		foreach ( $wc_cart_object->coupons as $coupon ) {
-			$limit_usage_qty = get_post_meta( $coupon->get_id(), 'limit_usage_to_x_items', true );
+			if ( method_exists( $coupon, 'get_id' ) ) { // Woo 3.0+
+				$limit_usage_qty = get_post_meta( $coupon->get_id(), 'limit_usage_to_x_items', true );
 
-			if ( $limit_usage_qty ) {
-				$coupon->set_limit_usage_to_x_items( $limit_usage_qty );
+				if ( $limit_usage_qty ) {
+					$coupon->set_limit_usage_to_x_items( $limit_usage_qty );
+				}
 			}
 		}
 


### PR DESCRIPTION
WooCommerce 3.1 has an odd way of handling "limit usage to X items" discounts. Inside `class-wc-coupon.php`, the limit usage quantity is reduced during the calculation process when obtaining the discounted price. Once TaxJar hooks into the calculation process, the limit usage quantity is already reduced to zero. This PR resets the limit usage quantity based on the coupon metadata so we can ensure tax isn't collected if the quantity threshold is reached.

WooCommerce 3.2 deprecates the `get_discounted_price` method in `class-wc-cart.php` and removes the code used to determine "limit usage to X items" for `get_discount_amount` in `class-wc-coupon.php`, so we need to test this functionality and ensure it's backwards-compatible in a future 3.2 beta.

WooCommerce 3.2 also introduces coupons / discounts for backend orders, so we'll want to test that as well in the future.

- [x] Test in WooCommerce 3.1
- [x] Test in WooCommerce 3.0
- [x] Test in WooCommerce 2.6.x