### PR TITLE
WooCommerce Subscription Free Trials

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -467,7 +467,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 		// Skip calculations for WC Subscription recurring totals, tax rate already available
 		if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
-			if ( 'recurring_total' == WC_Subscriptions_Cart::get_calculation_type() ) {
+			if ( 'recurring_total' == WC_Subscriptions_Cart::get_calculation_type() && ! WC_Subscriptions_Cart::all_cart_items_have_free_trial() ) {
 				return;
 			}
 		}
@@ -515,9 +515,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 			// Get WC Subscription sign-up fees for calculations
 			if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
 				if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
-					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
-						WC_Subscriptions_Synchroniser::maybe_set_free_trial();
-					}
 					$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
 				}
 			}
@@ -546,6 +543,15 @@ class WC_Taxjar_Integration extends WC_Integration {
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
 			new WC_Cart_Totals( $wc_cart_object );
+		}
+
+		if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
+			if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
+				WC_Subscriptions_Synchroniser::maybe_set_free_trial();
+			}
+			if ( WC_Subscriptions_Cart::all_cart_items_have_free_trial() ) {
+				return;
+			}
 		}
 
 		foreach ( $this->line_items as $line_item_key => $line_item ) {

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -529,6 +529,10 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 		}
 
+		if ( ! count( $line_items ) ) {
+			return;
+		}
+
 		$this->calculate_tax( array(
 			'to_city' => $to_city,
 			'to_state' => $to_state,

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -546,6 +546,10 @@ class WC_Taxjar_Integration extends WC_Integration {
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
 			new WC_Cart_Totals( $wc_cart_object );
+		} else {
+			remove_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			$wc_cart_object->calculate_totals();
+			add_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
 		}
 
 		if ( class_exists( 'WC_Subscriptions_Cart' ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,6 +41,12 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		require_once $this->tests_dir . '/framework/customer-helper.php';
 		require_once $this->tests_dir . '/framework/product-helper.php';
 		require_once $this->tests_dir . '/framework/shipping-helper.php';
+
+		// load woocommerce subscriptions
+		update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
+		update_option( 'woocommerce_db_version', WC_VERSION );
+		TaxJar_Woocommerce_Helper::prepare_woocommerce();
+		require_once $this->plugin_dir . 'woocommerce-subscriptions/woocommerce-subscriptions.php';
 	}
 
 	public function setup() {

--- a/tests/framework/product-helper.php
+++ b/tests/framework/product-helper.php
@@ -65,6 +65,11 @@ class TaxJar_Product_Helper {
 			'tax_status' => 'taxable',
 			'downloadable' => 'no',
 			'virtual' => 'yes',
+			'interval' => 1,
+			'period' => 'month',
+			'sign_up_fee' => 0,
+			'trial_length' => 1,
+			'trial_period' => 'month',
 		);
 
 		$post = array(
@@ -79,7 +84,7 @@ class TaxJar_Product_Helper {
 
 		register_taxonomy(
 			'product_type',
-			'product'
+			'subscription'
 		);
 
 		update_post_meta( $post_id, '_price', $post_meta['price'] );
@@ -93,15 +98,17 @@ class TaxJar_Product_Helper {
 		update_post_meta( $post_id, '_virtual', $post_meta['virtual'] );
 		update_post_meta( $post_id, '_stock_status', 'instock' );
 
+		// Subscription meta
+		update_post_meta( $post_id, '_subscription_price', $post_meta['price'] );
+		update_post_meta( $post_id, '_subscription_period_interval', $post_meta['interval'] );
+		update_post_meta( $post_id, '_subscription_period', $post_meta['period'] );
+		update_post_meta( $post_id, '_subscription_sign_up_fee', $post_meta['sign_up_fee'] );
+		update_post_meta( $post_id, '_subscription_trial_length', $post_meta['trial_length'] );
+		update_post_meta( $post_id, '_subscription_trial_period', $post_meta['trial_period'] );
+
 		wp_set_object_terms( $post_id, 'subscription', 'product_type' );
 
-		$products = get_posts( array(
-			'post_type' => 'product',
-			'_sku' => $post_meta['sku'],
-		) );
-
-		$factory = new WC_Product_Factory();
-		return $factory->get_product( $products[0]->ID );
+		return new WC_Product_Subscription( $post_id );
 	}
 
 }

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -559,4 +559,152 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->assertEquals( WC()->cart->get_taxes_total(), 2.4, '', 0.01 );
 	}
 
+	function test_correct_taxes_for_subscription_products_with_trial() {
+		$subscription_product = TaxJar_Product_Helper::create_product( 'subscription', array(
+			'price' => '19.99',
+			'sign_up_fee' => 0,
+			'trial_length' => 1,
+		) )->get_id();
+
+		WC()->cart->add_to_cart( $subscription_product );
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 0, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0, '', 0.01 );
+	}
+
+	function test_correct_taxes_for_subscription_products_with_trial_and_signup_fee() {
+		$subscription_product = TaxJar_Product_Helper::create_product( 'subscription', array(
+			'price' => '19.99',
+			'sign_up_fee' => 50,
+			'trial_length' => 1,
+		) )->get_id();
+
+		WC()->cart->add_to_cart( $subscription_product );
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 2, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 2, '', 0.01 );
+
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 50 + 2, '', 0.01 );
+		}
+
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
+			$product = $item['data'];
+			$sku = $product->get_sku();
+
+			if ( 'SUBSCRIPTION1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 2, '', 0.01 );
+			}
+		}
+
+		foreach ( WC()->cart->recurring_carts as $recurring_cart ) {
+			$this->assertEquals( $recurring_cart->tax_total, 0.8, '', 0.01 );
+			$this->assertEquals( $recurring_cart->get_taxes_total(), 0.8, '', 0.01 );
+		}
+	}
+
+	function test_correct_taxes_for_subscription_products_with_no_trial() {
+		$subscription_product = TaxJar_Product_Helper::create_product( 'subscription', array(
+			'price' => '19.99',
+			'sign_up_fee' => 0,
+			'trial_length' => 0,
+		) )->get_id();
+
+		WC()->cart->add_to_cart( $subscription_product );
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 0.8, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0.8, '', 0.01 );
+
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 19.99 + 0.8, '', 0.01 );
+		}
+
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
+			$product = $item['data'];
+			$sku = $product->get_sku();
+
+			if ( 'SUBSCRIPTION1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 0.8, '', 0.01 );
+			}
+		}
+
+		foreach ( WC()->cart->recurring_carts as $recurring_cart ) {
+			$this->assertEquals( $recurring_cart->tax_total, 0.8, '', 0.01 );
+			$this->assertEquals( $recurring_cart->get_taxes_total(), 0.8, '', 0.01 );
+		}
+	}
+
+	function test_correct_taxes_for_subscription_products_with_no_trial_and_signup_fee() {
+		$subscription_product = TaxJar_Product_Helper::create_product( 'subscription', array(
+			'price' => '19.99',
+			'sign_up_fee' => 50,
+			'trial_length' => 0,
+		) )->get_id();
+
+		WC()->cart->add_to_cart( $subscription_product );
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 2.8, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 2.8, '', 0.01 );
+
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 19.99 + 50 + 2.8, '', 0.01 );
+		}
+
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
+			$product = $item['data'];
+			$sku = $product->get_sku();
+
+			if ( 'SUBSCRIPTION1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 2.8, '', 0.01 );
+			}
+		}
+
+		foreach ( WC()->cart->recurring_carts as $recurring_cart ) {
+			$this->assertEquals( $recurring_cart->tax_total, 0.8, '', 0.01 );
+			$this->assertEquals( $recurring_cart->get_taxes_total(), 0.8, '', 0.01 );
+		}
+	}
+
+	function test_correct_taxes_for_subscription_products_with_other_products() {
+		$subscription_product = TaxJar_Product_Helper::create_product( 'subscription', array(
+			'price' => '19.99',
+			'sign_up_fee' => 0,
+			'trial_length' => 0,
+		) )->get_id();
+
+		$extra_product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+
+		WC()->cart->add_to_cart( $subscription_product );
+		WC()->cart->add_to_cart( $extra_product );
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 1.2, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 1.2, '', 0.01 );
+
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 19.99 + 10 + 1.2, '', 0.01 );
+		}
+
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
+			$product = $item['data'];
+			$sku = $product->get_sku();
+
+			if ( 'SUBSCRIPTION1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 0.8, '', 0.01 );
+			}
+
+			if ( 'SIMPLE1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 0.4, '', 0.01 );
+			}
+		}
+
+		foreach ( WC()->cart->recurring_carts as $recurring_cart ) {
+			$this->assertEquals( $recurring_cart->tax_total, 0.8, '', 0.01 );
+			$this->assertEquals( $recurring_cart->get_taxes_total(), 0.8, '', 0.01 );
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes recurring tax for 2.6.x and 3.0.x carts where all items have a free trial. It also ensures upfront tax remains $0 if all items have a free trial.

Also fixes upfront tax for sign-up fees with a free trial in 3.2+.

**Versions Tested:**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6.14
- [x] Woo 2.6.2
- [x] Woo 2.6.0