### PR TITLE
Add fix for compatibility with WooCommerce Smart Coupons

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -582,6 +582,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
+
+			// Prevent WooCommerce Smart Coupons from removing the applied gift card amount when calculating totals the second time
+			if ( WC()->cart->smart_coupon_credit_used ) {
+                WC()->cart->smart_coupon_credit_used = array();
+            }
+
 			new WC_Cart_Totals( $wc_cart_object );
 			remove_action( 'woocommerce_after_calculate_totals', array( $this, 'calculate_totals' ), 20 );
 			do_action( 'woocommerce_after_calculate_totals', $wc_cart_object );


### PR DESCRIPTION
When running the TaxJar plugin with WooCommerce Smart Coupons installed, there was an issue where when the user used applied a gift card coupon and placed an order, the applied value of the gift card would go to zero (thus not reducing the amount the customer needed to pay) even though the gift cards value was still reduced by the order amount.

There is logic built into the WooCommerce Smart Coupons plugin that runs before WooCommerce calculates the totals for the cart. This logic checks to see if any gift cards have been applied and if so it prevents them from being applied again. This is in place to prevent a gift card from being double applied and it works great in normal circumstances.

However when run in combination with the TaxJar plugin it presents an issue. In order for tax to be accurately calculated, the coupons and gift cards used in an order have to be taken into account. However, WooCommerce does the coupon calculations after it has initially calculated the cart totals. The way the TaxJar plugin compensates for this is by letting WooCommerce do its initial cart and coupon calculations normally, then calculating the correct taxes for the order and finally making WooCommerce rerun the totals calculations to get the final and correct totals for the cart.

This is where the problem lies. When the TaxJar plugin forces WooCommerce to recalculate the totals, the Smart Coupon plugin detects that it has already applied the coupon and prevents it from being applied again. But because TaxJar has altered the cart during the tax calculation (and in effect removed the applied gift card amount), the Smart Coupon plugin needs to rerun the portion of the code so that the gift card will be calculated and applied again to the order.

This PR solves the issue by removing the indicator in the cart that the Smart Coupon plugin uses to determine if it has already applied the gift card before triggering WooCommerce to calculate the cart totals the second time. Once that indicator is removed, the Smart Coupon plugin will correctly apply the gift card again.

**Steps to Reproduce**

1. Install and configure the TaxJar plugin
2. Install WooCommerce Smart Coupons
3. Create a gift card for any amount greater than 0.
4. Add a product to the cart and apply the created gift code.
5. Go to the checkout page and you will see that the applied gift card amount goes to $0 and the cart total is the same as if no gift card is applied.
6. Place the test order, and on the order record you will notice the same as what was shown on checkout. Also the gift card will have been reduced in value as if it was applied correctly (even though it wasn't).

**Expected Result**

After applying the PR, when using the steps to replicate above, on the checkout you will see that the gift card applies for the correct value and when the order is placed the gift card will have applied correctly (reducing the cart total by the amount of the giftcard, or to $0 if the giftcard is greater than the order total).

**Click-Test Versions**

- [X] Woo 3.5
- [X] Woo 3.4
- [ ] Woo 3.3
- [X] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
- [ ] Woo 2.6

**Specs Passing**

- [X] Woo 3.5
- [X] Woo 3.4
- [ ] Woo 3.3
- [X] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
- [ ] Woo 2.6

Note: The latest version of WooCommerce Smart Coupons in not compatible with WooCommerce 2.6 or 3.0, so this fix could not be tested against those versions.
