### PR TITLE
Fix exempt products getting taxed on back end

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -770,9 +770,9 @@ class WC_Taxjar_Integration extends WC_Integration {
 			$tax_class = explode( '-', $tax_class_name );
 			$tax_code = '';
 
-			if ( isset( $tax_class[1] ) && is_numeric( $tax_class[1] ) ) {
-				$tax_code = $tax_class[1];
-			}
+            if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
+                $tax_code = end( $tax_class );
+            }
 
 			if ( 'taxable' !== $tax_status ) {
 				$tax_code = '99999';


### PR DESCRIPTION
There was an issue where when calculating the taxes for an order created on the backend, some products with an exempt tax class were still being taxed. This was caused by the method that pulled out the line items from the order. It would grab the tax class for each line item, for example clothing-rate-20010, and then it would attempt to pull out the TaxJar category ID from that string. However, the logic was built so that it explode the string into an array with the hyphen as the delimiter. It then always selected the second element in the array. In the example mentioned it selected `rate` instead of `20010`. Since the array element it selected was not an integer, it treated it as if there was no tax class when it made the request to the TaxJar API. 

This PR fixes the issue by altering the logic so that it will always pull the last element of the array (the exploded tax class), instead of the second element. Changing this logic aligns the method with the logic in the method that gets the line items from orders on the front end.

**Steps to Reproduce**

1. Install and configure the TaxJar plugin
2. Configure a product with an exempt tax class (clothing-rate-20010)
3. Create an order on the backend, add that product to the order and calculate the taxes/totals
4. You will see that the line item with the exemption still gets tax calculated and applied to it.

**Expected Result**

After applying the PR, when you create the order in step 4, the line item will no longer have tax applied to it.

**Click-Test Versions**

- [X] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6

**Specs Passing**

- [X] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6
