### PR TITLE
Tax Code Precedence for Calculations

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -699,12 +699,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$unit_price = $product->get_price();
 			$tax_code = '';
 
-			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
-				$tax_code = '99999';
-			}
-
 			if ( isset( $tax_class[1] ) && is_numeric( $tax_class[1] ) ) {
 				$tax_code = $tax_class[1];
+			}
+
+			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
+				$tax_code = '99999';
 			}
 
 			if ( $unit_price ) {

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -637,12 +637,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$tax_class = explode( '-', $product->get_tax_class() );
 			$tax_code = '';
 
-			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
-				$tax_code = '99999';
-			}
-
 			if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
 				$tax_code = end( $tax_class );
+			}
+
+			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
+				$tax_code = '99999';
 			}
 
 			// Get WC Subscription sign-up fees for calculations

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -253,6 +253,19 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$this->assertEquals( WC()->cart->get_taxes_total(), 0, '', 0.01 );
 	}
 
+	function test_correct_taxes_for_categorized_exempt_products() {
+		$exempt_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'tax_status' => 'none',
+			'tax_class' => 'clothing-rate-20010',
+		) )->get_id();
+
+		WC()->cart->add_to_cart( $exempt_product );
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 0, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 0, '', 0.01 );
+	}
+
 	function test_correct_taxes_for_zero_rate_exempt_products() {
 		$exempt_product = TaxJar_Product_Helper::create_product( 'simple', array(
 			'tax_class' => 'zero-rate',


### PR DESCRIPTION
This PR ensures products set to a "None" tax status with a custom product tax class containing a product tax code remain fully exempt. For example:

1) Set `None` tax status for a given product
2) Set `Clothing - 20010` or another custom tax class for the product

Our plugin should send a `99999` tax code for this product, not `20010`.