### PR TITLE
Tweak specs to fully support environmental variables

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,7 +15,7 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 
 		$this->tests_dir    = dirname( __FILE__ );
 		$this->plugin_dir   = __DIR__ . '/../../';
-		$this->wp_tests_dir = '/tmp/wordpress-tests-lib/';
+		$this->wp_tests_dir = !empty( getenv('WP_TESTS_DIR' ) ) ? getenv('WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib/';
 
 		$this->api_token = getenv( 'TAXJAR_API_TOKEN' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,7 +15,7 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 
 		$this->tests_dir    = dirname( __FILE__ );
 		$this->plugin_dir   = __DIR__ . '/../../';
-		$this->wp_tests_dir = !empty( getenv('WP_TESTS_DIR' ) ) ? getenv('WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib/';
+		$this->wp_tests_dir = ! empty( getenv( 'WP_TESTS_DIR' ) ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib/';
 
 		$this->api_token = getenv( 'TAXJAR_API_TOKEN' );
 


### PR DESCRIPTION
In the install.sh file it checks for an environmental variable (WP_TESTS_DIR) and if it is not set it then defaults to "/tmp/wordpress-tests-lib". However in the bootstrap.php file it is hardcoded to "/tmp/wordpress-tests-lib". This creates an issue when the environmental variable is already set, as it will install the files in the directory set in that environmental variable and then attempt to run them from the "/tmp/wordpress-tests-lib" directory.

This PR fixes the issue by using the same logic to set the WordPress tests directory in the bootstrap.php file as is in the install.sh file.

**Click-Test Versions**

- [X] Woo 3.5
- [X] Woo 3.4
- [ ] Woo 3.3
- [X] Woo 3.2
- [ ] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6

**Specs Passing**

- [X] Woo 3.5
- [X] Woo 3.4
- [ ] Woo 3.3
- [X] Woo 3.2
- [ ] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6
