### PR TITLE
Fix compatibility with PHP 5.2 and 5.3

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -347,7 +347,8 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 			// Add line item tax rates
 			foreach ( $taxes['line_items'] as $line_item_key => $line_item ) {
-				$product_id = explode( '-', $line_item_key )[0];
+				$line_item_key_chunks = explode( '-', $line_item_key );
+				$product_id = $line_item_key_chunks[0];
 				$product = wc_get_product( $product_id );
 				$tax_class = $product->get_tax_class();
 
@@ -729,7 +730,8 @@ class WC_Taxjar_Integration extends WC_Integration {
 	public function override_woocommerce_tax_rates( $taxes, $price, $rates ) {
 		if ( isset( $this->response_line_items ) && array_values( $rates ) ) {
 			// Get tax rate ID for current item
-			$tax_rate_id = array_keys( $taxes )[0];
+			$keys = array_keys( $taxes );
+			$tax_rate_id = $keys[0];
 			$line_items = array();
 
 			// Map line items using rate ID


### PR DESCRIPTION
We were porting your latest changes back to `woocommerce-services` and we found [these errors](https://travis-ci.org/Automattic/woocommerce-services/builds/378972561) in our CI. The `func_call_that_returns_array()[0]` syntax is only supported in `PHP 5.4` and up.

WooCommerce Services supports `PHP 5.2+` so we already fixed it in our repo.

I'm not sure what PHP version you folks support, seeing some old commits it looks like it's `PHP 5.3`? If so, you should merge this PR :)

Note that I've only fixed this particular error, I didn't test the whole plugin with an old version of PHP.