### PR TITLE
Update bootstrap to completely clear woocommerce data from db before setting up specs

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,12 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		// load woocommerce core
 		require_once $this->plugin_dir . 'woocommerce/woocommerce.php';
 
+		// completely remove woocommerce data from DB
+        define( 'WP_UNINSTALL_PLUGIN', true );
+        define( 'WC_REMOVE_ALL_DATA', true );
+        update_option( 'woocommerce_status_options', array( 'uninstall_data' => 1 ) );
+        include $this->plugin_dir . 'woocommerce/uninstall.php';
+
 		// load taxjar core
 		require_once $this->plugin_dir . 'taxjar-woocommerce-plugin/taxjar-woocommerce.php';
 
@@ -42,11 +48,6 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		require_once $this->tests_dir . '/framework/product-helper.php';
 		require_once $this->tests_dir . '/framework/shipping-helper.php';
 
-		// load woocommerce subscriptions
-		update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
-		update_option( 'woocommerce_db_version', WC_VERSION );
-		TaxJar_Woocommerce_Helper::prepare_woocommerce();
-		require_once $this->plugin_dir . 'woocommerce-subscriptions/woocommerce-subscriptions.php';
 	}
 
 	public function setup() {
@@ -66,8 +67,12 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		update_option( 'woocommerce_calc_shipping', 'yes' );
 		update_option( 'woocommerce_coupons_enabled', 'yes' );
 
-		$wc_install = new WC_Install;
-		$wc_install->install();
+		WC_Install::install();
+
+		// load woocommerce subscriptions
+        update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
+        update_option( 'woocommerce_db_version', WC_VERSION );
+        require_once $this->plugin_dir . 'woocommerce-subscriptions/woocommerce-subscriptions.php';
 
 		do_action( 'plugins_loaded' );
 		do_action( 'woocommerce_init' );


### PR DESCRIPTION
Previously, when setting up the unit tests, not all of the data was cleared out from the WooCommerce tables in the testing database. This caused sometime unexpected effects, including causing tests to fail when run in a group but pass successfully when run individually. This PR updates the bootstrap file in order to completely clear the database before reinstalling WooCommerce. This PR also eliminates an unnecessary call to the prepare_woocommerce helper function. There is no need to run it in the bootstrap file as it will be run when each test is setup.

**Steps to Reproduce**

The steps to reproduce the issues are inconsistent. However I was able to confirm the issue no longer occurred once the PR was applied.

1. Setup unit tests on a clean install
2. Run all unit tests
3. One unit test will fail during initial run
4. Rerun unit tests
5. This time all will pass

**Expected Result**

After applying the PR, the flaky spec will not fail when running for the first time on a clean install.

**Specs Passing**

- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6
