### PR TITLE
Catch JSON parsing errors for backend orders

### DIFF
--- a/includes/js/wc-taxjar-order.js
+++ b/includes/js/wc-taxjar-order.js
@@ -5,21 +5,25 @@ jQuery( document ).ready( function() {
 	var TaxJarOrder = ( function( $, m ) {
 		$( document ).ajaxSend( function( event, request, settings ) {
 			if ( settings.data ) {
-				var data = JSON.parse( '{"' + decodeURIComponent( settings.data.replace( /&/g, '","' ).replace( /=/g, '":"' ) ) + '"}' );
+				try {
+					var data = JSON.parse( '{"' + decodeURIComponent( settings.data.replace( /&/g, '","' ).replace( /=/g, '":"' ) ) + '"}' );
 
-				if ( 'woocommerce_calc_line_taxes' === data.action ) {
-					var street = '';
+					if ( 'woocommerce_calc_line_taxes' === data.action ) {
+						var street = '';
 
-					if ( 'shipping' === woocommerce_admin_meta_boxes.tax_based_on ) {
-						street = $( '#_shipping_address_1' ).val();
+						if ( 'shipping' === woocommerce_admin_meta_boxes.tax_based_on ) {
+							street = $( '#_shipping_address_1' ).val();
+						}
+
+						if ( 'billing' === woocommerce_admin_meta_boxes.tax_based_on ) {
+							street = $( '#_billing_address_1' ).val();
+						}
+
+						data.street = street;
+						settings.data = $.param( data );
 					}
-
-					if ( 'billing' === woocommerce_admin_meta_boxes.tax_based_on ) {
-						street = $( '#_billing_address_1' ).val();
-					}
-
-					data.street = street;
-					settings.data = $.param( data );
+				} catch ( e ) {
+					// Ignore invalid JSON
 				}
 			}
 		} );


### PR DESCRIPTION
We intercept AJAX requests for backend orders to pass in a street address for rooftop accuracy. When a WooCommerce merchant manually creates a backend order with variable products using an unexpected variation label (such as a shoe size with special characters), `JSON.parse` can return an error and prevent the merchant from creating the order. This PR catches the error and allows the merchant to proceed.

**Steps to Reproduce**

1. Create a variable product with a variation name such as "2 1/4 x 3 1/2"
2. Start a new backend order
3. Add the variable product's variation to the order
4. Attempt to submit and create the order

**Expected Result**

After applying the PR, the browser should not show a `JSON.parse` error in the console and the merchant should be able to successfully create the order.