### PR TITLE
Fix backend order rates after a product tax class is changed

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -394,12 +394,10 @@ class WC_Taxjar_Integration extends WC_Integration {
 				$product_id = $line_item_key_chunks[0];
 				$product = wc_get_product( $product_id );
 
-				if ( $product ) {
-					$tax_class = $product->get_tax_class();
+				if ( isset( $this->backend_tax_classes[$product_id] ) ) {
+					$tax_class = $this->backend_tax_classes[$product_id];
 				} else {
-					if ( isset( $this->backend_tax_classes[$product_id] ) ) {
-						$tax_class = $this->backend_tax_classes[$product_id];
-					}
+					$tax_class = $product->get_tax_class();
 				}
 
 				if ( $line_item->combined_tax_rate ) {


### PR DESCRIPTION
When modifying an existing order in WP admin or creating a new backend order, line item tax classes remain the same even if the underlying product tax classes change.

If you change a tax class for a product and click the "Recalculate" button without first removing the associated line item, the old tax class will be used for the API request and the new tax class will be used when creating a tax rate from the response. This results in a tax rate created for exempt tax classes greater than 0.

**Specs Passing**

- [x] Woo 3.5
- [x] Woo 3.4
- [x] Woo 3.3
- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6