### PR TITLE
Call `woocommerce_after_calculate_totals` action for other plugins

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -552,6 +552,9 @@ class WC_Taxjar_Integration extends WC_Integration {
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
 			new WC_Cart_Totals( $wc_cart_object );
+			remove_action( 'woocommerce_after_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			do_action( 'woocommerce_after_calculate_totals', $wc_cart_object );
+			add_action( 'woocommerce_after_calculate_totals', array( $this, 'calculate_totals' ), 20 );
 		} else {
 			remove_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
 			$wc_cart_object->calculate_totals();


### PR DESCRIPTION
This PR resolves #80 to always call `woocommerce_after_calculate_totals` so other plugins can hook into the process immediately after tax is recalculated in the TaxJar plugin for WooCommerce 3.2+. Since we require discounts and additional data prior to making a sales tax API request and creating a native rate for WooCommerce's internal calculation process, we have to recalculate tax in WooCommerce again after creating the new tax rate and make sure we call the associated actions:

- woocommerce_before_calculate_totals
- woocommerce_after_calculate_totals

Test to make sure general calculations in 3.2+ continue to work. Specs passing.

**Versions Tested:**

- [x] Woo 3.4
- [x] Woo 3.3
- [x] Woo 3.2