### PR TITLE
Perf Improvements (Round 2)

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -418,8 +418,14 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$this->_log( ':: Adding New Tax Rate ::' );
 			$this->_log( $tax_rate );
 			$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
-			WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_clean( $location['to_zip'] ) );
-			WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
+
+			if ( isset( $location['to_zip'] ) ) {
+				WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_clean( $location['to_zip'] ) );
+			}
+
+			if ( isset( $location['to_city'] ) ) {
+				WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
+			}
 		}
 
 		$this->_log( 'Tax Rate ID Set for ' . $rate_id );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -515,11 +515,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 		}
 
-		// Recalculate shipping package rates
-		foreach ( $wc_cart_object->get_shipping_packages() as $package_key => $package ) {
-			WC()->session->set( 'shipping_for_package_' . $package_key, null );
-		}
-
 		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );


### PR DESCRIPTION
This PR revisits the shipping package rate purge we added in v1.6 to ensure total calculations are correct when shipping is taxable and a new shipping tax rate is added in Woo 3.0 - 3.1. We're going to drop the change to address performance issues with multiple / redundant shipping calculations mentioned in #66 and seen causing duplicate queries against the database with shipping plugins. Let's test things out again.