### PR TITLE
Calculate order totals twice for WooCommerce 3.2

### DIFF
--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -18,6 +18,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 	function tearDown() {
 		// Prevent duplicate action callbacks
+		remove_action( 'woocommerce_before_calculate_totals', array( $this->tj, 'calculate_totals' ), 20 );
 		remove_action( 'woocommerce_calculate_totals', array( $this->tj, 'calculate_totals' ), 20 );
 		remove_action( 'woocommerce_before_save_order_items', array( $this->tj, 'calculate_backend_totals' ), 20 );
 


### PR DESCRIPTION
WooCommerce 3.2 completely revamped their tax calculation process and changed the order on how they calculate item totals, shippings, and fees. The `woocommerce_calculate_totals` action now comes at the end of this process.

In order to properly calculate the order total, we need tax rates in the system to be applied to the item totals. However, we can't get the amount to collect without calculating discounts first. So if we try to hook only into `woocommerce_before_calculate_totals`, we won't be able to properly calculate the total amount of sales tax to collect. If we only hook into `woocommerce_calculate_totals`, the new rate won't be applied to the item totals and we won't update the grand total correctly.

For this reason, we need to calculate the order totals twice. The first time allows us to create a new tax rate in WooCommerce using `woocommerce_before_calculate_totals`. The second time we actually apply the tax rate and get the correct amount to collect with discounts applied using `woocommerce_calculate_totals`.

👍