### PR TITLE
Validate zip codes before performing API requests

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -985,7 +985,7 @@ class WC_Taxjar_Integration extends WC_Integration {
             'AU' => '/^\d{4}$/',
         );
 
-	    if ( isset( $postal_regexes[$to_country] ) ) {
+	    if ( isset( $postal_regexes[ $to_country ] ) ) {
 
 	        // SmartCalcs api allows requests with no zip codes outside of the US, mark them as valid
 	        if ( empty( $to_zip ) ) {
@@ -996,7 +996,7 @@ class WC_Taxjar_Integration extends WC_Integration {
                 }
             }
 
-	        if ( preg_match( $postal_regexes[$to_country], $to_zip ) === 0 ) {
+	        if ( preg_match( $postal_regexes[ $to_country ], $to_zip ) === 0 ) {
                 $this->_log( ':::: Postal code ' . $to_zip . ' is invalid for country ' . $to_country . ', API request stopped. ::::' );
 	            return false;
             }

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -310,6 +310,12 @@ class WC_Taxjar_Integration extends WC_Integration {
 			return false;
 		}
 
+		// Valid zip codes to prevent unnecessary API requests
+        if ( ! $this->is_postal_code_valid( $to_country, $to_state, $to_zip ) ) {
+            //$this->_log( ':::: Order contains invalid ship to zip code ::::' );
+            return false;
+        }
+
 		$taxjar_nexus = new WC_Taxjar_Nexus( $this );
 
 		if ( ! $taxjar_nexus->has_nexus_check( $to_country, $to_state ) ) {
@@ -961,6 +967,45 @@ class WC_Taxjar_Integration extends WC_Integration {
 		return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city, $street ) );
 	}
 
+	public function is_postal_code_valid( $to_country, $to_state, $to_zip ) {
+
+	    $postal_regexes = array(
+            'US' => '/^\d{5}([ \-]\d{4})?$/',
+            'CA' => '/^[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ ]?\d[ABCEGHJ-NPRSTV-Z]\d$/',
+            'UK' => '/^GIR[ ]?0AA|((AB|AL|B|BA|BB|BD|BH|BL|BN|BR|BS|BT|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}))|BFPO[ ]?\d{1,4}$/',
+            'FR' => '/^\d{2}[ ]?\d{3}$/',
+            'IT' => '/^\d{5}$/',
+            'DE' => '/^\d{5}$/',
+            'NL' => '/^\d{4}[ ]?[A-Z]{2}$/',
+            'ES' => '/^\d{5}$/',
+            'DK' => '/^\d{4}$/',
+            'SE' => '/^\d{3}[ ]?\d{2}$/',
+            'BE' => '/^\d{4}$/',
+            'IN' => '/^\d{6}$/',
+            'AU' => '/^\d{4}$/',
+        );
+
+	    if ( isset( $postal_regexes[$to_country] ) ) {
+
+	        // SmartCalcs api allows requests with no zip codes outside of the US, mark them as valid
+	        if ( empty( $to_zip ) ) {
+	            if ( $to_country == 'US' ) {
+	                return false;
+                } else {
+	                return true;
+                }
+            }
+
+	        if ( preg_match( $postal_regexes[$to_country], $to_zip ) === 0 ) {
+                $this->_log( ':::: Postal code ' . $to_zip . ' is invalid for country ' . $to_country . ', API request stopped. ::::' );
+	            return false;
+            }
+
+        }
+
+	    return true;
+    }
+
 	/**
 	 * Return either the post value or settings value of a key
 	 *
@@ -975,16 +1020,16 @@ class WC_Taxjar_Integration extends WC_Integration {
             $val = $this->settings[ $key ];
         }
 
-		if ( 'yes' == $val ) {
-			$val = 1;
-		}
+        if ( 'yes' == $val ) {
+            $val = 1;
+        }
 
-		if ( 'no' == $val ) {
-			$val = 0;
-		}
+        if ( 'no' == $val ) {
+            $val = 0;
+        }
 
-		return $val;
-	}
+        return $val;
+    }
 
 	/**
 	 * Check if there is an existing WooCommerce 2.4 API Key

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -312,7 +312,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 		// Valid zip codes to prevent unnecessary API requests
         if ( ! $this->is_postal_code_valid( $to_country, $to_state, $to_zip ) ) {
-            //$this->_log( ':::: Order contains invalid ship to zip code ::::' );
             return false;
         }
 
@@ -968,7 +967,6 @@ class WC_Taxjar_Integration extends WC_Integration {
 	}
 
 	public function is_postal_code_valid( $to_country, $to_state, $to_zip ) {
-
 	    $postal_regexes = array(
             'US' => '/^\d{5}([ \-]\d{4})?$/',
             'CA' => '/^[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ ]?\d[ABCEGHJ-NPRSTV-Z]\d$/',
@@ -986,7 +984,6 @@ class WC_Taxjar_Integration extends WC_Integration {
         );
 
 	    if ( isset( $postal_regexes[ $to_country ] ) ) {
-
 	        // SmartCalcs api allows requests with no zip codes outside of the US, mark them as valid
 	        if ( empty( $to_zip ) ) {
 	            if ( $to_country == 'US' ) {
@@ -1000,7 +997,6 @@ class WC_Taxjar_Integration extends WC_Integration {
                 $this->_log( ':::: Postal code ' . $to_zip . ' is invalid for country ' . $to_country . ', API request stopped. ::::' );
 	            return false;
             }
-
         }
 
 	    return true;

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -1244,7 +1244,6 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 	}
 
 	function test_is_postal_code_valid() {
-
 	    $postal_array = array(
             'US' => array(
               '60515630-968-2144' => false,
@@ -1363,11 +1362,10 @@ class TJ_WC_Actions extends WP_UnitTestCase {
             )
         );
 
-	    foreach( $postal_array as $country => $codes ) {
-	        foreach( $codes as $code => $expected ) {
+	    foreach ( $postal_array as $country => $codes ) {
+	        foreach ( $codes as $code => $expected ) {
                 $this->assertEquals( $this->tj->is_postal_code_valid( $country, null, $code ), $expected );
             }
         }
-
     }
 }

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -840,7 +840,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
 			'store_country' => 'AU',
 			'store_state' => 'NSW',
-			'store_postcode' => 'NSW 2000',
+			'store_postcode' => '2000',
 			'store_city' => 'Sydney',
 		) );
 
@@ -848,7 +848,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
 			'country' => 'AU',
 			'state' => 'VIC',
-			'zip' => 'VIC3002',
+			'zip' => '3002',
 			'city' => 'Richmond',
 		) );
 

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -1242,4 +1242,132 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			$this->assertEquals( $recurring_cart->get_taxes_total(), 1.77, '', 0.01 );
 		}
 	}
+
+	function test_is_postal_code_valid() {
+
+	    $postal_array = array(
+            'US' => array(
+              '60515630-968-2144' => false,
+              '' => false,
+              '1' => false,
+              '12' => false,
+              '123' => false,
+              '1234' => false,
+              '12345-' => false,
+              '12345-1' => false,
+              '23451-123' => false,
+              '12345-12345' => false,
+              'A1111' => false,
+              'ACDES' => false,
+              '12345' => true,
+              '12345-1234' => true
+            ),
+            'CA' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '1' => false,
+                '12' => false,
+                '12345-1' => false,
+                'A1111' => false,
+                'ACDES' => false,
+                '12345' => false,
+                '12345-1234' => false,
+                'P1P 0G0' => true,
+                'J0T 0P2' => true
+            ),
+            'UK' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => false,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+                'EC1A 1BB' => true,
+                'CR2 6XH' => true
+            ),
+            'FR' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => true,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+                '12 345' => true
+            ),
+            'IT' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => true,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+            ),
+            'DE' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => true,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+            ),
+            'NL' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => false,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+                '1234 AB' => true,
+                '1234AB' => true
+            ),
+            'ES' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => true,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+            ),
+            'DK' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => false,
+                '1234' => true,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+            ),
+            'SE' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => true,
+                '123 45' => true,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+            ),
+            'BE' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => false,
+                '1234' => true,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+            ),
+            'IN' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '123456' => true,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+            ),
+            'AU' => array(
+                '60515630-968-2144' => false,
+                '' => true,
+                '12345' => false,
+                '1234' => true,
+                '12345-1234' => false,
+                'P1P 0G0' => false,
+            )
+        );
+
+	    foreach( $postal_array as $country => $codes ) {
+	        foreach( $codes as $code => $expected ) {
+                $this->assertEquals( $this->tj->is_postal_code_valid( $country, null, $code ), $expected );
+            }
+        }
+
+    }
 }


### PR DESCRIPTION
The TaxJar plugin works by sending both the store address as well as the ship to address to the TaxJar SmartCalcs API in order to the correct tax rates for each order. This occurs inside of WooCommerce's processes for calculating the order totals. While on the cart (in some themes) or checkout page, each time an end user updates their shipping information WooCommerce will recalculate the totals and cause an additional API request to SmartCalcs. There is already a caching of rates that occurs to help reduce the number of calls to the SmartCalcs API, however rates are only pulled from the cache when there is an exact match to an order (so all the shipping details have to perfectly match). In some themes and situations each character a user enters may cause WooCommerce to recalculate the totals and make a different API request to SmartCalcs. This in turn causes a higher cost to the merchants as use of the SmartCalcs API is billed by the number of requests. Often the request just returns no rates as the zip codes are invalid until the user finishes entering them completely.

This PR solves the issue, and the secondary issue of the user just entering an invalid zip code by validating the zip codes before the API request is performed. The validation method uses the same logic that is present in the SmartCalcs API, so that any request that would have previously returned an error regarding an invalid zip code will skip the request and fall back on the existing rates in WooCommerce (that was the normal functionality after the error was returned from SmartCalcs). This will reduce the number of unnecessary calls to the SmartCalcs API and reduce merchant costs.

**Steps to Reproduce**

1. Enable and configure the TaxJar plugin and enable the logs
2. Add any taxable product to the cart and go to checkout
3. Enter shipping information with an invalid postal code for the country selected
4. Check the logs and you will see that the SmartCalcs API returned an error regarding the invalid zip code. 

**Expected Result**

After applying the PR and performing the above steps, the logs will indicate the the API request was skipped due to an invalid zip code.

Note: For the US, the SmartCalcs API does not except an empty zip code. However, internationally it does. This PR imitates that logic when validating zip codes.

**Click-Test Versions**

- [X] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [X] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
- [X] Woo 2.6

**Specs Passing**

- [X] Woo 3.5
- [X] Woo 3.4
- [x] Woo 3.3
- [X] Woo 3.2
- [x] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6
