### PR TITLE
Handle case where there aren’t order line items, but there are shipping charges.

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -268,7 +268,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 		);
 
 		// Strict conditions to be met before API call can be conducted
-		if ( empty( $to_country ) || empty( $to_zip ) || empty( $line_items ) || WC()->customer->is_vat_exempt() ) {
+		if (
+			empty( $to_country ) ||
+			empty( $to_zip ) ||
+			( empty( $line_items ) && ( 0 == $shipping_amount ) ) ||
+			WC()->customer->is_vat_exempt()
+		) {
 			return false;
 		}
 
@@ -303,9 +308,15 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'to_city' => $to_city,
 			'to_zip' => $to_zip,
 			'shipping' => $shipping_amount,
-			'line_items' => $line_items,
 			'plugin' => 'woo',
 		);
+
+		// Either `amount` or `line_items` parameters are required to perform tax calculations.
+		if ( empty( $line_items ) ) {
+			$body['amount'] = 0.0;
+		} else {
+			$body['line_items'] = $line_items;
+		}
 
 		$response = $this->smartcalcs_cache_request( wp_json_encode( $body ) );
 


### PR DESCRIPTION
From feedback on https://github.com/Automattic/woocommerce-services/pull/1435#issuecomment-396187342:

> The fix stops the invalid API requests. But when I created a product with price set to 0 and then selected a paid shipping options, there were no taxes requested for the shipping price.
> 
> This is because products with falsey price are not added to `$line_items`.

This PR conditionally includes `amount` or `line_items` as referenced in the documentation here: https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order

> Either `amount` or `line_items` parameters are required to perform tax calculations.