### PR TITLE
Spec Improvements

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,6 +40,7 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		require_once $this->tests_dir . '/framework/coupon-helper.php';
 		require_once $this->tests_dir . '/framework/customer-helper.php';
 		require_once $this->tests_dir . '/framework/product-helper.php';
+		require_once $this->tests_dir . '/framework/shipping-helper.php';
 	}
 
 	public function setup() {

--- a/tests/framework/product-helper.php
+++ b/tests/framework/product-helper.php
@@ -103,4 +103,5 @@ class TaxJar_Product_Helper {
 		$factory = new WC_Product_Factory();
 		return $factory->get_product( $products[0]->ID );
 	}
+
 }

--- a/tests/framework/shipping-helper.php
+++ b/tests/framework/shipping-helper.php
@@ -10,6 +10,7 @@ class TaxJar_Shipping_Helper {
 			'tax_status'   => 'taxable',
 			'cost'         => $cost,
 		);
+
 		update_option( 'woocommerce_flat_rate_settings', $flat_rate_settings );
 		update_option( 'woocommerce_flat_rate', array() );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );

--- a/tests/framework/shipping-helper.php
+++ b/tests/framework/shipping-helper.php
@@ -1,0 +1,26 @@
+<?php
+class TaxJar_Shipping_Helper {
+
+	public static function create_simple_flat_rate( $cost = 10 ) {
+		$flat_rate_settings = array(
+			'enabled'      => 'yes',
+			'title'        => 'Flat rate',
+			'availability' => 'all',
+			'countries'    => '',
+			'tax_status'   => 'taxable',
+			'cost'         => $cost,
+		);
+		update_option( 'woocommerce_flat_rate_settings', $flat_rate_settings );
+		update_option( 'woocommerce_flat_rate', array() );
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+		WC()->shipping->load_shipping_methods();
+	}
+
+	public static function delete_simple_flat_rate() {
+		delete_option( 'woocommerce_flat_rate_settings' );
+		delete_option( 'woocommerce_flat_rate' );
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+		WC()->shipping->unregister_shipping_methods();
+	}
+
+}

--- a/tests/framework/woocommerce-helper.php
+++ b/tests/framework/woocommerce-helper.php
@@ -10,6 +10,7 @@ class TaxJar_Woocommerce_Helper {
 		$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
 		$woocommerce->session  = new $session_class();
 		$woocommerce->cart = new WC_Cart();
+		$woocommerce->countries = new WC_Countries();
 
 		// Start with an empty cart
 		$woocommerce->cart->empty_cart();

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -5,7 +5,6 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		global $woocommerce;
 		TaxJar_Woocommerce_Helper::prepare_woocommerce();
 		$this->tj = new WC_Taxjar_Integration();
-		$this->wc = $woocommerce;
 
 		// Reset shipping origin
 		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
@@ -20,6 +19,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		} else {
 			$this->action = 'woocommerce_calculate_totals';
 		}
+
+		// We need this to have the calculate_totals() method calculate totals
+		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
+			define( 'WOOCOMMERCE_CHECKOUT', true );
+		}
 	}
 
 	function tearDown() {
@@ -28,38 +32,70 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		remove_action( 'woocommerce_before_save_order_items', array( $this->tj, 'calculate_backend_totals' ), 20 );
 
 		// Empty the cart
-		$this->wc->cart->empty_cart();
+		WC()->cart->empty_cart();
 	}
 
 	function test_taxjar_calculate_totals() {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
-		$this->wc->cart->add_to_cart( $product );
-		do_action( $this->action, $this->wc->cart );
-		$this->assertTrue( $this->wc->cart->get_taxes_total() != 0 );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->calculate_totals();
+		$this->assertTrue( WC()->cart->get_taxes_total() != 0 );
 	}
 
 	function test_correct_taxes_with_shipping() {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 
-		$this->wc->shipping->shipping_total = 5;
-		$this->wc->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product );
 
-		do_action( $this->action, $this->wc->cart );
+		TaxJar_Shipping_Helper::create_simple_flat_rate( 5 );
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
 
-		$this->assertEquals( $this->wc->cart->tax_total, 0.4, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->shipping_tax_total, 0.2, '', 0.001 );
+		WC()->cart->calculate_totals();
 
-		if ( method_exists( $this->wc->cart, 'get_shipping_taxes' ) ) {
-			$this->assertEquals( array_values( $this->wc->cart->get_shipping_taxes() )[0], 0.2, '', 0.001 );
+		$this->assertEquals( WC()->cart->tax_total, 0.4, '', 0.01 );
+		$this->assertEquals( WC()->cart->shipping_tax_total, 0.2, '', 0.01 );
+
+		if ( method_exists( WC()->cart, 'get_shipping_taxes' ) ) {
+			$this->assertEquals( array_values( WC()->cart->get_shipping_taxes() )[0], 0.2, '', 0.01 );
 		} else {
-			$this->assertEquals( array_values( $this->wc->cart->shipping_taxes )[0], 0.2, '', 0.001 );
+			$this->assertEquals( array_values( WC()->cart->shipping_taxes )[0], 0.2, '', 0.01 );
 		}
 
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.6, '', 0.001 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0.6, '', 0.01 );
 
-		foreach ( $this->wc->cart->get_cart() as $cart_item_key => $item ) {
-			$this->assertEquals( $item['line_tax'], 0.4, '', 0.001 );
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
+			$this->assertEquals( $item['line_tax'], 0.4, '', 0.01 );
 		}
+
+		TaxJar_Shipping_Helper::delete_simple_flat_rate();
+	}
+
+	function test_correct_taxes_with_exempt_shipping() {
+		// CA shipping address
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
+			'state' => 'CA',
+			'zip' => '90404',
+			'city' => 'Santa Monica',
+		) );
+
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+
+		WC()->cart->add_to_cart( $product );
+
+		TaxJar_Shipping_Helper::create_simple_flat_rate( 5 );
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
+
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 1.03, '', 0.01 );
+		$this->assertEquals( WC()->cart->shipping_tax_total, 0, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 1.03, '', 0.01 );
+
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
+			$this->assertEquals( $item['line_tax'], 1.03, '', 0.01 );
+		}
+
+		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
 	function test_correct_taxes_for_multiple_products() {
@@ -69,29 +105,28 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			'sku' => 'SIMPLE2',
 		) )->get_id();
 
-		$this->wc->cart->add_to_cart( $product );
-		$this->wc->cart->add_to_cart( $extra_product, 2 );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $extra_product, 2 );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
+		$this->assertEquals( WC()->cart->tax_total, 2.4, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 2.4, '', 0.01 );
 
-		$this->assertEquals( $this->wc->cart->tax_total, 2.4, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
-
-		foreach ( $this->wc->cart->get_cart() as $cart_item_key => $item ) {
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
 			$product = $item['data'];
 			$sku = $product->get_sku();
 
 			if ( 'SIMPLE2' == $sku ) {
-				$this->assertEquals( $item['line_tax'], 2, '', 0.001 );
+				$this->assertEquals( $item['line_tax'], 2, '', 0.01 );
 			}
 
 			if ( 'SIMPLE1' == $sku ) {
-				$this->assertEquals( $item['line_tax'], 0.4, '', 0.001 );
+				$this->assertEquals( $item['line_tax'], 0.4, '', 0.01 );
 			}
 		}
 
-		if ( version_compare( $this->wc->version, '3.2', '>=' ) ) {
-			$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 62.4, '', 0.001 );
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 62.4, '', 0.01 );
 		}
 	}
 
@@ -104,34 +139,33 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			'sku' => 'SIMPLE2',
 		) )->get_id();
 
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'state' => 'CA',
 			'zip' => '93013',
 			'city' => 'Carpinteria',
 		) );
 
-		$this->wc->cart->add_to_cart( $product );
-		$this->wc->cart->add_to_cart( $extra_product, 2 );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $extra_product, 2 );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
+		$this->assertEquals( WC()->cart->tax_total, 72.47, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 72.47, '', 0.01 );
 
-		$this->assertEquals( $this->wc->cart->tax_total, 72.47, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 72.47, '', 0.001 );
-
-		if ( version_compare( $this->wc->version, '3.2', '>=' ) ) {
-			$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 1007.47, '', 0.001 );
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 1007.47, '', 0.01 );
 		}
 
-		foreach ( $this->wc->cart->get_cart() as $cart_item_key => $item ) {
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
 			$product = $item['data'];
 			$sku = $product->get_sku();
 
 			if ( 'SIMPLE1' == $sku ) {
-				$this->assertEquals( $item['line_tax'], 37.59, '', 0.001 );
+				$this->assertEquals( $item['line_tax'], 37.59, '', 0.01 );
 			}
 
 			if ( 'SIMPLE2' == $sku ) {
-				$this->assertEquals( $item['line_tax'], 34.88, '', 0.001 );
+				$this->assertEquals( $item['line_tax'], 34.88, '', 0.01 );
 			}
 		}
 	}
@@ -139,16 +173,15 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 	function test_correct_taxes_for_duplicate_line_items() {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 
-		$this->wc->cart->add_to_cart( $product );
-		$this->wc->cart->add_to_cart( $product, 1, 0, [], [ 'duplicate' => true ] );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product, 1, 0, [], [ 'duplicate' => true ] );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
+		$this->assertEquals( WC()->cart->tax_total, 0.8, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0.8, '', 0.01 );
 
-		$this->assertEquals( $this->wc->cart->tax_total, 0.8, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.8, '', 0.001 );
-
-		if ( version_compare( $this->wc->version, '3.2', '>=' ) ) {
-			$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 20.8, '', 0.001 );
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 20.8, '', 0.01 );
 		}
 	}
 
@@ -157,12 +190,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			'tax_status' => 'none',
 		) )->get_id();
 
-		$this->wc->cart->add_to_cart( $exempt_product );
+		WC()->cart->add_to_cart( $exempt_product );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
-
-		$this->assertEquals( $this->wc->cart->tax_total, 0, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0, '', 0.001 );
+		$this->assertEquals( WC()->cart->tax_total, 0, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0, '', 0.01 );
 	}
 
 	function test_correct_taxes_for_zero_rate_exempt_products() {
@@ -170,12 +202,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			'tax_class' => 'zero-rate',
 		) )->get_id();
 
-		$this->wc->cart->add_to_cart( $exempt_product );
+		WC()->cart->add_to_cart( $exempt_product );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
-
-		$this->assertEquals( $this->wc->cart->tax_total, 0, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0, '', 0.001 );
+		$this->assertEquals( WC()->cart->tax_total, 0, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0, '', 0.01 );
 	}
 
 	function test_correct_taxes_for_product_exemptions() {
@@ -187,7 +218,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		// NY shipping address
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'state' => 'NY',
 			'zip' => '10001',
 			'city' => 'New York City',
@@ -200,29 +231,28 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			'tax_class' => 'clothing-rate-20010',
 		) )->get_id();
 
-		$this->wc->cart->add_to_cart( $taxable_product );
-		$this->wc->cart->add_to_cart( $exempt_product, 2 );
+		WC()->cart->add_to_cart( $taxable_product );
+		WC()->cart->add_to_cart( $exempt_product, 2 );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
+		$this->assertEquals( WC()->cart->tax_total, 0.89, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0.89, '', 0.01 );
 
-		$this->assertEquals( $this->wc->cart->tax_total, 0.89, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.89, '', 0.001 );
-
-		foreach ( $this->wc->cart->get_cart() as $cart_item_key => $item ) {
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
 			$product = $item['data'];
 			$sku = $product->get_sku();
 
 			if ( 'EXEMPT1' == $sku ) {
-				$this->assertEquals( $item['line_tax'], 0, '', 0.001 );
+				$this->assertEquals( $item['line_tax'], 0, '', 0.01 );
 			}
 
 			if ( 'SIMPLE1' == $sku ) {
-				$this->assertEquals( $item['line_tax'], 0.89, '', 0.001 );
+				$this->assertEquals( $item['line_tax'], 0.89, '', 0.01 );
 			}
 		}
 
-		if ( version_compare( $this->wc->version, '3.2', '>=' ) ) {
-			$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 60.89, '', 0.001 );
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 60.89, '', 0.01 );
 		}
 	}
 
@@ -235,7 +265,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		// NY shipping address
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'state' => 'NY',
 			'zip' => '10001',
 			'city' => 'New York City',
@@ -252,24 +282,70 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			'tax_class' => 'clothing-rate-20010',
 		) )->get_id();
 
-		$this->wc->cart->add_to_cart( $taxable_product );
-		$this->wc->cart->add_to_cart( $exempt_product, 2 );
+		WC()->cart->add_to_cart( $taxable_product );
+		WC()->cart->add_to_cart( $exempt_product, 2 );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
+		$this->assertEquals( WC()->cart->tax_total, 13.31, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 13.31, '', 0.01 );
 
-		$this->assertEquals( $this->wc->cart->tax_total, 13.31, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 13.31, '', 0.001 );
-
-		foreach ( $this->wc->cart->get_cart() as $item_key => $item ) {
+		foreach ( WC()->cart->get_cart() as $item_key => $item ) {
 			$product = $item['data'];
 			$sku = $product->get_sku();
 
 			if ( 'EXEMPT1' == $sku ) {
-				$this->assertEquals( $item['line_tax'], 0, '', 0.001 );
+				$this->assertEquals( $item['line_tax'], 0, '', 0.01 );
 			}
 
 			if ( 'EXEMPTOVER1' == $sku ) {
-				$this->assertEquals( $item['line_tax'], 13.31, '', 0.001 );
+				$this->assertEquals( $item['line_tax'], 13.31, '', 0.01 );
+			}
+		}
+	}
+
+	function test_correct_taxes_for_product_exemption_threshold_reduced_rates() {
+		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
+			'store_country' => 'US',
+			'store_state' => 'NY',
+			'store_zip' => '10118',
+			'store_city' => 'New York City',
+		) );
+
+		// NY shipping address
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
+			'state' => 'NY',
+			'zip' => '10541',
+			'city' => 'Mahopac',
+		) );
+
+		$taxable_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'price' => '150', // Over $110 threshold
+			'sku' => 'EXEMPTOVER1',
+			'tax_class' => 'clothing-rate-20010',
+		) )->get_id();
+		$reduced_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'price' => '25',
+			'sku' => 'REDUCED1',
+			'tax_class' => 'clothing-rate-20010',
+		) )->get_id();
+
+		WC()->cart->add_to_cart( $taxable_product );
+		WC()->cart->add_to_cart( $reduced_product, 2 );
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 14.75, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 14.75, '', 0.01 );
+
+		foreach ( WC()->cart->get_cart() as $item_key => $item ) {
+			$product = $item['data'];
+			$sku = $product->get_sku();
+
+			if ( 'REDUCED1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 2.19, '', 0.01 );
+			}
+
+			if ( 'EXEMPTOVER1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 12.56, '', 0.01 );
 			}
 		}
 	}
@@ -285,23 +361,22 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			'discount_type' => 'fixed_cart',
 		) );
 
-		if ( version_compare( $this->wc->version, '3.0', '>=' ) ) {
+		if ( version_compare( WC()->version, '3.0', '>=' ) ) {
 			$coupon = $coupon->get_code();
 		} else {
 			$coupon = $coupon->code;
 		}
 
-		$this->wc->cart->add_to_cart( $product );
-		$this->wc->cart->add_to_cart( $product2, 2 );
-		$this->wc->cart->add_discount( $coupon );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product2, 2 );
+		WC()->cart->add_discount( $coupon );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
+		$this->assertEquals( WC()->cart->tax_total, 2.4, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 2.4, '', 0.01 );
 
-		$this->assertEquals( $this->wc->cart->tax_total, 2.4, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
-
-		if ( version_compare( $this->wc->version, '3.2', '>=' ) ) {
-			$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 62.4, '', 0.001 );
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 62.4, '', 0.01 );
 		}
 	}
 
@@ -314,22 +389,21 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		// TX shipping address
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'state' => 'TX',
 			'zip' => '73301',
 			'city' => 'Austin',
 		) );
 
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
-		$this->wc->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
+		$this->assertEquals( WC()->cart->tax_total, 0.83, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0.83, '', 0.01 );
 
-		$this->assertEquals( $this->wc->cart->tax_total, 0.83, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.83, '', 0.001 );
-
-		if ( version_compare( $this->wc->version, '3.2', '>=' ) ) {
-			$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 10.83, '', 0.001 );
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 10.83, '', 0.01 );
 		}
 	}
 
@@ -343,22 +417,21 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 		// TX shipping address
 		// Make sure your test account has nexus in TX
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'state' => 'TX',
 			'zip' => '73301',
 			'city' => 'Austin',
 		) );
 
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
-		$this->wc->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
+		$this->assertEquals( WC()->cart->tax_total, 0.83, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0.83, '', 0.01 );
 
-		$this->assertEquals( $this->wc->cart->tax_total, 0.83, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 0.83, '', 0.001 );
-
-		if ( version_compare( $this->wc->version, '3.2', '>=' ) ) {
-			$this->assertEquals( $this->wc->cart->get_total( 'amount' ), 10.83, '', 0.001 );
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 10.83, '', 0.01 );
 		}
 	}
 
@@ -371,7 +444,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		// CA shipping address
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'country' => 'CA',
 			'state' => 'ON',
 			'zip' => 'M5V 2T6',
@@ -379,12 +452,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
-		$this->wc->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
-
-		$this->assertEquals( $this->wc->cart->tax_total, 1.3, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 1.3, '', 0.001 );
+		$this->assertEquals( WC()->cart->tax_total, 1.3, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 1.3, '', 0.01 );
 	}
 
 	function test_correct_taxes_for_au() {
@@ -396,7 +468,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		// AU shipping address
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'country' => 'AU',
 			'state' => 'VIC',
 			'zip' => 'VIC 3002',
@@ -404,12 +476,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
-		$this->wc->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
-
-		$this->assertEquals( $this->wc->cart->tax_total, 1, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 1, '', 0.001 );
+		$this->assertEquals( WC()->cart->tax_total, 1, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 1, '', 0.01 );
 	}
 
 	function test_correct_taxes_for_eu() {
@@ -421,7 +492,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		// EU shipping address
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'country' => 'FR',
 			'state' => '',
 			'zip' => '13281',
@@ -429,12 +500,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
-		$this->wc->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
-
-		$this->assertEquals( $this->wc->cart->tax_total, 2, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2, '', 0.001 );
+		$this->assertEquals( WC()->cart->tax_total, 2, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 2, '', 0.01 );
 	}
 
 	function test_correct_taxes_for_uk_or_gb() {
@@ -446,7 +516,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		// UK shipping address
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'country' => 'GB',
 			'state' => '',
 			'zip' => 'SW1A 1AA',
@@ -454,12 +524,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
-		$this->wc->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
-
-		$this->assertEquals( $this->wc->cart->tax_total, 2, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2, '', 0.001 );
+		$this->assertEquals( WC()->cart->tax_total, 2, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 2, '', 0.01 );
 	}
 
 	function test_correct_taxes_for_el_or_gr() {
@@ -471,7 +540,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		// Greece shipping address
-		$this->wc->customer = TaxJar_Customer_Helper::create_customer( array(
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'country' => 'GR',
 			'state' => '',
 			'zip' => '104 31',
@@ -479,12 +548,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
-		$this->wc->cart->add_to_cart( $product );
+		WC()->cart->add_to_cart( $product );
+		WC()->cart->calculate_totals();
 
-		do_action( $this->action, $this->wc->cart );
-
-		$this->assertEquals( $this->wc->cart->tax_total, 2.4, '', 0.001 );
-		$this->assertEquals( $this->wc->cart->get_taxes_total(), 2.4, '', 0.001 );
+		$this->assertEquals( WC()->cart->tax_total, 2.4, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 2.4, '', 0.01 );
 	}
 
 }

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -49,6 +49,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 		TaxJar_Shipping_Helper::create_simple_flat_rate( 5 );
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
+		WC()->shipping->shipping_total = 5;
 
 		WC()->cart->calculate_totals();
 
@@ -67,6 +68,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			$this->assertEquals( $item['line_tax'], 0.4, '', 0.01 );
 		}
 
+		WC()->session->set( 'chosen_shipping_methods', array() );
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
@@ -84,6 +86,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 		TaxJar_Shipping_Helper::create_simple_flat_rate( 5 );
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
+		WC()->shipping->shipping_total = 5;
 
 		WC()->cart->calculate_totals();
 
@@ -95,6 +98,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			$this->assertEquals( $item['line_tax'], 1.03, '', 0.01 );
 		}
 
+		WC()->session->set( 'chosen_shipping_methods', array() );
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 


### PR DESCRIPTION
General improvements to specs from #61:

- New specs around exempt shipping and product exemption thresholds
- Use `WC()` function similar to Woo's native specs
- Drop `do_action` for `WC()->cart->calculate_totals()`
- Shipping helper class
- Tweak assert precision