### PR TITLE
WooCommerce 3.7 Support

### DIFF
--- a/tests/framework/product-helper.php
+++ b/tests/framework/product-helper.php
@@ -12,49 +12,28 @@ class TaxJar_Product_Helper {
 
 	private static function create_simple_product( $opts = array() ) {
 		$defaults = array(
-			'price' => '10',
-			'sku' => 'SIMPLE1',
-			'tax_class' => '',
-			'tax_status' => 'taxable',
-			'downloadable' => 'no',
-			'virtual' => 'no',
+			'name'          => 'Dummy Product',
+			'price'         => 10,
+			'sku'           => 'SIMPLE1',
+			'manage_stock'  => false,
+			'tax_status'    => 'taxable',
+			'downloadable'  => false,
+			'virtual'       => false,
+			'stock_status'  => 'instock',
+			'weight'        => '1.1',
 		);
 
-		$post = array(
-			'post_title' => 'Dummy Product',
-			'post_type' => 'product',
-			'post_status' => 'publish',
-		);
-		$post_meta = array_replace_recursive( $defaults, $opts );
-		$post_meta['regular_price'] = $post_meta['price'];
+		$props = array_replace_recursive( $defaults, $opts );
+		$props[ 'regular_price' ] = $props[ 'price' ];
+		$product = new WC_Product_Simple();
+		$product->set_props( $props );
 
-		$post_id = wp_insert_post( $post );
+		if ( ! empty( $opts[ 'tax_class' ] ) ) {
+			$product->set_tax_class( $opts[ 'tax_class' ] );
+		}
 
-		register_taxonomy(
-			'product_type',
-			'product'
-		);
-
-		update_post_meta( $post_id, '_price', $post_meta['price'] );
-		update_post_meta( $post_id, '_regular_price', $post_meta['regular_price'] );
-		update_post_meta( $post_id, '_sale_price', '' );
-		update_post_meta( $post_id, '_sku', $post_meta['sku'] );
-		update_post_meta( $post_id, '_manage_stock', 'no' );
-		update_post_meta( $post_id, '_tax_class', $post_meta['tax_class'] );
-		update_post_meta( $post_id, '_tax_status', $post_meta['tax_status'] );
-		update_post_meta( $post_id, '_downloadable', $post_meta['downloadable'] );
-		update_post_meta( $post_id, '_virtual', $post_meta['virtual'] );
-		update_post_meta( $post_id, '_stock_status', 'instock' );
-
-		wp_set_object_terms( $post_id, 'simple', 'product_type' );
-
-		$products = get_posts( array(
-			'post_type' => 'product',
-			'_sku' => $post_meta['sku'],
-		) );
-
-		$factory = new WC_Product_Factory();
-		return $factory->get_product( $products[0]->ID );
+		$product->save( );
+		return wc_get_product( $product->get_id() );
 	}
 
 	private static function create_subscription_product( $opts = array() ) {

--- a/tests/framework/woocommerce-helper.php
+++ b/tests/framework/woocommerce-helper.php
@@ -33,6 +33,10 @@ class TaxJar_Woocommerce_Helper {
 		// WooCommerce 3.2 checks for a valid class
 		update_option( 'woocommerce_tax_classes', "Reduced rate\nZero Rate\nClothing Rate - 20010" );
 
+		if ( version_compare( WC()->version, '3.7.0', '>=' ) ) {
+			WC_Tax::create_tax_class( 'Clothing Rate - 20010' );
+		}
+
 		// Allow calculate_totals to run in specs for WooCommerce < 3.2
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
 			define( 'WOOCOMMERCE_CART', true );

--- a/tests/specs/test-class-subscriptions.php
+++ b/tests/specs/test-class-subscriptions.php
@@ -369,9 +369,6 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		}
 	}
 
-	/**
-	 * @expectedDeprecated get_used_coupons
-	 */
 	function test_correct_taxes_for_subscription_recurring_order() {
 		wp_set_current_user( $this->user );
 
@@ -401,9 +398,6 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
-	/**
-	 * @expectedDeprecated get_used_coupons
-	 */
 	function test_correct_taxes_for_subscription_recurring_order_with_one_month_trial() {
 		wp_set_current_user( $this->user );
 
@@ -444,9 +438,6 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
-	/**
-	 * @expectedDeprecated get_used_coupons
-	 */
 	function test_correct_taxes_for_subscription_recurring_order_with_trial_and_signup_fee() {
 		wp_set_current_user( $this->user );
 
@@ -486,10 +477,7 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
-
-	/**
-	 * @expectedDeprecated get_used_coupons
-	 */
+	
 	function test_correct_taxes_for_subscription_recurring_order_with_multiple_products() {
 		wp_set_current_user( $this->user );
 

--- a/tests/specs/test-class-subscriptions.php
+++ b/tests/specs/test-class-subscriptions.php
@@ -369,6 +369,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		}
 	}
 
+	/**
+	 * @expectedDeprecated get_used_coupons
+	 */
 	function test_correct_taxes_for_subscription_recurring_order() {
 		wp_set_current_user( $this->user );
 
@@ -398,6 +401,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
+	/**
+	 * @expectedDeprecated get_used_coupons
+	 */
 	function test_correct_taxes_for_subscription_recurring_order_with_one_month_trial() {
 		wp_set_current_user( $this->user );
 
@@ -438,6 +444,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
+	/**
+	 * @expectedDeprecated get_used_coupons
+	 */
 	function test_correct_taxes_for_subscription_recurring_order_with_trial_and_signup_fee() {
 		wp_set_current_user( $this->user );
 
@@ -478,6 +487,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
+	/**
+	 * @expectedDeprecated get_used_coupons
+	 */
 	function test_correct_taxes_for_subscription_recurring_order_with_multiple_products() {
 		wp_set_current_user( $this->user );
 


### PR DESCRIPTION
This PR adds support for WooCommerce 3.7

**Click-Test Versions**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0


**Specs Passing**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
