### PR TITLE
Modify order total if missing tax in WooCommerce 3.2+

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -56,6 +56,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			// Filters
 			add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, array( $this, 'sanitize_settings' ) );
 			add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
+			add_filter( 'woocommerce_calculated_total', array( $this, 'calculated_total' ), 10, 2 );
 
 			// If TaxJar is enabled and a user disables taxes we renable them
 			update_option( 'woocommerce_calc_taxes', 'yes' );
@@ -558,6 +559,19 @@ class WC_Taxjar_Integration extends WC_Integration {
 				$wc_cart_object->cart_contents[ $cart_item_key ]['line_tax'] = $this->line_items[ $product->get_id() ]->tax_collectable;
 			}
 		}
+	}
+
+	/**
+	 * Modify total if missing tax for WooCommerce 3.2+
+	 *
+	 * @return float
+	 */
+	public function calculated_total( $total, $cart ) {
+		if ( $cart->get_subtotal() == $total && $this->amount_to_collect > 0 ) {
+			$total += $this->amount_to_collect;
+		}
+
+		return $total;
 	}
 
 	/**

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -567,8 +567,8 @@ class WC_Taxjar_Integration extends WC_Integration {
 	 * @return float
 	 */
 	public function calculated_total( $total, $cart ) {
-		if ( method_exists( $cart, 'get_subtotal' ) ) { // Woo 3.2+
-			if ( $cart->get_subtotal() == $total && $this->amount_to_collect > 0 ) {
+		if ( method_exists( $cart, 'get_total_tax' ) ) { // Woo 3.2+
+			if ( $cart->get_total_tax() < $this->amount_to_collect && $this->amount_to_collect > 0 ) {
 				$total += $this->amount_to_collect;
 			}
 		}

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -567,8 +567,10 @@ class WC_Taxjar_Integration extends WC_Integration {
 	 * @return float
 	 */
 	public function calculated_total( $total, $cart ) {
-		if ( $cart->get_subtotal() == $total && $this->amount_to_collect > 0 ) {
-			$total += $this->amount_to_collect;
+		if ( method_exists( $cart, 'get_subtotal' ) ) { // Woo 3.2+
+			if ( $cart->get_subtotal() == $total && $this->amount_to_collect > 0 ) {
+				$total += $this->amount_to_collect;
+			}
 		}
 
 		return $total;


### PR DESCRIPTION
Since WooCommerce 3.2 revamped the calculation process to calculate totals before we can create a tax rate based on our API response, we need a way to modify the grand total without having to re-calculate for brand new rates introduced in the system.

This PR adds a new hook for the `woocommerce_calculated_total` filter and only updates the grand total if the subtotal is equal to grand total and tax is returned from SmartCalcs.