### PR TITLE
UK / Greece ISO 3166-1 Code Exceptions

### DIFF
--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -71,9 +71,17 @@ class WC_Taxjar_Nexus {
 					return true;
 				}
 			} elseif ( isset( $nexus->country_code ) ) {
-					if ( $country == $nexus->country_code ) {
-						return true;
-					}
+				if ( $country == $nexus->country_code ) {
+					return true;
+				}
+
+				if ( 'GB' == $country && 'UK' == $nexus->country_code ) {
+					return true;
+				}
+
+				if ( 'GR' == $country && 'EL' == $nexus->country_code ) {
+					return true;
+				}
 			}
 		}
 

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -361,4 +361,54 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2, '', 0.001 );
 	}
 
+	function test_correct_taxes_for_uk_or_gb() {
+		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
+			'store_country' => 'UK',
+			'store_state' => '',
+			'store_zip' => 'SW1A 1AA',
+			'store_city' => 'London',
+		) );
+
+		// UK shipping address
+		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+			'country' => 'GB',
+			'state' => '',
+			'zip' => 'SW1A 1AA',
+			'city' => 'London',
+		) );
+
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		$this->wc->cart->add_to_cart( $product );
+
+		do_action( $this->action, $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 2, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2, '', 0.001 );
+	}
+
+	function test_correct_taxes_for_el_or_gr() {
+		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
+			'store_country' => 'EL',
+			'store_state' => '',
+			'store_zip' => '104 47',
+			'store_city' => 'Athens',
+		) );
+
+		// Greece shipping address
+		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+			'country' => 'GR',
+			'state' => '',
+			'zip' => '104 31',
+			'city' => 'Athens',
+		) );
+
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		$this->wc->cart->add_to_cart( $product );
+
+		do_action( $this->action, $this->wc->cart );
+
+		$this->assertEquals( $this->wc->cart->tax_total, 2.4, '', 0.001 );
+		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
+	}
+
 }


### PR DESCRIPTION
This PR ensures the TaxJar plugin calculates sales tax when a user has their business location set to UK or Greece. SmartCalcs returns `UK` instead of `GB` and `EL` instead of `GR`. [Exceptions found here](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Imperfect_implementations).

**Versions Tested:**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6