### PR TITLE
Display Native Rate Tables for Custom Rates

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -52,7 +52,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 			// Settings Page
 			add_action( 'woocommerce_sections_tax',  array( $this, 'output_sections_before' ),  9 );
-			add_action( 'woocommerce_sections_tax',  array( $this, 'output_sections_after' ),  11 );
 
 			// Filters
 			add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
@@ -1005,20 +1004,10 @@ class WC_Taxjar_Integration extends WC_Integration {
 	}
 
 	/**
-	 * Hack to hide the tax sections for additional tax class rate tables.
-	 *
+	 * Output TaxJar message above tax configuration screen
 	 */
 	public function output_sections_before() {
-		echo '<div class="updated taxjar-notice"><p><b>Powered by <a href="https://www.taxjar.com" target="_blank">TaxJar</a></b> ― Your tax rates and settings are automatically configured.</p><p><a href="admin.php?page=wc-settings&tab=integration&section=taxjar-integration" class="button-primary">Configure TaxJar</a> &nbsp; <a href="https://www.taxjar.com/contact/" class="button" target="_blank">Help &amp; Support</a></p></div>';
-		echo '<div style="display: none">';
-	}
-
-	/**
-	 * Hack to hide the tax sections for additional tax class rate tables.
-	 *
-	 */
-	public function output_sections_after() {
-		echo '</div>';
+		echo '<div class="updated taxjar-notice"><p><b>Powered by <a href="https://www.taxjar.com" target="_blank">TaxJar</a></b> ― Your tax rates and settings are automatically configured below.</p><p><a href="admin.php?page=wc-settings&tab=integration&section=taxjar-integration" class="button-primary">Configure TaxJar</a> &nbsp; <a href="https://www.taxjar.com/contact/" class="button" target="_blank">Help &amp; Support</a></p></div>';
 	}
 
 	/**


### PR DESCRIPTION
Our plugin currently hides the links to the native rate tables inside WooCommerce to prevent merchants from adding US-based rates and then having them overridden by our API. However, some merchants may want to collect tax in other countries we don't support yet or simply use their own rate without creating a nexus location in TaxJar. Exposing these rate tables allow them to do so.

To test, make sure the rate table links are shown in WooCommerce under **Settings > Tax**.

**Versions Tested:**

- [x] Woo 3.4
- [x] Woo 3.3
- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6.2
- [x] Woo 2.6.1
- [x] Woo 2.6.0