### PR TITLE
Fix Backend Order Calculations for Woo 2.6

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -600,7 +600,9 @@ class WC_Taxjar_Integration extends WC_Integration {
 		} else { // Recalculate tax for Woo 2.6 to apply new tax rates
 			if ( class_exists( 'WC_AJAX' ) ) {
 				remove_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
-				WC_AJAX::calc_line_taxes();
+				if ( check_ajax_referer( 'calc-totals', 'security', false ) ) {
+					WC_AJAX::calc_line_taxes();
+				}
 				add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
 			}
 		}


### PR DESCRIPTION
This PR checks the AJAX referrer when recalculating tax for backend orders in Woo 2.6 to avoid 403 forbidden errors. Regression introduced in #72.

1. Test in WooCommerce 2.6.13 or below.
2. Start a new order.
3. Add an item to the order and click "Save".

The item portion of the screen will stall unless this PR is applied.

- [x] Woo 2.6.13
- [x] Woo 2.6.2
- [x] Woo 2.6.1
- [x] Woo 2.6.0