### PR TITLE
 Add filters/actions allowing to override some of the plugin functions

### DIFF
--- a/includes/class-wc-taxjar-connection.php
+++ b/includes/class-wc-taxjar-connection.php
@@ -27,6 +27,12 @@ class WC_Taxjar_Connection {
 	}
 
 	private function check_status() {
+		if ( ! apply_filters( 'taxjar_should_check_status', true ) ) {
+			$this->api_token_valid = apply_filters( 'taxjar_api_token_valid', false );
+			$this->can_connect = apply_filters( 'taxjar_can_connect', false );
+			return;
+		}
+
 		$description = '';
 		$url         = $this->integration->uri . 'verify';
 		$body_string = 'token=' . $this->integration->post_or_setting( 'api_token' );

--- a/includes/class-wc-taxjar-download-orders.php
+++ b/includes/class-wc-taxjar-download-orders.php
@@ -29,6 +29,7 @@ class WC_Taxjar_Download_Orders {
 		} else {
 			$value = 'no';
 		}
+		$value = apply_filters( 'taxjar_download_orders', $value );
 
 		if ( ($value != $previous_value ) ) {
 			if ( 'yes' == $value ) {

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -17,7 +17,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 	public function __construct() {
 		$this->id                 = 'taxjar-integration';
 		$this->method_title       = __( 'TaxJar', 'wc-taxjar' );
-		$this->method_description = __( 'TaxJar is the easiest to use sales tax calculation and reporting engine for WooCommerce. Enter your API token (<a href="https://app.taxjar.com/api_sign_up/" target="_blank">click here to get a token</a>), city, and zip code from which your store ships. Enable TaxJar calculations to automatically collect sales tax at checkout. You may also enable order downloads to begin importing transactions from this store into your TaxJar account, all in one click!<br><br><b>For the fastest help, please email <a href="mailto:support@taxjar.com">support@taxjar.com</a>. We\'ll get back to you within hours.</b>', 'wc-taxjar' );
+		$this->method_description = apply_filters( 'taxjar_method_description', __( 'TaxJar is the easiest to use sales tax calculation and reporting engine for WooCommerce. Enter your API token (<a href="https://app.taxjar.com/api_sign_up/" target="_blank">click here to get a token</a>), city, and zip code from which your store ships. Enable TaxJar calculations to automatically collect sales tax at checkout. You may also enable order downloads to begin importing transactions from this store into your TaxJar account, all in one click!<br><br><b>For the fastest help, please email <a href="mailto:support@taxjar.com">support@taxjar.com</a>. We\'ll get back to you within hours.</b>', 'wc-taxjar' ) );
 		$this->app_uri            = 'https://app.taxjar.com/';
 		$this->integration_uri    = $this->app_uri . 'account/apps/add/woo';
 		$this->regions_uri        = $this->app_uri . 'account#states';
@@ -130,7 +130,8 @@ class WC_Taxjar_Integration extends WC_Integration {
 			);
 		}
 
-		if ( $this->post_or_setting( 'api_token' ) && $tj_connection->api_token_valid ) {
+		$api_token_valid = apply_filters( 'taxjar_api_token_valid', $this->post_or_setting( 'api_token' ) && $tj_connection->api_token_valid );
+		if ( $api_token_valid ) {
 			$this->form_fields = array_merge( $this->form_fields,
 				array(
 					'taxjar_title_step_2' => array(
@@ -227,6 +228,8 @@ class WC_Taxjar_Integration extends WC_Integration {
 				)
 			);
 		} // End if().
+
+		$this->form_fields = apply_filters( 'taxjar_form_fields', $this->form_fields );
 	}
 
 	/**
@@ -235,6 +238,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 	 * @return void
 	 */
 	public function _log( $message ) {
+		do_action( 'taxjar_log', $message );
 		if ( $this->debug ) {
 			if ( ! isset( $this->log ) ) {
 			    $this->log = new WC_Logger();
@@ -477,18 +481,20 @@ class WC_Taxjar_Integration extends WC_Integration {
 	}
 
 	public function smartcalcs_request( $json ) {
-		$url = $this->uri . 'taxes';
+		$response = apply_filters( 'taxjar_smartcalcs_request', $json, false );
+		if ( ! $response ) {
+			$url = $this->uri . 'taxes';
+			$this->_log( 'Requesting: ' . $this->uri . 'taxes - ' . $json );
 
-		$this->_log( 'Requesting: ' . $this->uri . 'taxes - ' . $json );
-
-		$response = wp_remote_post( $url, array(
-			'headers' => array(
-							'Authorization' => 'Token token="' . $this->settings['api_token'] . '"',
-							'Content-Type' => 'application/json',
-						),
-			'user-agent' => $this->ua,
-			'body' => $json,
-		) );
+			$response = wp_remote_post( $url, array(
+				'headers' => array(
+								'Authorization' => 'Token token="' . $this->settings['api_token'] . '"',
+								'Content-Type' => 'application/json',
+							),
+				'user-agent' => $this->ua,
+				'body' => $json,
+			) );
+		}
 
 		if ( is_wp_error( $response ) ) {
 			new WP_Error( 'request', __( 'There was an error retrieving the tax rates. Please check your server configuration.' ) );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -481,7 +481,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 	}
 
 	public function smartcalcs_request( $json ) {
-		$response = apply_filters( 'taxjar_smartcalcs_request', $json, false );
+		$response = apply_filters( 'taxjar_smartcalcs_request', false, $json );
 		if ( ! $response ) {
 			$url = $this->uri . 'taxes';
 			$this->_log( 'Requesting: ' . $this->uri . 'taxes - ' . $json );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -39,7 +39,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'admin_menu', array( $this, 'taxjar_admin_menu' ),  15 );
 
-		if ( ( 'yes' == $this->settings['enabled'] ) ) {
+		if ( apply_filters( 'taxjar_enabled', 'yes' == $this->settings['enabled'] ) ) {
 			// Calculate Taxes at Cart / Checkout
 			if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
 				add_action( 'woocommerce_after_calculate_totals', array( $this, 'calculate_totals' ), 20 );

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -236,7 +236,7 @@ final class WC_Taxjar {
 
 		$api_token = WC()->integrations->integrations['taxjar-integration']->get_option( 'api_token' );
 
-		if ( '' == $api_token ) {
+		if ( '' == $api_token && apply_filters( 'taxjar_should_display_connect_notice', true ) ) {
 			$url = $this->get_settings_url();
 			// translators: Installation admin notice
 			echo '<div class="updated fade"><p>' . sprintf( __( '%1$sTaxJar for WooCommerce is almost ready. %2$sTo get started, %3$sconnect your TaxJar account%4$s.', 'wc-taxjar' ), '<strong>', '</strong>', '<a href="' . esc_url( $url ) . '">', '</a>' ) . '</p></div>' . "\n";


### PR DESCRIPTION
Over at WooCommerce Services, we are experimenting with integrating our plugins to work better together. Instead of porting the code over to our plugin we decided to try to add hooks that we could use to control the TaxJar plugin.

See https://github.com/Automattic/woocommerce-services/pull/1494 for how the new hooks are being used.

This PR proposes the following hooks:
* `taxjar_should_check_status` allows preventing the connection test request from being sent
* `taxjar_api_token_valid` overrides the API token validation
* `taxjar_can_connect` overrides the connection test result
* `taxjar_download_orders` overrides the value of the download orders option. [Combined with triggering the order validation on saving](https://github.com/Automattic/woocommerce-services/pull/1494/commits/c991c51588c1d40e2cde4412b45ad79b979b2207), this should unlink the account if downloads are enabled and the user opts-in for WooCommerce Services functionality
* `taxjar_method_description` overrides the method description
* `taxjar_enabled` overrides the enabled flag if the user opted in for the taxes functionality. See https://github.com/Automattic/woocommerce-services/pull/1494/commits/531a56e2c7e50d677675cc9c668cb9d847752766
* `taxjar_form_fields` allows modifying the form fields on the settings page
* `taxjar_log` allows extending the logging
* `taxjar_smartcalcs_request` allows overriding the smartcalcs request. If it returns `false`, then the default functionality is used