### PR TITLE
Remove Default Customer Address Setting Override

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -70,9 +70,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 			// Rate calculations assume tax not included
 			update_option( 'woocommerce_prices_include_tax', 'no' );
 
-			// Don't ever set a default customer address
-			update_option( 'woocommerce_default_customer_address', '' );
-
 			// Use no special handling on shipping taxes, our API handles that
 			update_option( 'woocommerce_shipping_tax_class', '' );
 


### PR DESCRIPTION
This PR removes TaxJar's override of the default customer address so merchants can set it to geolocate if needed. Resolves #34 