### PR TITLE
Zero Rate Tax Class Support

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -506,7 +506,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$tax_class = explode( '-', $product->get_tax_class() );
 			$tax_code = '';
 
-			if ( ! $product->is_taxable() || 'zero-rate' == $product->get_tax_class() ) {
+			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
 				$tax_code = '99999';
 			}
 
@@ -615,7 +615,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$unit_price = $product->get_price();
 			$tax_code = '';
 
-			if ( ! $product->is_taxable() || 'zero-rate' == $product->get_tax_class() ) {
+			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
 				$tax_code = '99999';
 			}
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -509,7 +509,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$tax_class = explode( '-', $product->get_tax_class() );
 			$tax_code = '';
 
-			if ( ! $product->is_taxable() ) {
+			if ( ! $product->is_taxable() || 'zero-rate' == $product->get_tax_class() ) {
 				$tax_code = '99999';
 			}
 
@@ -618,7 +618,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$unit_price = $product->get_price();
 			$tax_code = '';
 
-			if ( ! $product->is_taxable() ) {
+			if ( ! $product->is_taxable() || 'zero-rate' == $product->get_tax_class() ) {
 				$tax_code = '99999';
 			}
 

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -119,6 +119,19 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0, '', 0.001 );
 	}
 
+	function test_correct_taxes_for_zero_rate_exempt_products() {
+		$exempt_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'tax_class' => 'zero-rate',
+		) )->get_id();
+
+		$this->wc->cart->add_to_cart( $exempt_product );
+
+		do_action( $this->action, $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 0, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0, '', 0.001 );
+	}
+
 	function test_correct_taxes_for_product_exemptions() {
 		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
 			'store_country' => 'US',


### PR DESCRIPTION
Out of the box, WooCommerce has several default tax classes for VAT rates in the EU: Standard, reduced, and zero rates. As the name implies, the "Zero rate" tax class can be used for things such as VAT disability exemptions. Instead of requiring the user to rename this tax class to include the `99999` TaxJar exempt tax code, let's exempt it automatically.

This PR resolves issue #51.

**Versions Tested:**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6