### PR TITLE
Sales Tax for Duplicate Line Items

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -370,10 +370,11 @@ class WC_Taxjar_Integration extends WC_Integration {
 			);
 
 			// Add line item tax rates
-			foreach ( $this->line_items as $product_id => $line_item ) {
+			foreach ( $this->line_items as $line_item_key => $line_item ) {
+				$product_id = explode( '-', $line_item_key )[0];
 				$product = wc_get_product( $product_id );
 				$tax_class = $product->get_tax_class();
-				$this->create_or_update_tax_rate( $product_id, $location, $line_item->combined_tax_rate * 100, $tax_class );
+				$this->create_or_update_tax_rate( $line_item_key, $location, $line_item->combined_tax_rate * 100, $tax_class );
 			}
 
 			// Add shipping tax rate
@@ -509,7 +510,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 			if ( $unit_price && $line_subtotal ) {
 				array_push($line_items, array(
-					'id' => $id,
+					'id' => $id . '-' . $cart_item_key,
 					'quantity' => $quantity,
 					'product_tax_code' => $tax_code,
 					'unit_price' => $unit_price,
@@ -577,7 +578,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$shipping = $order->get_total_shipping(); // Woo 2.6
 		}
 
-		foreach ( $order->get_items() as $item ) {
+		foreach ( $order->get_items() as $item_key => $item ) {
 			if ( is_object( $item ) ) { // Woo 3.0+
 				$id = $item->get_product_id();
 				$quantity = $item->get_quantity();
@@ -604,7 +605,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 			if ( $unit_price ) {
 				array_push($line_items, array(
-					'id' => $id,
+					'id' => $id . '-' . $item_key,
 					'quantity' => $quantity,
 					'product_tax_code' => $tax_code,
 					'unit_price' => $unit_price,

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -93,6 +93,19 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 62.4, '', 0.001 );
 	}
 
+	function test_correct_taxes_for_duplicate_line_items() {
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+
+		$this->wc->cart->add_to_cart( $product );
+		$this->wc->cart->add_to_cart( $product, 1, 0, [], [ 'duplicate' => true ] );
+
+		do_action( $this->action, $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 0.8, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.8, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 20.8, '', 0.001 );
+	}
+
 	function test_correct_taxes_for_exempt_products() {
 		$exempt_product = TaxJar_Product_Helper::create_product( 'simple', array(
 			'tax_status' => 'none',
@@ -186,7 +199,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->assertEquals( $this->wc->cart->tax_total, 13.31, '', 0.001 );
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 13.31, '', 0.001 );
 
-		foreach ( $this->wc->cart->get_cart() as $cart_item_key => $item ) {
+		foreach ( $this->wc->cart->get_cart() as $item_key => $item ) {
 			$product = $item['data'];
 			$sku = $product->get_sku();
 


### PR DESCRIPTION
Plugins such as [WooCommerce Product Bundles](https://woocommerce.com/products/product-bundles/) that allow merchants to create kits / bundled products can add duplicate line items with the same product ID in the cart. If this happens, our API can't differentiate between these line items and consolidates them. This results in a lower tax amount than expected.

This PR appends the cart item key to the line item ID and retains the product ID to determine the tax class when creating a new tax rate in WooCommerce.

**Versions Tested:**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6.14
- [x] Woo 2.6.2
- [x] Woo 2.6.0