### PR TITLE
Product Exemption Threshold Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.7.1 (2018-07-05)
+* Tested up to WooCommerce 3.4
+* Skip API requests when there are no line items or shipping charges
+* Fix backend order tax calculations for deleted products
+* Fix compatibility issues with PHP 5.2 and 5.3
+* Fix tax code precedence for "None" tax status and custom tax class products
+* Fix error handling when syncing nexus regions with an expired API token
+
 # 1.7.0 (2018-05-10)
 * Improve performance by skipping calculations in the mini-cart
 * Drop TLC transients library in favor of native WP Transients API

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -22,7 +22,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 		$this->integration_uri    = $this->app_uri . 'account/apps/add/woo';
 		$this->regions_uri        = $this->app_uri . 'account#states';
 		$this->uri                = 'https://api.taxjar.com/v2/';
-		$this->ua                 = 'TaxJarWordPressPlugin/1.7.0/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' );
+		$this->ua                 = 'TaxJarWordPressPlugin/1.7.1/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' );
 		$this->debug              = filter_var( $this->get_option( 'debug' ), FILTER_VALIDATE_BOOLEAN );
 		$this->download_orders    = new WC_Taxjar_Download_Orders( $this );
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -521,6 +521,16 @@ class WC_Taxjar_Integration extends WC_Integration {
 		$this->response_rate_ids = $taxes['rate_ids'];
 		$this->response_line_items = $taxes['line_items'];
 
+		if ( isset( $this->response_line_items ) ) {
+			foreach ( $this->response_line_items as $response_line_item_key => $response_line_item ) {
+				$line_item = $this->get_line_item( $response_line_item_key, $line_items );
+
+				if ( isset( $line_item ) ) {
+					$this->response_line_items[ $response_line_item_key ]->line_price = ( $line_item['unit_price'] * $line_item['quantity'] ) - $line_item['discount'];
+				}
+			}
+		}
+
 		foreach ( $wc_cart_object->get_cart() as $cart_item_key => $cart_item ) {
 			$product = $cart_item['data'];
 			$line_item_key = $product->get_id() . '-' . $cart_item_key;
@@ -741,6 +751,16 @@ class WC_Taxjar_Integration extends WC_Integration {
 		return $line_items;
 	}
 
+	protected function get_line_item( $id, $line_items ) {
+		foreach ( $line_items as $line_item ) {
+			if ( $line_item['id'] === $id ) {
+				return $line_item;
+			}
+		}
+
+		return null;
+	}
+
 	/**
 	 * Override Woo's native tax rates to handle multiple line items with the same tax rate
 	 * within the same tax class with different rates due to exemption thresholds
@@ -768,7 +788,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 			foreach ( $this->response_line_items as $line_item_key => $line_item ) {
 				// If line item belongs to rate and matches the price, manually set the tax
-				if ( in_array( $line_item_key, $line_items ) && $price == $line_item->taxable_amount ) {
+				if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_price ) {
 					if ( function_exists( 'wc_add_number_precision' ) ) {
 						$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
 					} else {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 4.2
 Tested up to: 4.9.2
-Stable tag: 1.7.0
+Stable tag: 1.7.1
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 2.6.0
@@ -90,6 +90,14 @@ Yes. The fee is $19.95 per state, per filing.
 1. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 1.7.1 (2018-07-05) =
+* Tested up to WooCommerce 3.4
+* Skip API requests when there are no line items or shipping charges
+* Fix backend order tax calculations for deleted products
+* Fix compatibility issues with PHP 5.2 and 5.3
+* Fix tax code precedence for "None" tax status and custom tax class products
+* Fix error handling when syncing nexus regions with an expired API token
 
 = 1.7.0 (2018-05-10) =
 * Improve performance by skipping calculations in the mini-cart

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 1.7.0
+ * Version: 1.7.1
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 2.6.0

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -376,6 +376,57 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		}
 	}
 
+	function test_correct_taxes_for_product_exemption_threshold_ma() {
+		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
+			'store_country' => 'US',
+			'store_state' => 'SC',
+			'store_zip' => '29401',
+			'store_city' => 'Charleston',
+		) );
+
+		// NY shipping address
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
+			'state' => 'MA',
+			'zip' => '02127',
+			'city' => 'Boston',
+		) );
+
+		$taxable_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'price' => '205', // Over $110 threshold
+			'sku' => 'EXEMPTOVER1',
+			'tax_class' => 'clothing-rate-20010',
+		) )->get_id();
+		$exempt_product = TaxJar_Product_Helper::create_product( 'simple', array(
+			'price' => '78',
+			'sku' => 'EXEMPT1',
+			'tax_class' => 'clothing-rate-20010',
+		) )->get_id();
+
+		WC()->cart->add_to_cart( $taxable_product );
+		WC()->cart->add_to_cart( $exempt_product );
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( WC()->cart->tax_total, 1.88, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 1.88, '', 0.01 );
+
+		if ( version_compare( WC()->version, '3.2', '>=' ) ) {
+			$this->assertEquals( WC()->cart->get_total( 'amount' ), 283 + 1.88, '', 0.01 );
+		}
+
+		foreach ( WC()->cart->get_cart() as $item_key => $item ) {
+			$product = $item['data'];
+			$sku = $product->get_sku();
+
+			if ( 'EXEMPT1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 0, '', 0.01 );
+			}
+
+			if ( 'EXEMPTOVER1' == $sku ) {
+				$this->assertEquals( $item['line_tax'], 1.88, '', 0.01 );
+			}
+		}
+	}
+
 	function test_correct_taxes_for_product_exemption_threshold_reduced_rates() {
 		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
 			'store_country' => 'US',


### PR DESCRIPTION
This PR resolves a calculation issue with exemption thresholds on multiple line items sharing the same product tax class. For example, two clothing line items with one item over a given state threshold and another item below the threshold.

**Versions Tested:**

- [x] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
- [ ] Woo 2.6.2
- [ ] Woo 2.6.1
- [ ] Woo 2.6.0