### PR TITLE
Rounding Fix for Line Item Rounding in WC 3.2

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -280,7 +280,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 		$this->tax_rate             = 0;
 		$this->amount_to_collect    = 0;
-		$this->item_collectable     = 0;
 		$this->shipping_collectable = 0;
 		$this->freight_taxable      = 1;
 		$this->line_items           = array();
@@ -355,8 +354,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 					$this->line_items = $line_items;
 				}
 			}
-
-			$this->item_collectable = $this->amount_to_collect - $this->shipping_collectable;
 		}
 
 		// Remove taxes if they are set somehow and customer is exempt
@@ -488,6 +485,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 		$to_city = isset( $taxable_address[3] ) && ! empty( $taxable_address[3] ) ? $taxable_address[3] : false;
 		$line_items = array();
 		$cart_taxes = array();
+		$cart_tax_total = 0;
 
 		foreach ( $wc_cart_object->coupons as $coupon ) {
 			if ( method_exists( $coupon, 'get_id' ) ) { // Woo 3.0+
@@ -559,10 +557,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 			} else {
 				$cart_taxes[ $this->rate_ids[ $line_item_key ] ] = $line_item->tax_collectable;
 			}
+
+			$cart_tax_total += $line_item->tax_collectable;
 		}
 
 		// Store the rate ID and the amount on the cart's totals
-		$wc_cart_object->tax_total = $this->item_collectable;
+		$wc_cart_object->tax_total = $cart_tax_total;
 		$wc_cart_object->shipping_tax_total = $this->shipping_collectable;
 		$wc_cart_object->taxes = $cart_taxes;
 


### PR DESCRIPTION
By default the TaxJar plugin disables "Round tax at subtotal level":

<img width="667" alt="screen shot 2017-12-08 at 3 12 15 pm" src="https://user-images.githubusercontent.com/1137184/33788958-3835508e-dc2a-11e7-8d1c-523a5a1e610a.png">

When we set the tax total in the cart, we should respect this setting and sum up the tax by line item instead. However, this change alone doesn't resolve rounding issues on the grand total. WC handles that calculation for us.

WC 3.2.5 wasn't properly rounding per line, so the spec attached to this PR won't pass. After [merging this PR](https://github.com/woocommerce/woocommerce/pull/18008), the spec passes and the rounding issue appears to be fully resolved. So once WC 3.2.6 or 3.3 is shipped we'll get this merged into the TaxJar plugin.

**Versions Tested:**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6