### PR TITLE
Fix floating point precision issue when handling exempt products

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -841,7 +841,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 			foreach ( $this->response_line_items as $line_item_key => $line_item ) {
 				// If line item belongs to rate and matches the price, manually set the tax
-				if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_total ) {
+				if ( in_array( $line_item_key, $line_items ) && round( $price, 2 ) == round( $line_item->line_total, 2 ) ) {
 					if ( function_exists( 'wc_add_number_precision' ) ) {
 						$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
 					} else {


### PR DESCRIPTION
When an order was being placed with larger number of exempt products in the cart, occasionally some of those exempt products where having tax applied to them. This was due to a floating point precision error in the override_woocommerce_tax_rates method. When comparing two floats using the == operator, it can return false on two seemingly the same doubles do to a different level of precision. This PR fixes the issue by using the round method to ensure the doubles being compared have the same level of precision. 

**Steps to Reproduce**

1. Create a product and add a tax exempt class to it (such as Clothing - 20010) 
2. Add a high quantity of the item to the cart (I was using a product that had a price of 14.95, and adding 14 of them to the cart would always replicate the error).
3. Check the calculated taxes. You will see that even though the product is exempt, tax are being applied to the line item.

**Expected Result**

After applying the PR, on step 3 no taxes will be applied to the line item.

**Click-Test Versions**

- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6

**Specs Passing**

- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6
