### PR TITLE
Exempt Shipping Tax for Fully Exempt Orders

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -355,6 +355,11 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 
 			$this->item_collectable = $this->amount_to_collect - $this->shipping_collectable;
+
+			if ( 0 == $this->item_collectable ) {
+				$this->freight_taxable = 0;
+				$this->shipping_collectable = 0;
+			}
 		}
 
 		// Remove taxes if they are set somehow and customer is exempt


### PR DESCRIPTION
Currently our API doesn't exempt shipping tax on fully exempt orders where shipping is taxable such as New York. If a customer purchases a clothing item in NY under $110, sales tax is still collected on shipping. This logic could potentially vary by state. If so, we should look at specific states where this rule applies.

This is a temporary fix until our API resolves this issue.

**Versions Tested:**

- [x] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
- [ ] Woo 2.6.14
- [ ] Woo 2.6.2
- [ ] Woo 2.6.0