### PR TITLE
Exempt FL Shipping Tax If Local Pickup Available

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -355,6 +355,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 
 			$this->item_collectable = $this->amount_to_collect - $this->shipping_collectable;
+
+			// Exempt shipping tax in FL if local pickup is available
+			if ( 'FL' == $to_state && $this->has_shipping_method( 'local_pickup' ) ) {
+				$this->freight_taxable = 0;
+				$this->shipping_collectable = 0;
+			}
 		}
 
 		// Remove taxes if they are set somehow and customer is exempt
@@ -671,6 +677,26 @@ class WC_Taxjar_Integration extends WC_Integration {
 		}
 
 		return array( $country, $state, $postcode, $city );
+	}
+
+	/**
+	 * Check whether this cart has a specific shipping method or not.
+	 *
+	 * @param string $method_id
+	 * @return boolean
+	 */
+	public function has_shipping_method( $method_id ) {
+		$packages = WC()->shipping->calculate_shipping( WC()->shipping->get_packages() );
+
+		foreach ( $packages as $package ) {
+			foreach ( $package['rates'] as $rate ) {
+				if ( $method_id == $rate->get_method_id() ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
If a local pickup shipping method is shown to the customer in Florida, we should exempt shipping tax: https://blog.taxjar.com/shipping-in-florida-taxable/

This PR sets the shipping tax to $0 and turns off freight taxability so the tax rate saved doesn't affect shipping, which hopefully prevents the shipping tax from being added after processing the payment and saving the order.

**Versions Tested:**

- [x] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
- [ ] Woo 2.6.14
- [ ] Woo 2.6.2
- [ ] Woo 2.6.0