### PR TITLE
Local Pickup Calculation v2.0 Fix

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -57,6 +57,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 			add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, array( $this, 'sanitize_settings' ) );
 			add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
+			add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_for_matched_rates' ), 10, 2 );
 
 			// Scripts / Stylesheets
 			add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_new_order_assets' ) );
@@ -849,7 +850,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 	 * @return array
 	 */
 	public function append_base_address_to_customer_taxable_address( $address ) {
-		$store_settings = $this->get_store_settings();
 		$tax_based_on = '';
 
 		list( $country, $state, $postcode, $city, $street ) = array_pad( $address, 5, '' );
@@ -867,6 +867,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 		}
 
 		if ( 'base' == $tax_based_on ) {
+			$store_settings = $this->get_store_settings();
 			$postcode = $store_settings['postcode'];
 			$city = strtoupper( $store_settings['city'] );
 			$street = $store_settings['street'];
@@ -877,6 +878,33 @@ class WC_Taxjar_Integration extends WC_Integration {
 		} else {
 			return array( $country, $state, $postcode, $city );
 		}
+	}
+
+	/**
+	 * Allow street address to be passed when finding rates
+	 *
+	 * @param array $matched_tax_rates
+	 * @param string $tax_class
+	 * @return array
+	 */
+	public function allow_street_for_matched_rates( $matched_tax_rates, $tax_class = '' ) {
+		$tax_class         = sanitize_title( $tax_class );
+		$location          = WC_Tax::get_tax_location( $tax_class );
+		$matched_tax_rates = array();
+
+		if ( sizeof( $location ) >= 4 ) {
+			list( $country, $state, $postcode, $city, $street ) = array_pad( $location, 5, '' );
+
+			$matched_tax_rates = WC_Tax::find_rates( array(
+				'country' 	=> $country,
+				'state' 	=> $state,
+				'postcode' 	=> $postcode,
+				'city' 		=> $city,
+				'tax_class' => $tax_class,
+			) );
+		}
+
+		return $matched_tax_rates;
 	}
 
 	/**
@@ -900,11 +928,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 		}
 
 		if ( 'base' === $tax_based_on ) {
-			$country  = WC()->countries->get_base_country();
-			$state    = WC()->countries->get_base_state();
-			$postcode = WC()->countries->get_base_postcode();
-			$city     = WC()->countries->get_base_city();
-			$street   = $this->store_street;
+			$store_settings = $this->get_store_settings();
+			$country  = $store_settings['country'];
+			$state    = $store_settings['state'];
+			$postcode = $store_settings['postcode'];
+			$city     = $store_settings['city'];
+			$street   = $store_settings['street'];
 		} elseif ( 'billing' === $tax_based_on ) {
 			$country  = WC()->customer->get_billing_country();
 			$state    = WC()->customer->get_billing_state();

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -57,7 +57,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 			add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, array( $this, 'sanitize_settings' ) );
 			add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
-			add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_for_matched_rates' ), 10, 2 );
+			add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
 
 			// Scripts / Stylesheets
 			add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_new_order_assets' ) );
@@ -887,7 +887,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 	 * @param string $tax_class
 	 * @return array
 	 */
-	public function allow_street_for_matched_rates( $matched_tax_rates, $tax_class = '' ) {
+	public function allow_street_address_for_matched_rates( $matched_tax_rates, $tax_class = '' ) {
 		$tax_class         = sanitize_title( $tax_class );
 		$location          = WC_Tax::get_tax_location( $tax_class );
 		$matched_tax_rates = array();


### PR DESCRIPTION
This PR fixes local pickup method calculations for v2.0 of our plugin with street address support. When passing the street address, WooCommerce has a hard check for the location to have 4 parts (country, state, postal code, city) when looking up native tax rates. We need to hook into the `woocommerce_matched_rates` filter to support up to 5.

**Versions Tested:**

- [x] Woo 3.4
- [x] Woo 3.3
- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6