### PR TITLE
WooCommerce Subscription Sign-Up Fees & Totals

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -468,6 +468,13 @@ class WC_Taxjar_Integration extends WC_Integration {
 	public function calculate_totals( $wc_cart_object ) {
 		global $woocommerce;
 
+		// Skip calculations for WC Subscription recurring totals, tax rate already available
+		if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
+			if ( 'recurring_total' == WC_Subscriptions_Cart::get_calculation_type() ) {
+				return;
+			}
+		}
+
 		// Get all of the required customer params
 		$taxable_address = $woocommerce->customer->get_taxable_address(); // returns unassociated array
 		$taxable_address = is_array( $taxable_address ) ? $taxable_address : array();
@@ -522,13 +529,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 					'unit_price' => $unit_price,
 					'discount' => $discount,
 				));
-			}
-		}
-
-		// Skip calculations for WC Subscription recurring totals, tax rate already available
-		if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
-			if ( 'recurring_total' == WC_Subscriptions_Cart::get_calculation_type() ) {
-				return;
 			}
 		}
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -528,6 +528,8 @@ class WC_Taxjar_Integration extends WC_Integration {
 		) );
 
 		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
+			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
+			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
 			new WC_Cart_Totals( $wc_cart_object );
 		}
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -517,6 +517,9 @@ class WC_Taxjar_Integration extends WC_Integration {
 			// Get WC Subscription sign-up fees for calculations
 			if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
 				if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
+					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
+						WC_Subscriptions_Synchroniser::maybe_set_free_trial();
+					}
 					$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
 				}
 			}

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -507,6 +507,13 @@ class WC_Taxjar_Integration extends WC_Integration {
 				$tax_code = end( $tax_class );
 			}
 
+			// Get WC Subscription sign-up fees for calculations
+			if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
+				if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
+					$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
+				}
+			}
+
 			if ( $unit_price && $line_subtotal ) {
 				array_push($line_items, array(
 					'id' => $id,
@@ -515,6 +522,13 @@ class WC_Taxjar_Integration extends WC_Integration {
 					'unit_price' => $unit_price,
 					'discount' => $discount,
 				));
+			}
+		}
+
+		// Skip calculations for WC Subscription recurring totals, tax rate already available
+		if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
+			if ( 'recurring_total' == WC_Subscriptions_Cart::get_calculation_type() ) {
+				return;
 			}
 		}
 


### PR DESCRIPTION
This PR should accurately calculate sign-up fees with WooCommerce Subscriptions. To pass the sign-up fee amount to our API for tax calculations, we need to pull it directly using the `set_subscription_prices_for_calculation` method in `WC_Subscriptions_Cart`.

It should also fix related tax total issues by skipping calcs for the recurring totals cloned cart: https://wordpress.org/support/topic/woocommerce-subscriptions-tax-total-display-bug/

**Versions Tested:**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6.14
- [x] Woo 2.6.2
- [x] Woo 2.6.0