### PR TITLE
Include Customer ID in Backend Order Tax Calculation

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -849,7 +849,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			$shipping = $order->get_total_shipping(); // Woo 2.6
 		}
 
-		$customer_id = apply_filters( 'taxjar_get_customer_id', $order->get_customer_id() );
+		$customer_id = isset( $_POST[ 'customer_user' ] ) ? wc_clean( $_POST[ 'customer_user' ] ) : 0;
 
 		$taxes = $this->calculate_tax( array(
 			'to_country' => $address['to_country'],

--- a/includes/js/wc-taxjar-order.js
+++ b/includes/js/wc-taxjar-order.js
@@ -19,7 +19,13 @@ jQuery( document ).ready( function() {
 							street = $( '#_billing_address_1' ).val();
 						}
 
+						var customer_user = '';
+						if ( $( '#customer_user' ).val() ) {
+							customer_user = $( '#customer_user' ).val();
+						}
+
 						data.street = street;
+						data.customer_user = customer_user;
 						settings.data = $.param( data );
 					}
 				} catch ( e ) {


### PR DESCRIPTION
Previously, the customer id was not included when creating an order on the backend. This PR resolves the issue.
