### PR TITLE
WooCommerce Subscriptions Refactor

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -627,6 +627,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'shipping_amount' => $woocommerce->shipping->shipping_total,
 			'line_items' => $line_items,
 		) );
+
+		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
+			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
+			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
+			new WC_Cart_Totals( $wc_cart_object );
+		}
 	}
 
 	/**

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -371,24 +371,24 @@ class WC_Taxjar_Integration extends WC_Integration {
 				$tax_class = $product->get_tax_class();
 
 				if ( $line_item->combined_tax_rate ) {
-					$rate_id = $this->create_or_update_tax_rate(
+					$taxes['rate_ids'][ $line_item_key ] = $this->create_or_update_tax_rate(
 						$location,
 						$line_item->combined_tax_rate * 100,
 						$tax_class,
 						$taxes['freight_taxable']
 					);
-					$taxes['rate_ids'][ $line_item_key ] = $rate_id;
 				}
 			}
 
 			// Add shipping tax rate
-			$shipping_rate_id = $this->create_or_update_tax_rate(
-				$location,
-				$taxes['tax_rate'] * 100,
-				'',
-				$taxes['freight_taxable']
-			);
-			$taxes['rate_ids']['shipping'] = $shipping_rate_id;
+			if ( $taxes['tax_rate'] ) {
+				$taxes['rate_ids']['shipping'] = $this->create_or_update_tax_rate(
+					$location,
+					$taxes['tax_rate'] * 100,
+					'',
+					$taxes['freight_taxable']
+				);
+			}
 		} // End if().
 
 		return $taxes;

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -522,6 +522,11 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 		}
 
+		// Recalculate shipping package rates
+		foreach ( $wc_cart_object->get_shipping_packages() as $package_key => $package ) {
+			$woocommerce->session->set( 'shipping_for_package_' . $package_key, null );
+		}
+
 		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -499,6 +499,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 		}
 
 		$address = $this->get_address( $wc_cart_object );
+		$line_items = $this->get_line_items( $wc_cart_object );
 
 		$taxes = $this->calculate_tax( array(
 			'to_city' => $address['to_city'],
@@ -506,7 +507,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'to_country' => $address['to_country'],
 			'to_zip' => $address['to_zip'],
 			'shipping_amount' => $woocommerce->shipping->shipping_total,
-			'line_items' => $this->get_line_items( $wc_cart_object ),
+			'line_items' => $line_items,
 		) );
 
 		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
@@ -554,6 +555,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 	public function calculate_backend_totals( $order_id ) {
 		$order = wc_get_order( $order_id );
 		$address = $this->get_backend_address();
+		$line_items = $this->get_backend_line_items( $order );
 
 		if ( method_exists( $order, 'get_shipping_total' ) ) {
 			$shipping = $order->get_shipping_total(); // Woo 3.0+
@@ -567,7 +569,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'to_country' => $address['to_country'],
 			'to_zip' => $address['to_zip'],
 			'shipping_amount' => $shipping,
-			'line_items' => $this->get_backend_line_items( $order ),
+			'line_items' => $line_items,
 		) );
 
 		// Add tax rates manually for Woo 3.0+
@@ -611,6 +613,11 @@ class WC_Taxjar_Integration extends WC_Integration {
 		}
 
 		$address = $this->get_address( $wc_cart_object );
+		$line_items = $this->get_line_items( $wc_cart_object );
+
+		if ( ! count( $line_items ) ) {
+			return;
+		}
 
 		$taxes = $this->calculate_tax( array(
 			'to_city' => $address['to_city'],
@@ -618,7 +625,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'to_country' => $address['to_country'],
 			'to_zip' => $address['to_zip'],
 			'shipping_amount' => $woocommerce->shipping->shipping_total,
-			'line_items' => $this->get_line_items( $wc_cart_object ),
+			'line_items' => $line_items,
 		) );
 	}
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -385,6 +385,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$shipping_rate_id = $this->create_or_update_tax_rate(
 				$location,
 				$taxes['tax_rate'] * 100,
+				'',
 				$taxes['freight_taxable']
 			);
 			$taxes['rate_ids']['shipping'] = $shipping_rate_id;

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -434,6 +434,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 		} else {
 			// Insert a rate if we did not find one
 			$this->_log( ':: Adding New Tax Rate ::' );
+			$this->_log( $tax_rate );
 			$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 			WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_clean( $location['to_zip'] ) );
 			WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -632,6 +632,10 @@ class WC_Taxjar_Integration extends WC_Integration {
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
 			new WC_Cart_Totals( $wc_cart_object );
+		} else {
+			remove_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			$wc_cart_object->calculate_totals();
+			add_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
 		}
 	}
 

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -821,6 +821,63 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		}
 	}
 
+	function test_correct_taxes_for_subscription_products_with_other_products_and_trial_and_shipping() {
+		// NJ shipping address
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
+			'state' => 'NJ',
+			'zip' => '07001',
+			'city' => 'Avenel',
+		) );
+
+		$subscription_product = TaxJar_Product_Helper::create_product( 'subscription', array(
+			'price' => '10',
+			'sign_up_fee' => 100,
+			'trial_length' => 1,
+		) )->get_id();
+		$taxable_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'price' => '200',
+			'sku' => 'EXEMPT1',
+			'tax_class' => 'clothing-rate-20010',
+		) )->get_id();
+		$exempt_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'price' => '100',
+			'sku' => 'EXEMPT2',
+			'tax_class' => 'clothing-rate-20010',
+		) )->get_id();
+
+		WC()->cart->add_to_cart( $subscription_product );
+		WC()->cart->add_to_cart( $taxable_product );
+		WC()->cart->add_to_cart( $exempt_product );
+
+		TaxJar_Shipping_Helper::create_simple_flat_rate( 10 );
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
+		WC()->shipping->shipping_total = 10;
+
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 6.63, '', 0.01 );
+		$this->assertEquals( WC()->cart->shipping_tax_total, 0.66, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 7.29, '', 0.01 );
+
+		if ( method_exists( WC()->cart, 'get_shipping_taxes' ) ) {
+			$this->assertEquals( array_values( WC()->cart->get_shipping_taxes() )[0], 0.66, '', 0.01 );
+		} else {
+			$this->assertEquals( array_values( WC()->cart->shipping_taxes )[0], 0.66, '', 0.01 );
+		}
+
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 400 + 7.29, '', 0.01 );
+		}
+
+		foreach ( WC()->cart->recurring_carts as $recurring_cart ) {
+			$this->assertEquals( $recurring_cart->tax_total, 0.66, '', 0.01 );
+			$this->assertEquals( $recurring_cart->get_taxes_total(), 0.66, '', 0.01 );
+		}
+
+		WC()->session->set( 'chosen_shipping_methods', array() );
+		TaxJar_Shipping_Helper::delete_simple_flat_rate();
+	}
+
 	function test_correct_taxes_for_subscription_products_with_other_products_and_trial_and_thresholds() {
 		// NY shipping address
 		WC()->customer = TaxJar_Customer_Helper::create_customer( array(

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -833,6 +833,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			'price' => '10',
 			'sign_up_fee' => 100,
 			'trial_length' => 1,
+			'virtual' => 'no',
 		) )->get_id();
 		$taxable_product = TaxJar_Product_Helper::create_product( 'simple', array(
 			'price' => '200',
@@ -871,7 +872,8 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 		foreach ( WC()->cart->recurring_carts as $recurring_cart ) {
 			$this->assertEquals( $recurring_cart->tax_total, 0.66, '', 0.01 );
-			$this->assertEquals( $recurring_cart->get_taxes_total(), 0.66, '', 0.01 );
+			$this->assertEquals( $recurring_cart->shipping_tax_total, 0.66, '', 0.01 );
+			$this->assertEquals( $recurring_cart->get_taxes_total(), 1.32, '', 0.01 );
 		}
 
 		WC()->session->set( 'chosen_shipping_methods', array() );

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -866,7 +866,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		}
 
 		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
-			$this->assertEquals( WC()->cart->get_total( 'amount' ), 400 + 7.29, '', 0.01 );
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 400 + 10 + 7.29, '', 0.01 );
 		}
 
 		foreach ( WC()->cart->recurring_carts as $recurring_cart ) {


### PR DESCRIPTION
This PR resolves ongoing issues with recurring totals for subscription products between Woo 2.6 and 3.3. The `calculate_tax` method no longer uses class properties that can be modified by cloned carts in WooCommerce Subscriptions for recurring totals. A new method was introduced to calculate tax specifically for recurring totals without affecting the original totals. I also added some helper methods to get address and line item data before calculating tax.

**Versions Tested:**

- [x] Woo 3.3
- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6