### PR TITLE
Pi 111 exempt shipping redundant calcs

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -588,15 +588,19 @@ class WC_Taxjar_Integration extends WC_Integration {
 		// ensure fully exempt orders have no tax on shipping
 		if ( ! $taxes[ 'freight_taxable' ] ) {
 			foreach ( $wc_cart_object->get_shipping_packages() as $package_key => $package ) {
-				$shipping_for_package =  WC()->session->get( 'shipping_for_package_' . $package_key );
-				if ( !empty( $shipping_for_package[ 'rates' ] ) ) {
+				$shipping_for_package = WC()->session->get( 'shipping_for_package_' . $package_key );
+				if ( ! empty( $shipping_for_package['rates'] ) ) {
 					foreach ( $shipping_for_package['rates'] as $shipping_rate ) {
-						$shipping_rate->set_taxes( array() );
+						if ( method_exists( $shipping_rate, 'set_taxes' ) ) {
+							$shipping_rate->set_taxes( array() );
+						} else {
+							$shipping_rate->taxes = array();
+						}
+						WC()->session->set( 'shipping_for_package_' . $package_key, $shipping_for_package );
 					}
-					WC()->session->set( 'shipping_for_package_' . $package_key, $shipping_for_package );
 				}
 			}
-        }
+		}
 
 		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );


### PR DESCRIPTION
The code replaced in this PR was originally added in order to ensure that when an order only contained fully exempt items, no tax was charged on the shipping for the order. However this code had been reported to cause issues with various shipping method plugins due to it overriding the cached shipping rates and setting them to null, which caused the shipping to have to be recalculated an extra time during the tax calculation. This PR fixes the issue by actually setting the cached shipping rate tax amount to $0 for fully exempt orders, rather than removing it and letting the shipping recalculate.

**Steps to Reproduce**

1. Enable TaxJar and USPS shipping
2. Create a USPS shipping rate and turn on debug mode, you also must make sure the rate is set to calculate shipping for the entire order (not individual packages for each line).
3. Add two items to the cart (on exempt and one not exempt) and then go to the cart page. Remove the non exempt item from the cart.
4. You will see that the USPS API was called 3 times.

**Expected Result**

After applying the PR, when looking at the cart page in step 4 you should only see 1 or 2 calls to the USPS API. This depends on a number of factors and is how the USPS plugin itself is built. We also still have to trigger an extra call as we must cause the cart to recalculate totals a second time.
**Click-Test Versions**

- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6

**Specs Passing**

- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
- [X] Woo 2.6
