### PR TITLE
Tax Rate Lookup State Containing Space Fix

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -459,13 +459,24 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'tax_rate_class' => $tax_class,
 		);
 
-		$wc_rate = WC_Tax::find_rates( array(
-			'country' => $location['to_country'],
-			'state' => sanitize_key( $location['to_state'] ),
-			'postcode' => $location['to_zip'],
-			'city' => $location['to_city'],
-			'tax_class' => $tax_class,
-		) );
+		if ( version_compare( WC()->version, '3.2.0', '<' ) ) {
+			$wc_rate = WC_Tax::find_rates( array(
+				'country' => $location['to_country'],
+				'state' => $location['to_state'],
+				'postcode' => $location['to_zip'],
+				'city' => $location['to_city'],
+				'tax_class' => $tax_class,
+			) );
+        } else {
+			$wc_rate = WC_Tax::find_rates( array(
+				'country' => $location['to_country'],
+				'state' => sanitize_key( $location['to_state'] ),
+				'postcode' => $location['to_zip'],
+				'city' => $location['to_city'],
+				'tax_class' => $tax_class,
+			) );
+        }
+
 
 		if ( ! empty( $wc_rate ) ) {
 			$this->_log( ':: Tax Rate Found ::' );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -459,25 +459,19 @@ class WC_Taxjar_Integration extends WC_Integration {
 			'tax_rate_class' => $tax_class,
 		);
 
-		if ( version_compare( WC()->version, '3.2.0', '<' ) ) {
-			$wc_rate = WC_Tax::find_rates( array(
-				'country' => $location['to_country'],
-				'state' => $location['to_state'],
-				'postcode' => $location['to_zip'],
-				'city' => $location['to_city'],
-				'tax_class' => $tax_class,
-			) );
-        } else {
-			$wc_rate = WC_Tax::find_rates( array(
-				'country' => $location['to_country'],
-				'state' => sanitize_key( $location['to_state'] ),
-				'postcode' => $location['to_zip'],
-				'city' => $location['to_city'],
-				'tax_class' => $tax_class,
-			) );
-        }
+		$rate_lookup = array(
+			'country' => $location['to_country'],
+			'state' => $location['to_state'],
+			'postcode' => $location['to_zip'],
+			'city' => $location['to_city'],
+			'tax_class' => $tax_class,
+		);
 
-
+		if ( version_compare( WC()->version, '3.2.0', '>=' ) ) {
+			$rate_lookup['state'] = sanitize_key( $location['to_state'] );
+		}
+		
+		$wc_rate = WC_Tax::find_rates( $rate_lookup );
 		if ( ! empty( $wc_rate ) ) {
 			$this->_log( ':: Tax Rate Found ::' );
 			$this->_log( $wc_rate );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -470,8 +470,9 @@ class WC_Taxjar_Integration extends WC_Integration {
 		if ( version_compare( WC()->version, '3.2.0', '>=' ) ) {
 			$rate_lookup['state'] = sanitize_key( $location['to_state'] );
 		}
-		
+
 		$wc_rate = WC_Tax::find_rates( $rate_lookup );
+
 		if ( ! empty( $wc_rate ) ) {
 			$this->_log( ':: Tax Rate Found ::' );
 			$this->_log( $wc_rate );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -461,7 +461,7 @@ class WC_Taxjar_Integration extends WC_Integration {
 
 		$wc_rate = WC_Tax::find_rates( array(
 			'country' => $location['to_country'],
-			'state' => $location['to_state'],
+			'state' => sanitize_key( $location['to_state'] ),
 			'postcode' => $location['to_zip'],
 			'city' => $location['to_city'],
 			'tax_class' => $tax_class,

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -1070,4 +1070,17 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		WC()->session->set( 'chosen_shipping_methods', array() );
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
+
+	function test_tax_lookup_state_with_space() {
+		$location = array(
+			'to_country' => 'GB',
+			'to_state' => 'West Sussex',
+			'to_zip' => 'BN15 1S2',
+			'to_city' => 'London'
+		);
+		$rate_id = $this->tj->create_or_update_tax_rate( $location, 10 );
+		$found_rate_id = $this->tj->create_or_update_tax_rate( $location, 10 );
+
+		$this->assertEquals( $rate_id, $found_rate_id );
+	}
 }


### PR DESCRIPTION
When placing orders outside of the US, there was an issue that occurred when the state field (can be called other names depending on the country) contained a space. An example of this is "West Sussex". When this is entered at checkout, the plugin would perform the API request to get the rates and insert them into WooCommerce's tax rate table. However when during the calculations, and we attempt to look up the rate in the table it would never be found. This is due to WooCommerce sanitizing the state field with the sanitize_key function when inserting the rate (which removes the space), but neglecting to do this during the rate lookup. This PR fixes the issue by performing the same sanitation before doing the lookup in the affected WooCommerce versions.

**Steps to Reproduce**

1. Add and item to cart and go to checkout
2. Enter an international address with the state field having a space in it.
3. Tax will not be calculated on the order as the rate saved during the API request will not be found

**Expected Result**

After applying the PR, on step 3 tax will be correctly calculated for the order.

**Click-Test Versions**

- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
