### PR TITLE
Always Use Taxable Address for WC Rate Lookups

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -280,7 +280,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 		$this->freight_taxable      = 1;
 		$this->line_items           = array();
 		$this->has_nexus            = 0;
-		$this->tax_source           = 'origin';
 		$this->rate_ids             = array();
 
 		// Strict conditions to be met before API call can be conducted
@@ -334,7 +333,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 			// Update Properties based on Response
 			$this->has_nexus          = (int) $taxjar_response->has_nexus;
-			$this->tax_source         = empty( $taxjar_response->tax_source ) ? 'origin' : $taxjar_response->tax_source;
 			$this->amount_to_collect  = $taxjar_response->amount_to_collect;
 			$this->tax_rate           = $taxjar_response->rate;
 			$this->freight_taxable    = (int) $taxjar_response->freight_taxable;
@@ -361,18 +359,11 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$wc_cart_object->remove_taxes();
 		} elseif ( $this->has_nexus ) {
 			// Use Woo core to find matching rates for taxable address
-			$source_zip = 'destination' == $this->tax_source ? $to_zip : $from_zip;
-			$source_city = 'destination' == $this->tax_source ? $to_city : $from_city;
-
-			if ( strtoupper( $to_city ) == strtoupper( $from_city ) ) {
-				$source_city = $to_city;
-			}
-
 			$location = array(
 				'to_country' => $to_country,
 				'to_state' => $to_state,
-				'to_zip' => $source_zip,
-				'to_city' => $source_city,
+				'to_zip' => $to_zip,
+				'to_city' => $to_city,
 			);
 
 			// Add line item tax rates

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -89,6 +89,8 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 				$this->assertEquals( $item['line_tax'], 0.4, '', 0.001 );
 			}
 		}
+
+		$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 62.4, '', 0.001 );
 	}
 
 	function test_correct_taxes_for_exempt_products() {
@@ -146,6 +148,8 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 				$this->assertEquals( $item['line_tax'], 0.89, '', 0.001 );
 			}
 		}
+
+		$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 60.89, '', 0.001 );
 	}
 
 	function test_correct_taxes_for_product_exemption_thresholds() {
@@ -215,6 +219,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 		$this->assertEquals( $this->wc->cart->tax_total, 2.4, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 62.4, '', 0.001 );
 	}
 
 	function test_correct_taxes_for_intrastate_origin_state() {

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -217,6 +217,57 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
 	}
 
+	function test_correct_taxes_for_intrastate_origin_state() {
+		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
+			'store_country' => 'US',
+			'store_state' => 'TX',
+			'store_zip' => '76082',
+			'store_city' => 'Agnes',
+		) );
+
+		// TX shipping address
+		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+			'state' => 'TX',
+			'zip' => '73301',
+			'city' => 'Austin',
+		) );
+
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		$this->wc->cart->add_to_cart( $product );
+
+		do_action( $this->action, $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 0.68, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.68, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 10.68, '', 0.001 );
+	}
+
+	function test_correct_taxes_for_interstate_origin_state() {
+		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
+			'store_country' => 'US',
+			'store_state' => 'NC',
+			'store_zip' => '27545',
+			'store_city' => 'Raleigh',
+		) );
+
+		// TX shipping address
+		// Make sure your test account has nexus in TX
+		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+			'state' => 'TX',
+			'zip' => '73301',
+			'city' => 'Austin',
+		) );
+
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		$this->wc->cart->add_to_cart( $product );
+
+		do_action( $this->action, $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 0.83, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.83, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 10.83, '', 0.001 );
+	}
+
 	function test_correct_taxes_for_canada() {
 		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
 			'store_country' => 'CA',


### PR DESCRIPTION
If a merchant has origin-based or CA modified-origin sourcing, our plugin could find a different native tax rate than WooCommerce's destination-based lookup since we were looking at the store's city and zip code, not the customer's city and zip code. We should always use the taxable address for looking up rates, similar to WooCommerce, to ensure we always update the same rate WooCommerce is using for internal total calculations. Using the same rate ensures the grand total always reflects the subtotal, shipping, and tax returned by TaxJar.

**Versions Tested:**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6.2
- [x] Woo 2.6.1
- [x] Woo 2.6.0