### PR TITLE
Add filter to enable dynamic tax codes

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -924,7 +924,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 		}
 
-		return $line_items;
+		return apply_filters( 'taxjar_get_backend_line_items', $line_items, $order, $this );
 	}
 
 	protected function get_line_item( $id, $line_items ) {

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -870,7 +870,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 			}
 		}
 
-		return $line_items;
+		return apply_filters( 'taxjar_get_line_items', $line_items, $wc_cart_object, $this );
 	}
 
 	/**


### PR DESCRIPTION
Adds the filter requested in [this issue](https://github.com/taxjar/taxjar-woocommerce-plugin/issues/110) so we can get the correct tax behavior for our services without having to modify the taxjar plugin directly.