### PR TITLE
Skip API request when there are no line items.

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -268,7 +268,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 		);
 
 		// Strict conditions to be met before API call can be conducted
-		if ( empty( $to_country ) || empty( $to_zip ) || WC()->customer->is_vat_exempt() ) {
+		if ( empty( $to_country ) || empty( $to_zip ) || empty( $line_items ) || WC()->customer->is_vat_exempt() ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1433.

Skip API request when there aren't any line items - happens during recalculating taxes on an order where all products have been deleted.