### PR TITLE
Beta Version 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.1 (2019-08-09)
+* Add hooks to allow setting of order level exemptions during tax calculation and order syncing
+* Fix issue syncing refunds with zero quantity line items
+* Fix refunds created while order processing not syncing when order completed
+* Add fallback to billing address when shipping address is empty on sync
+
 # 3.0.0 (2019-08-06)
 * Added transaction sync order push to TaxJar
 * Added customer sync to TaxJar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Fix issue syncing refunds with zero quantity line items
 * Fix refunds created while order processing not syncing when order completed
 * Add fallback to billing address when shipping address is empty on sync
+* Add filters to allow altering currency and country validation before syncing
+* Add filters to allow altering of request data before syncing orders and refunds
 
 # 3.0.0 (2019-08-06)
 * Added transaction sync order push to TaxJar

--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -364,6 +364,20 @@ abstract class TaxJar_Record {
 		return $wpdb->prefix . self::QUEUE_NAME;
 	}
 
+	/**
+	 * @return array - Country codes that will pass validation when syncing records
+	 */
+	public static function allowed_countries() {
+		return apply_filters( 'taxjar_sync_allowed_countries', array ( 'US' ) );
+	}
+
+	/**
+	 * @return array - Currencies that will pass validation when syncing records
+	 */
+	public static function allowed_currencies() {
+		return apply_filters( 'taxjar_sync_allowed_currencies', array ( 'USD' ) );
+	}
+
 	public function set_queue_id( $queue_id ) {
 		$this->queue_id = $queue_id;
 	}

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -211,6 +211,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 		}
 
 		$exemption_type = apply_filters( 'taxjar_order_sync_exemption_type', '', $this->object );
+
 		if ( WC_Taxjar_Integration::is_valid_exemption_type( $exemption_type ) ) {
 			$order_data[ 'exemption_type' ] = $exemption_type;
 		}

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -216,8 +216,8 @@ class TaxJar_Order_Record extends TaxJar_Record {
 			$order_data[ 'exemption_type' ] = $exemption_type;
 		}
 
+		$order_data = apply_filters( 'taxjar_order_sync_data', $order_data, $this->object );
 		$this->data = $order_data;
-
 		return $order_data;
 	}
 

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -52,13 +52,13 @@ class TaxJar_Order_Record extends TaxJar_Record {
 
 		$order_data = $this->get_data();
 
-		if ( $order_data[ 'to_country' ] != 'US' ) {
-			$this->add_error( __( 'Order failed validation, ship to country not US', 'wc-taxjar' ) );
+		if ( ! in_array( $order_data[ 'to_country' ], TaxJar_Record::allowed_countries() ) ) {
+			$this->add_error( __( 'Order failed validation, ship to country did not pass validation', 'wc-taxjar' ) );
 			return false;
 		}
 
-		if ( $this->object->get_currency() != 'USD' ) {
-			$this->add_error( __( 'Order failed validation, currency not USD.', 'wc-taxjar' ) );
+		if ( ! in_array( $this->object->get_currency(), TaxJar_Record::allowed_currencies() ) ) {
+			$this->add_error( __( 'Order failed validation, currency did not pass validation.', 'wc-taxjar' ) );
 			return false;
 		}
 

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -210,6 +210,11 @@ class TaxJar_Order_Record extends TaxJar_Record {
 			$order_data[ 'customer_id' ] = $customer_id;
 		}
 
+		$exemption_type = apply_filters( 'taxjar_order_sync_exemption_type', '', $this->object );
+		if ( WC_Taxjar_Integration::is_valid_exemption_type( $exemption_type ) ) {
+			$order_data[ 'exemption_type' ] = $exemption_type;
+		}
+
 		$this->data = $order_data;
 
 		return $order_data;

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -240,17 +240,17 @@ class TaxJar_Order_Record extends TaxJar_Record {
 			$city     = $store_settings['city'];
 			$street   = $store_settings['street'];
 		} elseif ( 'billing' === $tax_based_on ) {
-			$country  = $this->object->get_billing_country();
-			$state    = $this->object->get_billing_state();
-			$postcode = $this->object->get_billing_postcode();
-			$city     = $this->object->get_billing_city();
-			$street   = $this->object->get_billing_address_1();
+			$country  = ( ! empty( $this->object->get_billing_country() ) ? $this->object->get_billing_country() : $this->object->get_shipping_country() );
+			$state  = ( ! empty( $this->object->get_billing_state() ) ? $this->object->get_billing_state() : $this->object->get_shipping_state() );
+			$postcode  = ( ! empty( $this->object->get_billing_postcode() ) ? $this->object->get_billing_postcode() : $this->object->get_shipping_postcode() );
+			$city  = ( ! empty( $this->object->get_billing_city() ) ? $this->object->get_billing_city() : $this->object->get_shipping_city() );
+			$street  = ( ! empty( $this->object->get_billing_address_1() ) ? $this->object->get_billing_address_1() : $this->object->get_shipping_address_1() );
 		} else {
-			$country  = $this->object->get_shipping_country();
-			$state    = $this->object->get_shipping_state();
-			$postcode = $this->object->get_shipping_postcode();
-			$city     = $this->object->get_shipping_city();
-			$street   = $this->object->get_shipping_address_1();
+			$country  = ( ! empty( $this->object->get_shipping_country() ) ? $this->object->get_shipping_country() : $this->object->get_billing_country() );
+			$state  = ( ! empty( $this->object->get_shipping_state() ) ? $this->object->get_shipping_state() : $this->object->get_billing_state() );
+			$postcode  = ( ! empty( $this->object->get_shipping_postcode() ) ? $this->object->get_shipping_postcode() : $this->object->get_billing_postcode() );
+			$city  = ( ! empty( $this->object->get_shipping_city() ) ? $this->object->get_shipping_city() : $this->object->get_billing_city() );
+			$street  = ( ! empty( $this->object->get_shipping_address_1() ) ? $this->object->get_shipping_address_1() : $this->object->get_billing_address_1() );
 		}
 
 		$to_country = isset( $country ) && ! empty( $country ) ? $country : false;

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -129,6 +129,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 			$refund_data[ 'exemption_type' ] = $exemption_type;
 		}
 
+		$refund_data = apply_filters( 'taxjar_refund_sync_data', $refund_data, $this->object, $order );
 		$this->data = $refund_data;
 		return $refund_data;
 	}

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -156,17 +156,17 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 			$city     = $store_settings['city'];
 			$street   = $store_settings['street'];
 		} elseif ( 'billing' === $tax_based_on ) {
-			$country  = $order->get_billing_country();
-			$state    = $order->get_billing_state();
-			$postcode = $order->get_billing_postcode();
-			$city     = $order->get_billing_city();
-			$street   = $order->get_billing_address_1();
+			$country  = ( ! empty( $this->object->get_billing_country() ) ? $this->object->get_billing_country() : $this->object->get_shipping_country() );
+			$state  = ( ! empty( $this->object->get_billing_state() ) ? $this->object->get_billing_state() : $this->object->get_shipping_state() );
+			$postcode  = ( ! empty( $this->object->get_billing_postcode() ) ? $this->object->get_billing_postcode() : $this->object->get_shipping_postcode() );
+			$city  = ( ! empty( $this->object->get_billing_city() ) ? $this->object->get_billing_city() : $this->object->get_shipping_city() );
+			$street  = ( ! empty( $this->object->get_billing_address_1() ) ? $this->object->get_billing_address_1() : $this->object->get_shipping_address_1() );
 		} else {
-			$country  = $order->get_shipping_country();
-			$state    = $order->get_shipping_state();
-			$postcode = $order->get_shipping_postcode();
-			$city     = $order->get_shipping_city();
-			$street   = $order->get_shipping_address_1();
+			$country  = ( ! empty( $this->object->get_shipping_country() ) ? $this->object->get_shipping_country() : $this->object->get_billing_country() );
+			$state  = ( ! empty( $this->object->get_shipping_state() ) ? $this->object->get_shipping_state() : $this->object->get_billing_state() );
+			$postcode  = ( ! empty( $this->object->get_shipping_postcode() ) ? $this->object->get_shipping_postcode() : $this->object->get_billing_postcode() );
+			$city  = ( ! empty( $this->object->get_shipping_city() ) ? $this->object->get_shipping_city() : $this->object->get_billing_city() );
+			$street  = ( ! empty( $this->object->get_shipping_address_1() ) ? $this->object->get_shipping_address_1() : $this->object->get_billing_address_1() );
 		}
 
 		$to_country = isset( $country ) && ! empty( $country ) ? $country : false;

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -193,7 +193,12 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 				$product = $item->get_product();
 
 				$quantity = $item->get_quantity();
-				$unit_price = $item->get_subtotal() / $quantity;
+				if ( $quantity <= 0 ) {
+					$unit_price = $item->get_subtotal();
+					$quantity = 1;
+				} else {
+					$unit_price = $item->get_subtotal() / $quantity;
+				}
 				$discount = $item->get_subtotal() - $item->get_total();
 
 				$tax_class = explode( '-', $product->get_tax_class() );

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -118,11 +118,13 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		$refund_data = array_merge( $refund_data, $ship_to_address );
 
 		$customer_id = $order->get_customer_id();
+
 		if ( $customer_id ) {
 			$refund_data[ 'customer_id' ] = $customer_id;
 		}
 
 		$exemption_type = apply_filters( 'taxjar_refund_sync_exemption_type', '', $this->object );
+
 		if ( WC_Taxjar_Integration::is_valid_exemption_type( $exemption_type ) ) {
 			$refund_data[ 'exemption_type' ] = $exemption_type;
 		}
@@ -193,6 +195,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 				$product = $item->get_product();
 
 				$quantity = $item->get_quantity();
+
 				if ( $quantity <= 0 ) {
 					$unit_price = $item->get_subtotal();
 					$quantity = 1;

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -122,6 +122,11 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 			$refund_data[ 'customer_id' ] = $customer_id;
 		}
 
+		$exemption_type = apply_filters( 'taxjar_refund_sync_exemption_type', '', $this->object );
+		if ( WC_Taxjar_Integration::is_valid_exemption_type( $exemption_type ) ) {
+			$refund_data[ 'exemption_type' ] = $exemption_type;
+		}
+
 		$this->data = $refund_data;
 		return $refund_data;
 	}

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -45,13 +45,13 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 			}
 		}
 
-		if ( $data[ 'to_country' ] != 'US' ) {
-			$this->add_error( __( 'Refund failed validation - parent order ship to country is not US.', 'wc-taxjar' ) );
+		if ( ! in_array( $data[ 'to_country' ], TaxJar_Record::allowed_countries() ) ) {
+			$this->add_error( __( 'Refund failed validation, ship to country did not pass validation', 'wc-taxjar' ) );
 			return false;
 		}
 
-		if ( $this->object->get_currency() != 'USD' ) {
-			$this->add_error( __( 'Refund failed validation - currency is not USD.', 'wc-taxjar' ) );
+		if ( ! in_array( $this->object->get_currency(), TaxJar_Record::allowed_currencies() ) ) {
+			$this->add_error( __( 'Refund failed validation, currency did not pass validation.', 'wc-taxjar' ) );
 			return false;
 		}
 

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -156,17 +156,17 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 			$city     = $store_settings['city'];
 			$street   = $store_settings['street'];
 		} elseif ( 'billing' === $tax_based_on ) {
-			$country  = ( ! empty( $this->object->get_billing_country() ) ? $this->object->get_billing_country() : $this->object->get_shipping_country() );
-			$state  = ( ! empty( $this->object->get_billing_state() ) ? $this->object->get_billing_state() : $this->object->get_shipping_state() );
-			$postcode  = ( ! empty( $this->object->get_billing_postcode() ) ? $this->object->get_billing_postcode() : $this->object->get_shipping_postcode() );
-			$city  = ( ! empty( $this->object->get_billing_city() ) ? $this->object->get_billing_city() : $this->object->get_shipping_city() );
-			$street  = ( ! empty( $this->object->get_billing_address_1() ) ? $this->object->get_billing_address_1() : $this->object->get_shipping_address_1() );
+			$country  = ( ! empty( $order->get_billing_country() ) ? $order->get_billing_country() : $order->get_shipping_country() );
+			$state  = ( ! empty( $order->get_billing_state() ) ? $order->get_billing_state() : $order->get_shipping_state() );
+			$postcode  = ( ! empty( $order->get_billing_postcode() ) ? $order->get_billing_postcode() : $order->get_shipping_postcode() );
+			$city  = ( ! empty( $order->get_billing_city() ) ? $order->get_billing_city() : $order->get_shipping_city() );
+			$street  = ( ! empty( $order->get_billing_address_1() ) ? $order->get_billing_address_1() : $order->get_shipping_address_1() );
 		} else {
-			$country  = ( ! empty( $this->object->get_shipping_country() ) ? $this->object->get_shipping_country() : $this->object->get_billing_country() );
-			$state  = ( ! empty( $this->object->get_shipping_state() ) ? $this->object->get_shipping_state() : $this->object->get_billing_state() );
-			$postcode  = ( ! empty( $this->object->get_shipping_postcode() ) ? $this->object->get_shipping_postcode() : $this->object->get_billing_postcode() );
-			$city  = ( ! empty( $this->object->get_shipping_city() ) ? $this->object->get_shipping_city() : $this->object->get_billing_city() );
-			$street  = ( ! empty( $this->object->get_shipping_address_1() ) ? $this->object->get_shipping_address_1() : $this->object->get_billing_address_1() );
+			$country  = ( ! empty( $order->get_shipping_country() ) ? $order->get_shipping_country() : $order->get_billing_country() );
+			$state  = ( ! empty( $order->get_shipping_state() ) ? $order->get_shipping_state() : $order->get_billing_state() );
+			$postcode  = ( ! empty( $order->get_shipping_postcode() ) ? $order->get_shipping_postcode() : $order->get_billing_postcode() );
+			$city  = ( ! empty( $order->get_shipping_city() ) ? $order->get_shipping_city() : $order->get_billing_city() );
+			$street  = ( ! empty( $order->get_shipping_address_1() ) ? $order->get_shipping_address_1() : $order->get_billing_address_1() );
 		}
 
 		$to_country = isset( $country ) && ! empty( $country ) ? $country : false;

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -480,6 +480,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			'shipping_amount' => null, // WC()->shipping->shipping_total
 			'line_items' => null,
             'customer_id' => 0,
+            'exemption_type' => '',
 		), $options) );
 
 		$taxes = array(
@@ -555,6 +556,12 @@ class WC_Taxjar_Integration extends WC_Settings_API {
         } else {
 		    if ( ! empty( $customer_id ) ) {
 			    $body[ 'customer_id' ] = $customer_id;
+            }
+        }
+
+		if ( ! empty( $exemption_type ) ) {
+		    if ( self::is_valid_exemption_type( $exemption_type ) ) {
+			    $body[ 'exemption_type' ] = $exemption_type;
             }
         }
 
@@ -766,6 +773,8 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			$customer_id = apply_filters( 'taxjar_get_customer_id', WC()->customer->get_id(), WC()->customer );
 		}
 
+		$exemption_type = apply_filters( 'taxjar_cart_exemption_type', '', $wc_cart_object );
+
 		$taxes = $this->calculate_tax( array(
 			'to_country' => $address['to_country'],
 			'to_zip' => $address['to_zip'],
@@ -775,6 +784,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			'shipping_amount' => WC()->shipping->shipping_total,
 			'line_items' => $line_items,
             'customer_id' => $customer_id,
+            'exemption_type' => $exemption_type,
 		) );
 
 		$this->response_rate_ids = $taxes['rate_ids'];
@@ -857,6 +867,8 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 
 		$customer_id = apply_filters( 'taxjar_get_customer_id', isset( $_POST[ 'customer_user' ] ) ? wc_clean( $_POST[ 'customer_user' ] ) : 0 );
 
+		$exemption_type = apply_filters( 'taxjar_order_calculation_exemption_type', '', $order );
+
 		$taxes = $this->calculate_tax( array(
 			'to_country' => $address['to_country'],
 			'to_state' => $address['to_state'],
@@ -866,6 +878,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			'shipping_amount' => $shipping,
 			'line_items' => $line_items,
             'customer_id' => $customer_id,
+            'exemption_type' => $exemption_type,
 		) );
 
 		if ( class_exists( 'WC_Order_Item_Tax' ) ) { // Add tax rates manually for Woo 3.0+
@@ -936,6 +949,8 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 
 	    $customer_id = apply_filters( 'taxjar_get_customer_id', $order->get_customer_id() );
 
+	    $exemption_type = apply_filters( 'taxjar_order_calculation_exemption_type', '', $order );
+
 	    $taxes = $this->calculate_tax( array(
 		    'to_country' => $address[ 'to_country' ],
 		    'to_state' => $address[ 'to_state' ],
@@ -945,6 +960,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 		    'shipping_amount' => $shipping,
 		    'line_items' => $line_items,
             'customer_id' => $customer_id,
+            'exemption_type' => $exemption_type,
 	    ) );
 
 	    if ( class_exists( 'WC_Order_Item_Tax' ) ) { // Add tax rates manually for Woo 3.0+
@@ -1560,6 +1576,11 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 		wp_register_script( 'wc-taxjar-order', plugin_dir_url( __FILE__ ) . '/js/wc-taxjar-order.js' );
 		wp_enqueue_script( 'wc-taxjar-order' , array( 'jquery' ) );
 	}
+
+	static function is_valid_exemption_type( $exemption_type ) {
+		$valid_types = array( 'wholesale', 'government', 'other', 'non_exempt' );
+		return in_array( $exemption_type, $valid_types );
+    }
 
 }
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -37,7 +37,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 		$this->integration_uri    = $this->app_uri . 'account/apps/add/woo';
 		$this->regions_uri        = $this->app_uri . 'account#states';
 		$this->uri                = 'https://api.taxjar.com/v2/';
-		$this->ua                 = 'TaxJarWordPressPlugin/3.0.0/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' );
+		$this->ua                 = 'TaxJarWordPressPlugin/3.0.1/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' );
 		$this->debug              = filter_var( $this->get_option( 'debug' ), FILTER_VALIDATE_BOOLEAN );
 		$this->download_orders    = new WC_Taxjar_Download_Orders( $this );
 		$this->transaction_sync   = new WC_Taxjar_Transaction_Sync( $this );

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -266,15 +266,17 @@ class WC_Taxjar_Transaction_Sync {
 			$record->set_status( 'awaiting' );
 		} else {
 			$refunds = $record->object->get_refunds();
+
 			foreach ( $refunds as $refund ) {
 				$refund_queue_id = TaxJar_Refund_Record::find_active_in_queue( $refund->get_id() );
+
 				if ( $refund_queue_id ) {
 					continue;
 				}
 
 				$refund_record = new TaxJar_Refund_Record( $refund->get_id(), true );
-
 				$refund_record->load_object();
+
 				if ( ! $refund_record->object ) {
 					continue;
 				}
@@ -284,6 +286,7 @@ class WC_Taxjar_Transaction_Sync {
 				}
 
 				$refund_last_sync = $refund_record->get_last_sync_time();
+
 				if ( ! empty( $refund_last_sync ) ) {
 					$refund_record->set_status( 'awaiting' );
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 4.2
 Tested up to: 5.1.1
-Stable tag: 3.0.0
+Stable tag: 3.0.1
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 3.0.0
@@ -90,6 +90,12 @@ Yes. The fee is $19.95 per state, per filing.
 1. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 3.0.1 (2019-08-09)
+* Add hooks to allow setting of order level exemptions during tax calculation and order syncing
+* Fix issue syncing refunds with zero quantity line items
+* Fix refunds created while order processing not syncing when order completed
+* Add fallback to billing address when shipping address is empty on sync
 
 = 3.0.0 (2019-08-06)
 * Added transaction sync order push to TaxJar

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,8 @@ Yes. The fee is $19.95 per state, per filing.
 * Fix issue syncing refunds with zero quantity line items
 * Fix refunds created while order processing not syncing when order completed
 * Add fallback to billing address when shipping address is empty on sync
+* Add filters to allow altering currency and country validation before syncing
+* Add filters to allow altering of request data before syncing orders and refunds
 
 = 3.0.0 (2019-08-06)
 * Added transaction sync order push to TaxJar

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce (Beta)
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 3.0.0
+ * Version: 3.0.1
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 3.0.0

--- a/tests/framework/order-helper.php
+++ b/tests/framework/order-helper.php
@@ -560,4 +560,37 @@ class TaxJar_Order_Helper {
 
 		return $refund;
 	}
+
+	static function create_partial_line_item_refund_from_order( $order_id ) {
+		$order       = wc_get_order( $order_id );
+		$order_items = $order->get_items( array( 'line_item', 'shipping', 'fee' ) );
+
+		$line_items = array();
+		$refund_total = 0;
+		foreach ( $order_items as $item_id => $item ) {
+			if ( $item->get_type() != 'line_item' ) {
+				continue;
+			}
+			$line_refund_total = $item->get_total() / $item->get_quantity() / 2;
+			$line_refund_tax = $item->get_total_tax() / $item->get_quantity() / 2;
+			$refund_total += $line_refund_total;
+			$refund_total += $line_refund_tax;
+			$line_items[ $item_id ] = array(
+				'qty'          => 0,
+				'refund_total' => $line_refund_total,
+				'refund_tax'   => array( $line_refund_tax )
+			);
+		}
+
+		$refund = wc_create_refund(
+			array(
+				'amount'         => $refund_total,
+				'reason'         => 'Refund Reason',
+				'order_id'       => $order_id,
+				'line_items'     => $line_items,
+			)
+		);
+
+		return $refund;
+	}
 }

--- a/tests/framework/order-helper.php
+++ b/tests/framework/order-helper.php
@@ -101,6 +101,91 @@ class TaxJar_Order_Helper {
 		return $order;
 	}
 
+	public static function create_order_with_no_tax( $customer_id = 1, $order_options = array() ) {
+		$options = array(
+			'price' => '100'
+		);
+		$product = TaxJar_Product_Helper::create_product( 'simple', $options );
+
+		TaxJar_Shipping_Helper::create_simple_flat_rate( 10 );
+
+		$order_data = array(
+			'status'        => 'pending',
+			'customer_id'   => $customer_id,
+			'customer_note' => '',
+			'total'         => '',
+		);
+		$order_data = array_replace_recursive( $order_data, $order_options );
+
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception
+		$order 					= wc_create_order( $order_data );
+
+		$item = new WC_Order_Item_Product();
+		$item->set_props( array(
+			'product'  => $product,
+			'quantity' => 1,
+			'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => 1 ) ),
+			'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => 1 ) ),
+		) );
+		$item->set_order_id( $order->get_id() );
+		$item->save();
+		$order->add_item( $item );
+
+
+		// Set billing address
+		$order->set_billing_first_name( 'Fname' );
+		$order->set_billing_last_name( 'Lname' );
+		$order->set_billing_address_1( 'Billing Address' );
+		$order->set_billing_address_2( '' );
+		$order->set_billing_city( 'Greenwood Village' );
+		$order->set_billing_state( 'CO' );
+		$order->set_billing_postcode( '80111' );
+		$order->set_billing_country( 'US' );
+		$order->set_billing_email( 'admin@example.org' );
+		$order->set_billing_phone( '111-111-1111' );
+
+		// Set shipping address
+		$order->set_shipping_first_name( 'Fname' );
+		$order->set_shipping_last_name( 'Lname' );
+		$order->set_shipping_address_1( 'Shipping Address' );
+		$order->set_shipping_address_2( '' );
+		$order->set_shipping_city( 'Greenwood Village' );
+		$order->set_shipping_state( 'CO' );
+		$order->set_shipping_postcode( '80111' );
+		$order->set_shipping_country( 'US' );
+
+
+		// Add shipping costs
+		$rate   = new WC_Shipping_Rate( 'flat_rate_shipping', 'Flat rate shipping', '10', array( 0 ), 'flat_rate' );
+		$item   = new WC_Order_Item_Shipping();
+		$item->set_props( array(
+			'method_title' => $rate->label,
+			'method_id'    => $rate->id,
+			'total'        => wc_format_decimal( $rate->cost ),
+			'taxes'        => $rate->taxes,
+		) );
+		foreach ( $rate->get_meta_data() as $key => $value ) {
+			$item->add_meta_data( $key, $value, true );
+		}
+		$item->save();
+		$order->add_item( $item );
+
+		// Set payment gateway
+		$payment_gateways = WC()->payment_gateways->payment_gateways();
+		$order->set_payment_method( $payment_gateways['bacs'] );
+
+		// Set totals
+		$order->set_shipping_total( 10 );
+		$order->set_discount_total( 0 );
+		$order->set_discount_tax( 0 );
+		$order->set_cart_tax( 0 );
+		$order->set_shipping_tax( 0 );
+		$order->set_total( 110 ); // 4 x $10 simple helper product
+		$order->save();
+
+		return $order;
+	}
+
 	public static function create_order_quantity_two( $customer_id = 1, $order_options = array() ) {
 		$options = array(
 			'price' => '100'

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -1070,4 +1070,17 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		WC()->session->set( 'chosen_shipping_methods', array() );
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
+
+	function test_order_level_exemption_on_cart_calculation() {
+		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		WC()->cart->add_to_cart( $product );
+
+		add_filter( 'taxjar_cart_exemption_type', function ( $cart ) {
+			return 'wholesale';
+		} );
+
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( 0, WC()->cart->get_taxes_total() );
+	}
 }

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -1081,6 +1081,8 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 		WC()->cart->calculate_totals();
 
+		remove_all_filters( 'taxjar_cart_exemption_type' );
+
 		$this->assertEquals( 0, WC()->cart->get_taxes_total() );
 	}
 }

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -1520,6 +1520,26 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$refund_record->delete_in_taxjar();
 	}
 
+	function test_partial_line_item_refund() {
+		$order = TaxJar_Order_Helper::create_order( 1 );
+		$order->update_status( 'completed' );
+		$refund = TaxJar_Order_Helper::create_partial_line_item_refund_from_order( $order->get_id() );
+
+		$record = TaxJar_Order_Record::find_active_in_queue( $order->get_id() );
+		$refund_record = TaxJar_Refund_Record::find_active_in_queue( $refund->get_id() );
+
+		$record->load_object();
+		$result = $record->sync();
+		$this->assertTrue( $result );
+
+		$refund_record->load_object();
+		$result = $refund_record->sync();
+		$this->assertTrue( $result );
+
+		$record->delete_in_taxjar();
+		$refund_record->delete_in_taxjar();
+	}
+
 	function test_sync_fee_refund() {
 		$order = TaxJar_Order_Helper::create_order( 1 );
 		$fee = new WC_Order_Item_Fee();

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -128,6 +128,43 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		TaxJar_Order_Helper::delete_order( $order->get_id() );
 	}
 
+	function test_get_order_ship_to_address() {
+		$order = TaxJar_Order_Helper::create_order();
+		$record = new TaxJar_Order_Record( $order->get_id(), true );
+		$record->load_object();
+		$address_data = $record->get_ship_to_address();
+
+		$order->set_billing_address_1( 'Billing Address' );
+		$order->set_billing_city( 'Billing City' );
+		$order->set_billing_state( 'UT' );
+		$order->set_billing_postcode( '84651' );
+		$order->set_billing_country( 'GB' );
+		$order->save();
+
+		$this->assertEquals( 'US', $address_data[ 'to_country' ] );
+		$this->assertEquals( 'CO', $address_data[ 'to_state' ] );
+		$this->assertEquals( '80111', $address_data[ 'to_zip' ] );
+		$this->assertEquals( 'Greenwood Village', $address_data[ 'to_city' ] );
+		$this->assertEquals( 'Shipping Address', $address_data[ 'to_street' ] );
+
+		$order->set_shipping_address_1( '' );
+		$order->set_shipping_city( '' );
+		$order->set_shipping_state( '' );
+		$order->set_shipping_postcode( '' );
+		$order->set_shipping_country( '' );
+		$order->save();
+
+		$record = new TaxJar_Order_Record( $order->get_id(), true );
+		$record->load_object();
+		$address_data = $record->get_ship_to_address();
+
+		$this->assertEquals( 'GB', $address_data[ 'to_country' ] );
+		$this->assertEquals( 'UT', $address_data[ 'to_state' ] );
+		$this->assertEquals( '84651', $address_data[ 'to_zip' ] );
+		$this->assertEquals( 'Billing City', $address_data[ 'to_city' ] );
+		$this->assertEquals( 'Billing Address', $address_data[ 'to_street' ] );
+	}
+
 	function test_get_active_order_record_in_queue() {
 		$order = TaxJar_Order_Helper::create_order();
 		$record = new TaxJar_Order_Record( $order->get_id(), true );

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -128,43 +128,6 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		TaxJar_Order_Helper::delete_order( $order->get_id() );
 	}
 
-	function test_get_order_ship_to_address() {
-		$order = TaxJar_Order_Helper::create_order();
-		$record = new TaxJar_Order_Record( $order->get_id(), true );
-		$record->load_object();
-		$address_data = $record->get_ship_to_address();
-
-		$order->set_billing_address_1( 'Billing Address' );
-		$order->set_billing_city( 'Billing City' );
-		$order->set_billing_state( 'UT' );
-		$order->set_billing_postcode( '84651' );
-		$order->set_billing_country( 'GB' );
-		$order->save();
-
-		$this->assertEquals( 'US', $address_data[ 'to_country' ] );
-		$this->assertEquals( 'CO', $address_data[ 'to_state' ] );
-		$this->assertEquals( '80111', $address_data[ 'to_zip' ] );
-		$this->assertEquals( 'Greenwood Village', $address_data[ 'to_city' ] );
-		$this->assertEquals( 'Shipping Address', $address_data[ 'to_street' ] );
-
-		$order->set_shipping_address_1( '' );
-		$order->set_shipping_city( '' );
-		$order->set_shipping_state( '' );
-		$order->set_shipping_postcode( '' );
-		$order->set_shipping_country( '' );
-		$order->save();
-
-		$record = new TaxJar_Order_Record( $order->get_id(), true );
-		$record->load_object();
-		$address_data = $record->get_ship_to_address();
-
-		$this->assertEquals( 'GB', $address_data[ 'to_country' ] );
-		$this->assertEquals( 'UT', $address_data[ 'to_state' ] );
-		$this->assertEquals( '84651', $address_data[ 'to_zip' ] );
-		$this->assertEquals( 'Billing City', $address_data[ 'to_city' ] );
-		$this->assertEquals( 'Billing Address', $address_data[ 'to_street' ] );
-	}
-
 	function test_get_active_order_record_in_queue() {
 		$order = TaxJar_Order_Helper::create_order();
 		$record = new TaxJar_Order_Record( $order->get_id(), true );
@@ -411,6 +374,42 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$record->load_object();
 		$ship_to_address = $record->get_ship_to_address();
 		$this->assertEquals( "6060 S Quebec St", $ship_to_address[ 'to_street' ] );
+
+		update_option( 'woocommerce_tax_based_on', 'shipping' );
+		$order = TaxJar_Order_Helper::create_order();
+		$record = new TaxJar_Order_Record( $order->get_id(), true );
+		$record->load_object();
+		$address_data = $record->get_ship_to_address();
+
+		$order->set_billing_address_1( 'Billing Address' );
+		$order->set_billing_city( 'Billing City' );
+		$order->set_billing_state( 'UT' );
+		$order->set_billing_postcode( '84651' );
+		$order->set_billing_country( 'GB' );
+		$order->save();
+
+		$this->assertEquals( 'US', $address_data[ 'to_country' ] );
+		$this->assertEquals( 'CO', $address_data[ 'to_state' ] );
+		$this->assertEquals( '80111', $address_data[ 'to_zip' ] );
+		$this->assertEquals( 'Greenwood Village', $address_data[ 'to_city' ] );
+		$this->assertEquals( 'Shipping Address', $address_data[ 'to_street' ] );
+
+		$order->set_shipping_address_1( '' );
+		$order->set_shipping_city( '' );
+		$order->set_shipping_state( '' );
+		$order->set_shipping_postcode( '' );
+		$order->set_shipping_country( '' );
+		$order->save();
+
+		$record = new TaxJar_Order_Record( $order->get_id(), true );
+		$record->load_object();
+		$address_data = $record->get_ship_to_address();
+
+		$this->assertEquals( 'GB', $address_data[ 'to_country' ] );
+		$this->assertEquals( 'UT', $address_data[ 'to_state' ] );
+		$this->assertEquals( '84651', $address_data[ 'to_zip' ] );
+		$this->assertEquals( 'Billing City', $address_data[ 'to_city' ] );
+		$this->assertEquals( 'Billing Address', $address_data[ 'to_street' ] );
 	}
 
 	function test_order_record_get_fee_line_items() {

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -1463,4 +1463,16 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$in_queue = WC_Taxjar_Record_Queue::get_all_active_in_queue();
 		$this->assertEmpty( $in_queue );
 	}
+
+	function test_partial_refund_sync_on_order_completion() {
+		$order = TaxJar_Order_Helper::create_order_quantity_two( 1 );
+		$refund = TaxJar_Order_Helper::create_partial_refund_from_order( $order->get_id() );
+		$order->update_status( 'completed' );
+
+		$record = TaxJar_Order_Record::find_active_in_queue( $order->get_id() );
+		$refund_record = TaxJar_Refund_Record::find_active_in_queue( $refund->get_id() );
+
+		$this->assertNotFalse( $record );
+		$this->assertNotFalse( $refund_record );
+	}
 }


### PR DESCRIPTION
This PR fixes a number of issues discovered in the beta:

1. Added hooks that allow order level exemptions to be set during calculations and during order / refund syncing.
2. Fixed issue where refunds created before an order was completed did not sync over to TaxJar.
3. Fixed issue where refunds with zero quantity line items failed to sync.
4. Added fallback for orders and refunds to billing address when shipping address is empty.

**Click-Test Versions**

- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
