### PR TITLE
Nexus API Overages

### DIFF
--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Taxjar_Nexus {
 
+	const INVALID_OR_EXPIRED_API_TOKEN = 'Unauthorized';
+
 	public function __construct( $integration ) {
 		$this->integration = $integration;
 		$this->nexus = $this->get_or_update_cached_nexus();
@@ -91,6 +93,10 @@ class WC_Taxjar_Nexus {
 	public function get_or_update_cached_nexus( $force_update = false ) {
 		$nexus_list = $this->get_nexus_from_cache();
 
+		if ( ! $force_update && self::INVALID_OR_EXPIRED_API_TOKEN == $nexus_list ) {
+			return array();
+		}
+
 		if ( $force_update || false === $nexus_list || null === $nexus_list || ( is_array( $nexus_list ) && count( $nexus_list ) == 0 ) ) {
 			delete_transient( 'tlc__' . md5( 'get_nexus_from_cache' ) );
 			$nexus_list = $this->get_nexus_from_cache();
@@ -114,6 +120,10 @@ class WC_Taxjar_Nexus {
 			$this->integration->_log( ':::: Nexus addresses updated ::::' );
 			$body = json_decode( $response['body'] );
 			return $body->regions;
+		}
+
+		if ( $response['response']['code'] >= 400 ) {
+			return self::INVALID_OR_EXPIRED_API_TOKEN;
 		}
 
 		return array();

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Taxjar_Nexus {
 
-	const INVALID_OR_EXPIRED_API_TOKEN = 'Unauthorized';
+	const INVALID_OR_EXPIRED_API_TOKEN = array( 'Unauthorized' );
 
 	public function __construct( $integration ) {
 		$this->integration = $integration;

--- a/tests/specs/test-class-taxjar-nexus.php
+++ b/tests/specs/test-class-taxjar-nexus.php
@@ -48,6 +48,7 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 		delete_transient( $this->cache_key );
 		$nexus_list = $this->tj_nexus->get_or_update_cached_nexus();
 		$this->assertTrue( count( $nexus_list ) > 0 );
+		$this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'CO' ) );
 	}
 
 	function test_or_get_update_cached_nexus_unauthorized() {
@@ -55,6 +56,7 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 		$this->tj->settings['api_token'] = 'INVALID_OR_EXPIRED_API_TOKEN';
 		$nexus_list = $this->tj_nexus->get_or_update_cached_nexus();
 		$this->assertTrue( count( $nexus_list ) == 0 );
+		$this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'CO' ) );
 	}
 
 	function test_or_get_update_cached_nexus_stays_cached_on_unauthorized() {
@@ -63,6 +65,7 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 		$nexus_list = $this->tj_nexus->get_or_update_cached_nexus();
 		$transient = get_transient( $this->cache_key );
 		$this->assertTrue( count( $nexus_list ) == 0 );
+		$this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'CO' ) );
 
 		// Ensure nexus response is cached on 401 / 403 errors
 		// Requires manually syncing nexus addresses from admin to resolve
@@ -70,6 +73,7 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 			$nexus_list = $this->tj_nexus->get_or_update_cached_nexus();
 			$this->assertEquals( $transient[0], time() + 0.5 * DAY_IN_SECONDS );
 			$this->assertTrue( count( get_transient( $this->cache_key ) ) > 0 );
+			$this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'CO' ) );
 		}
 	}
 
@@ -79,9 +83,11 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 		$this->tj->settings['api_token'] = 'INVALID_OR_EXPIRED_API_TOKEN';
 		$nexus_list = $this->tj_nexus->get_or_update_cached_nexus();
 		$this->assertTrue( count( $nexus_list ) == 0 );
+		$this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'CO' ) );
 		$this->tj->settings['api_token'] = $original_api_token;
 		$nexus_list = $this->tj_nexus->get_or_update_cached_nexus( true );
 		$this->assertTrue( count( $nexus_list ) > 0 );
+		$this->assertTrue( $this->tj_nexus->has_nexus_check( 'US', 'CO' ) );
 	}
 
 	function test_has_nexus_check_uses_base_address() {


### PR DESCRIPTION
If a merchant's TaxJar API token becomes invalid or expired, excessive API calls were being made to `/v2/nexus/regions` to sync nexus addresses for each checkout calculation. This PR should fix the problem. For subsequent calculations, the nexus check will be skipped and the calculation request will still go through but it will return back an error.

Once we re-activate the API token in TaxJar, the merchant can manually refresh their nexus addresses from the TaxJar configuration screen inside WP admin.

**Specs passing in 2.6, 3.0, 3.1, 3.2, 3.3 🎉**