### PR TITLE
Fix Backend Error for Deleted Products

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -612,6 +612,11 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 
 			$product = wc_get_product( $id );
+
+			if ( ! $product ) {
+				continue;
+			}
+
 			$unit_price = $product->get_price();
 			$tax_code = '';
 


### PR DESCRIPTION
This PR fixes backend operations such as recalculating and saving orders when an order contains deleted products:

```
PHP Fatal error:  Uncaught Error: Call to a member function get_price() on boolean
```