### PR TITLE
Allows developers to override specific store setting values during runtime.

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -826,7 +826,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 		if ( isset( $default_wc_settings[1] ) ) {
 			$store_settings['store_state_setting'] = $default_wc_settings[1];
 		}
-		return $store_settings;
+		return apply_filters( 'taxjar_store_settings', $store_settings, $this->settings );
 	}
 
 	/**


### PR DESCRIPTION
In the current version of the TaxJar plugin (1.5.4 at the time of this note), the state and country values that TaxJar uses to calculate sales taxes are automatically pulled from the WooCommerce store address settings, and there is no way to change them.

In certain situations, a store owner's store address (as configured in the WooCommerce settings) is different than the address that needs to be used for TaxJar's calculations, leaving the store owner no choice but to change their store address in WooCommerce to get the TaxJar calculations to work.

This pull request adds a WordPress filter hook to the WC_Taxjar_Integration:get_store_settings() method return value, allowing the store owner to write a simple function that can override the store address settings without having to change their store address in the WooCommerce settings.

For example:

```php
add_filter( 'taxjar_store_settings', function ( $store_settings, $woocommerce_settings ) {
    // Override default state address
    $store_settings['store_state_setting'] = 'CO';
    return $store_settings;
}, 10, 2 );
```