### PR TITLE
Recalculate totals in WooCommerce 3.2 instead of manually updating total

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -44,7 +44,11 @@ class WC_Taxjar_Integration extends WC_Integration {
 		if ( ( 'yes' == $this->settings['enabled'] ) ) {
 
 			// Calculate Taxes at Cart / Checkout
-			add_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
+				add_action( 'woocommerce_after_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			} else {
+				add_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			}
 
 			// Calculate Taxes for Backend Orders (Woo 2.6+)
 			add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
@@ -56,7 +60,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 			// Filters
 			add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, array( $this, 'sanitize_settings' ) );
 			add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
-			add_filter( 'woocommerce_calculated_total', array( $this, 'calculated_total' ), 10, 2 );
 
 			// If TaxJar is enabled and user disables taxes we re-enable them
 			update_option( 'woocommerce_calc_taxes', 'yes' );
@@ -533,6 +536,10 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'line_items' => $line_items,
 		) );
 
+		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
+			new WC_Cart_Totals( $wc_cart_object );
+		}
+
 		foreach ( $this->line_items as $product_id => $line_item ) {
 			if ( isset( $cart_taxes[ $this->rate_ids[ $product_id ] ] ) ) {
 				$cart_taxes[ $this->rate_ids[ $product_id ] ] += $line_item->tax_collectable;
@@ -558,21 +565,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 				$wc_cart_object->cart_contents[ $cart_item_key ]['line_tax'] = $this->line_items[ $product->get_id() ]->tax_collectable;
 			}
 		}
-	}
-
-	/**
-	 * Modify total if missing tax for WooCommerce 3.2+
-	 *
-	 * @return float
-	 */
-	public function calculated_total( $total, $cart ) {
-		if ( method_exists( $cart, 'get_total_tax' ) ) { // Woo 3.2+
-			if ( $cart->get_total_tax() < $this->amount_to_collect && $this->amount_to_collect > 0 ) {
-				$total += $this->amount_to_collect;
-			}
-		}
-
-		return $total;
 	}
 
 	/**

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -14,11 +14,17 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			'store_zip' => '80111',
 			'store_city' => 'Greenwood Village',
 		) );
+
+		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
+			$this->action = 'woocommerce_after_calculate_totals';
+		} else {
+			$this->action = 'woocommerce_calculate_totals';
+		}
 	}
 
 	function tearDown() {
 		// Prevent duplicate action callbacks
-		remove_action( 'woocommerce_calculate_totals', array( $this->tj, 'calculate_totals' ), 20 );
+		remove_action( $this->action, array( $this->tj, 'calculate_totals' ), 20 );
 		remove_action( 'woocommerce_before_save_order_items', array( $this->tj, 'calculate_backend_totals' ), 20 );
 
 		// Empty the cart
@@ -28,7 +34,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 	function test_taxjar_calculate_totals() {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 		$this->wc->cart->add_to_cart( $product );
-		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		do_action( $this->action, $this->wc->cart );
 		$this->assertTrue( $this->wc->cart->get_taxes_total() != 0 );
 	}
 
@@ -38,7 +44,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->wc->shipping->shipping_total = 5;
 		$this->wc->cart->add_to_cart( $product );
 
-		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		do_action( $this->action, $this->wc->cart );
 
 		$this->assertEquals( $this->wc->cart->tax_total, 0.4, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->shipping_tax_total, 0.2, '', 0.001 );
@@ -66,7 +72,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->wc->cart->add_to_cart( $product );
 		$this->wc->cart->add_to_cart( $extra_product, 2 );
 
-		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		do_action( $this->action, $this->wc->cart );
 
 		$this->assertEquals( $this->wc->cart->tax_total, 2.4, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
@@ -92,7 +98,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 		$this->wc->cart->add_to_cart( $exempt_product );
 
-		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		do_action( $this->action, $this->wc->cart );
 
 		$this->assertEquals( $this->wc->cart->tax_total, 0, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0, '', 0.001 );
@@ -123,7 +129,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->wc->cart->add_to_cart( $taxable_product );
 		$this->wc->cart->add_to_cart( $exempt_product, 2 );
 
-		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		do_action( $this->action, $this->wc->cart );
 
 		$this->assertEquals( $this->wc->cart->tax_total, 0.89, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.89, '', 0.001 );
@@ -157,7 +163,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->wc->cart->add_to_cart( $product2, 2 );
 		$this->wc->cart->add_discount( $coupon );
 
-		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		do_action( $this->action, $this->wc->cart );
 
 		$this->assertEquals( $this->wc->cart->tax_total, 2.4, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
@@ -182,7 +188,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 		$this->wc->cart->add_to_cart( $product );
 
-		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		do_action( $this->action, $this->wc->cart );
 
 		$this->assertEquals( $this->wc->cart->tax_total, 1.3, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 1.3, '', 0.001 );
@@ -207,7 +213,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 		$this->wc->cart->add_to_cart( $product );
 
-		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		do_action( $this->action, $this->wc->cart );
 
 		$this->assertEquals( $this->wc->cart->tax_total, 1, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 1, '', 0.001 );
@@ -232,7 +238,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 		$this->wc->cart->add_to_cart( $product );
 
-		do_action( 'woocommerce_calculate_totals', $this->wc->cart );
+		do_action( $this->action, $this->wc->cart );
 
 		$this->assertEquals( $this->wc->cart->tax_total, 2, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2, '', 0.001 );


### PR DESCRIPTION
We've seen various edge cases with 3rd party plugins manipulating totals, such as order-level discounts causing issues with how TaxJar adds sales tax to the grand total.

Instead of using `woocommerce_calculated_total`, leverage `woocommerce_after_calculate_totals` in WooCommerce 3.2 and re-calculate for new tax rates introduced in the system.

**Versions Tested:**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6