### PR TITLE
Fix VAT exempt tax removal in Woo < 3.2

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -378,7 +378,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 		// Remove taxes if they are set somehow and customer is exempt
 		if ( WC()->customer->is_vat_exempt() ) {
-			$wc_cart_object->remove_taxes();
+			WC()->cart->remove_taxes(); // Woo < 3.2
 		} elseif ( $taxes['has_nexus'] ) {
 			// Use Woo core to find matching rates for taxable address
 			$location = array(


### PR DESCRIPTION
If a customer is VAT exempt, this PR removes taxes properly in Woo < 3.2. In later versions of Woo, if the customer is already exempt then `WC_Cart_Totals` should pick it up automatically via `get_is_vat_exempt`.

**Specs Passing**

- [x] Woo 3.2
- [x] Woo 3.1
- [x] Woo 3.0
- [x] Woo 2.6