### PR TITLE
Fix Potential Logging Issue on Shared Hosting

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -220,7 +220,9 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 		}
 		if ( $this->debug ) {
-			$this->log = new WC_Logger();
+			if ( ! isset( $this->log ) ) {
+			    $this->log = new WC_Logger();
+			}
 			if ( is_array( $message ) || is_object( $message ) ) {
 				$this->log->add( 'taxjar', print_r( $message, true ) );
 			} else {


### PR DESCRIPTION
If a TaxJar user has "Debug Log" enabled in their configuration on a shared hosting plan, it's possible to receive "too many open files" server errors. Legacy code in our plugin was instantiating the WC_Logger for every `_log()` call which is bad. This PR ensures we only instantiate WC_Logger once if it isn't already set.

**Versions Tested:**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6.14
- [x] Woo 2.6.2
- [x] Woo 2.6.0