### PR TITLE
Fix taxable to fully exempt shipping in same order

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -413,14 +413,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 
 			// Add shipping tax rate
-			if ( $taxes['tax_rate'] ) {
-				$taxes['rate_ids']['shipping'] = $this->create_or_update_tax_rate(
-					$location,
-					$taxes['tax_rate'] * 100,
-					'',
-					$taxes['freight_taxable']
-				);
-			}
+			$taxes['rate_ids']['shipping'] = $this->create_or_update_tax_rate(
+				$location,
+				$taxes['tax_rate'] * 100,
+				'',
+				$taxes['freight_taxable']
+			);
 		} // End if().
 
 		return $taxes;


### PR DESCRIPTION
This PR ensures an existing standard tax rate is updated to 0% after a customer removes all taxable items from their cart and the order becomes fully exempt, including shipping.

**Steps to Reproduce**

1. Add a clothing product (under $110) and a fully taxable product to the cart
2. Calculate shipping in the cart for a New York zip code
3. Verify tax is collected
4. Remove the taxable product from the cart
5. Verify the order is fully exempt with $0 tax collected

**Expected Result**

After applying the PR, shipping tax should no longer be included on a taxable -> fully exempt order in WooCommerce.

**Click-Test Versions**

- [ ] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
- [ ] Woo 2.6

**Specs Passing**

- [ ] Woo 3.5
- [X] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
- [ ] Woo 2.6
