### PR TITLE
Fix record sync when product is non existant

### DIFF
--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -281,12 +281,19 @@ class TaxJar_Order_Record extends TaxJar_Record {
 		if ( ! empty( $items ) ) {
 			foreach( $items as $item ) {
 				$product = $item->get_product();
+				$product_name = '';
+				$product_identifier = '';
+
+				if ( $product ) {
+					$product_name = $product->get_name();
+					$product_identifier = $product->get_sku();
+				}
 
 				$quantity = $item->get_quantity();
 				$unit_price = $item->get_subtotal() / $quantity;
 				$discount = $item->get_subtotal() - $item->get_total();
 
-				$tax_class = explode( '-', $product->get_tax_class() );
+				$tax_class = explode( '-', $item->get_tax_class() );
 				$tax_code = '';
 				if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
 					$tax_code = end( $tax_class );
@@ -295,8 +302,8 @@ class TaxJar_Order_Record extends TaxJar_Record {
 				$line_items_data[] = array(
 					'id' => $item->get_id(),
 					'quantity' => $quantity,
-					'product_identifier' => $product->get_sku(),
-					'description' => $product->get_name(),
+					'product_identifier' => $product_identifier,
+					'description' => $product_name,
 					'product_tax_code' => $tax_code,
 					'unit_price' => $unit_price,
 					'discount' => $discount,

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -194,8 +194,14 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		if ( ! empty( $items ) ) {
 			foreach( $items as $item ) {
 				$product = $item->get_product();
-
 				$quantity = $item->get_quantity();
+				$product_name = '';
+				$product_identifier = '';
+
+				if ( $product ) {
+					$product_name = $product->get_name();
+					$product_identifier = $product->get_sku();
+				}
 
 				if ( $quantity <= 0 ) {
 					$unit_price = $item->get_subtotal();
@@ -203,10 +209,11 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 				} else {
 					$unit_price = $item->get_subtotal() / $quantity;
 				}
-				$discount = $item->get_subtotal() - $item->get_total();
 
-				$tax_class = explode( '-', $product->get_tax_class() );
+				$discount = $item->get_subtotal() - $item->get_total();
+				$tax_class = explode( '-', $item->get_tax_class() );
 				$tax_code = '';
+
 				if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
 					$tax_code = end( $tax_class );
 				}
@@ -214,8 +221,8 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 				$line_items_data[] = array(
 					'id' => $item->get_id(),
 					'quantity' => $quantity,
-					'product_identifier' => $product->get_sku(),
-					'description' => $product->get_name(),
+					'product_identifier' => $product_identifier,
+					'description' => $product_name,
 					'product_tax_code' => $tax_code,
 					'unit_price' => $unit_price,
 					'discount' => $discount,
@@ -225,8 +232,6 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		}
 
 		$fees = $this->get_fee_line_items();
-
-
 		return array_merge( $line_items_data, $fees );
 	}
 

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -1641,4 +1641,41 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$record->delete_in_taxjar();
 		$refund_record->delete_in_taxjar();
 	}
+
+	function test_order_sync_with_deleted_product() {
+		$order = TaxJar_Order_Helper::create_order();
+		$order->update_status( 'completed' );
+		$line_items = $order->get_items();
+
+		foreach( $line_items as $line_item ) {
+			$product_id = $line_item->get_product_id();
+			$product = wc_get_product( $product_id );
+			$product->delete( true );
+		}
+
+		$record = new TaxJar_Order_Record( $order->get_id(), true );
+		$record->load_object();
+		$result = $record->sync();
+
+		$this->assertTrue( $result );
+	}
+
+	function test_refund_sync_with_deleted_product() {
+		$order = TaxJar_Order_Helper::create_order();
+		$order->update_status( 'completed' );
+		$refund = TaxJar_Order_Helper::create_refund_from_order( $order->get_id() );
+		$line_items = $order->get_items();
+
+		foreach( $line_items as $line_item ) {
+			$product_id = $line_item->get_product_id();
+			$product = wc_get_product( $product_id );
+			$product->delete( true );
+		}
+
+		$record = new TaxJar_Refund_Record( $refund->get_id(), true );
+		$record->load_object();
+		$result = $record->sync();
+
+		$this->assertTrue( $result );
+	}
 }


### PR DESCRIPTION
Previously there was an issue that arose when attempting to sync an order or refund where one of the line items was from a product that no longer existed. This can occur because either the product was deleted after the order was placed or because the order was imported from a different system and so there was no corresponding product. This PR resolves the issue and also includes two additional specs to ensure the issue does not arise again.

**Steps to Reproduce**

1. Create an order and mark it completed
2. Delete a product from that order
3. Attempt to sync the product (the sync will fail and throw an error).

**Expected Result**

After applying the PR, in step 3 the sync will be successful.

**Click-Test Versions**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
