### PR TITLE
Moved the total price calulation until after the taxes are added

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -542,12 +542,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'line_items' => $line_items,
 		) );
 
-		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
-			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
-			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
-			new WC_Cart_Totals( $wc_cart_object );
-		}
-
 		foreach ( $this->line_items as $line_item_key => $line_item ) {
 			if ( isset( $cart_taxes[ $this->rate_ids[ $line_item_key ] ] ) ) {
 				$cart_taxes[ $this->rate_ids[ $line_item_key ] ] += $line_item->tax_collectable;
@@ -576,6 +570,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 			if ( isset( $this->line_items[ $line_item_key ] ) ) {
 				$wc_cart_object->cart_contents[ $cart_item_key ]['line_tax'] = $this->line_items[ $line_item_key ]->tax_collectable;
 			}
+		}
+
+		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
+			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
+			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
+			new WC_Cart_Totals( $wc_cart_object );
 		}
 	}
 


### PR DESCRIPTION
Fixes #58 

By moving `new WC_Cart_Totals( $wc_cart_object );` until after the taxes are set on `$wc_cart_object` it takes the taxes into account when recalculating the totals (`WC_Cart_Totals` resets the `shipping_tax_total` in the calculation process if the method is not taxable)

If the selected shipping method is set as not taxable, the tax will not be added and the totals will be correct:
<img width="369" alt="screen shot 2018-02-15 at 20 17 36" src="https://user-images.githubusercontent.com/800604/36278935-4eb6fa44-128d-11e8-9825-aff811aabf39.png">
