### PR TITLE
Confirm compatibility with WooCommerce 3.6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Stable tag: 2.1.0
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 2.6.0
-WC tested up to: 3.5.0
+WC tested up to: 3.6.1
 
 Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculations, reporting, and filing.
 

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -7,7 +7,7 @@
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 2.6.0
- * WC tested up to: 3.5.0
+ * WC tested up to: 3.6.1
  *
  * Copyright: © 2014-2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc.
  * License: GNU General Public License v2.0 or later


### PR DESCRIPTION
Updated plugin to indicate compatibility with WooCommerce 3.6.1

**Click-Test Versions**

- [X] Woo 3.6.1

**Specs Passing**

- [X] Woo 3.6.1

