### PR TITLE
Tested up to WooCommerce 3.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,12 +2,12 @@
 Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 4.2
-Tested up to: 4.9.2
+Tested up to: 5.0.0
 Stable tag: 2.0.1
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 2.6.0
-WC tested up to: 3.4.0
+WC tested up to: 3.5.0
 
 Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculations, reporting, and filing.
 

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -7,9 +7,9 @@
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 2.6.0
- * WC tested up to: 3.4.0
+ * WC tested up to: 3.5.0
  *
- * Copyright: © 2014-2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc.
+ * Copyright: © 2014-2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc.
  * License: GNU General Public License v2.0 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  *


### PR DESCRIPTION
This PR indicates our plugin is tested up to WooCommerce 3.5 and WordPress 5.0.

**Steps to Reproduce**

1. Upgrade to WordPress 5.0
2. Upgrade to WooCommerce 3.5
3. Perform click-testing

**Expected Result**

All the things work in 3.5 💪

**Click-Test Versions**

- [x] Woo 3.5

**Specs Passing**

- [x] Woo 3.5
