### PR TITLE
Deregistering From TaxJar APP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.8 (2019-09-06)
+* Fix deregister functionality to sent correct store URL
+* Remove deregister upon API key update
+
 # 3.0.7 (2019-08-29)
 * Fix record sync when product does not exist
 

--- a/includes/class-wc-taxjar-install.php
+++ b/includes/class-wc-taxjar-install.php
@@ -33,13 +33,25 @@ class WC_Taxjar_Install {
 		if ( ! defined( 'IFRAME_REQUEST' ) && version_compare( $current_version, '3.0.0', '<' ) ) {
 			self::taxjar_300_update();
 		}
+
+		if ( ! defined( 'IFRAME_REQUEST' ) && version_compare( $current_version, '3.0.8', '<' ) && version_compare( $current_version, '2.3.1', '>' ) ) {
+			self::taxjar_308_update();
+		}
+	}
+
+	public static function taxjar_308_update() {
+		$tj = TaxJar();
+
+		if ( $tj->get_option( 'taxjar_download' ) == 'yes' ) {
+			$tj->download_orders->unlink_provider( home_url() );
+		}
 	}
 
 	public static function taxjar_300_update() {
 		$tj = TaxJar();
 
 		if ( $tj->get_option( 'taxjar_download' ) == 'yes' ) {
-			$tj->download_orders->unlink_provider( site_url() );
+			$tj->download_orders->unlink_provider( home_url() );
 			$start_date = date( 'Y-m-d H:i:s', strtotime( '-1 day, midnight', current_time( 'timestamp' ) ) );
 			$tj->transaction_sync->transaction_backfill( $start_date );
 			$tj->download_orders->delete_wc_taxjar_keys();

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1437,9 +1437,6 @@ class WC_Taxjar_Integration extends WC_Settings_API {
         }
 
 		if ( $setting_name == 'api_token' ) {
-			if ( ! $value && '' == $value && $this->download_orders->taxjar_download ) {
-				$this->download_orders->unlink_provider( home_url() );
-			}
 			return strtolower( wc_clean( $value ) );
         }
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -37,7 +37,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 		$this->integration_uri    = $this->app_uri . 'account/apps/add/woo';
 		$this->regions_uri        = $this->app_uri . 'account#states';
 		$this->uri                = 'https://api.taxjar.com/v2/';
-		$this->ua                 = 'TaxJarWordPressPlugin/3.0.7/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' );
+		$this->ua                 = 'TaxJarWordPressPlugin/3.0.8/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' );
 		$this->debug              = filter_var( $this->get_option( 'debug' ), FILTER_VALIDATE_BOOLEAN );
 		$this->download_orders    = new WC_Taxjar_Download_Orders( $this );
 		$this->transaction_sync   = new WC_Taxjar_Transaction_Sync( $this );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1428,7 +1428,6 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 	 * Sanitize our settings
 	 */
 	public function sanitize_settings( $value, $option ) {
-
 		parse_str( $option['id'], $option_name_array );
 		$option_name  = current( array_keys( $option_name_array ) );
 		$setting_name = key( $option_name_array[ $option_name ] );
@@ -1439,7 +1438,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 
 		if ( $setting_name == 'api_token' ) {
 			if ( ! $value && '' == $value && $this->download_orders->taxjar_download ) {
-				$this->download_orders->unlink_provider( site_url() );
+				$this->download_orders->unlink_provider( home_url() );
 			}
 			return strtolower( wc_clean( $value ) );
         }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 4.2
 Tested up to: 5.2.2
-Stable tag: 3.0.7
+Stable tag: 3.0.8
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 3.0.0
@@ -90,6 +90,10 @@ Yes. The fee is $19.95 per state, per filing.
 1. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 3.0.8 (2019-09-06)
+* Fix deregister functionality to sent correct store URL
+* Remove deregister upon API key update
 
 = 3.0.7 (2019-08-29)
 * Fix record sync when product does not exist

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 3.0.7
+ * Version: 3.0.8
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 3.0.0
@@ -42,7 +42,7 @@ if ( ! $woocommerce_active || version_compare( get_option( 'woocommerce_db_versi
  */
 final class WC_Taxjar {
 
-	static $version = '3.0.7';
+	static $version = '3.0.8';
 	public static $minimum_woocommerce_version = '3.0.0';
 
 	/**


### PR DESCRIPTION
When upgrading the plugin to 3.0.0 or higher, and request was made to the TaxJar API to deregister to linked account in TaxJar. (Having the linked account is no longer necessary since orders are now pushed into TaxJar directly through the TaxJar API). When this deregistering occurred, some sites had differences between the store URL they used to register and the the store URL that was sent to deregister. This was due to usage of a different method for getting the store URL when deregistering than what was previously used in the plugin to register with TaxJar. This PR fixes that issue by ensuring that the store URL used to deregister is the same that was used to register.

**Steps to Reproduce**

1. Install TaxJar version 2.3.1 on a store where the "Site Address" and "WordPress Address" are different in the WordPress settings.
2. Configure the plugin and enabled order downloads.
3. Check in the TaxJar app to ensure there is a linked account.
4. Update the plugin to a version at least 3.0.0
5. Check in the TaxJar app. The WooCommerce linked account will still remain.

**Expected Result**

After applying the PR, instead updating to this version  in step 4, when you arrive at step 5 there will no longer be a linked WooCommerce account.

**Click-Test Versions**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
