### PR TITLE
Fix empty nexus list issue

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -957,11 +957,11 @@ class WC_Taxjar_Integration extends WC_Integration {
 	public function post_or_setting( $key ) {
 		$val = null;
 
-		if ( count( $_POST ) > 0 ) {
-			$val = isset( $_POST[ 'woocommerce_taxjar-integration_' . $key ] ) ? $_POST[ 'woocommerce_taxjar-integration_' . $key ] : null;
-		} else {
-			$val = $this->settings[ $key ];
-		}
+        if ( isset( $_POST[ 'woocommerce_taxjar-integration_' . $key ] ) ) {
+            $val = $_POST[ 'woocommerce_taxjar-integration_' . $key ];
+        } else {
+            $val = $this->settings[ $key ];
+        }
 
 		if ( 'yes' == $val ) {
 			$val = 1;


### PR DESCRIPTION
On the TaxJar settings page, the nexus regions will occasionally appear to be blank. This is occurring due to an issue in getting the nexus data when creating an order on the back-end of WooCommerce. When a user requests to calculate taxes for an order on the back-end, this is done through AJAX. The TaxJar plugin hooks into that AJAX request and attempts to run its tax calculations. If the transient containing the nexus data is not set or expired, it will run a request to TaxJar to pull in the nexus data. This is where the error occurs. When the TaxJar plugin is creating its request to get the nexus data, it calls a method that gets the TaxJar API token from either the $_POST variable or from the TaxJar settings. The logic it uses to determine which source to get the API token from is based on whether the $_POST variable is not empty (so essentially if it is an AJAX request or not). In this case since the back-end calculates taxes using an AJAX request, it attempts to pull the API token from the $_POST variable and it is not set in that variable. So it sets null as the API token, creates the nexus transient and sets it to be the string "Unauthorized" (the null API token gets rejected by the TaxJar API). 

Once that occurs, if the user navigates to the TaxJar settings page, it checks the nexus transient in order to populate the nexus regions on the page. Since the transient is now set to "Unauthorized" the nexus regions list is not populated.

This PR fixes the issue by altering the logic of the function that gets the API token. It changes it so that it will first check the $_POST variable, and if the key for the API token is not set it will fall back on pulling it from the API settings.

**Steps to Reproduce**

1. Setup TaxJar plugin, enable calculations and sync nexus regions.
2. Delete or expire the `tj_nexus` transient .
3. Calculate taxes on a order in the WooCommerce backend.
4. Navigate to the TaxJar settings page. You should now see that the nexus regions list is empty.

**Expected Result**

After applying this PR, when you follow the steps to reproduce, on step 4 you should now see that the nexus regions list is populated with the nexus regions configured in your TaxJar account.

**Click-Test Versions**

- [X] Woo 3.5
- [X] Woo 3.4
- [ ] Woo 3.3
- [X] Woo 3.2
- [ ] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6

**Specs Passing**

- [X] Woo 3.5
- [X] Woo 3.4
- [ ] Woo 3.3
- [X] Woo 3.2
- [ ] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6

Note: TJ_WC_Actions::test_correct_taxes_with_local_pickup fails on both this fork and on master in Woo 2.6 and Woo 3.0