### PR TITLE
Remove Tax Code Numeric Validation

### DIFF
--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -293,11 +293,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 				$unit_price = $item->get_subtotal() / $quantity;
 				$discount = $item->get_subtotal() - $item->get_total();
 
-				$tax_class = explode( '-', $item->get_tax_class() );
-				$tax_code = '';
-				if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
-					$tax_code = end( $tax_class );
-				}
+				$tax_code = WC_Taxjar_Integration::get_tax_code_from_class( $item->get_tax_class() );
 
 				$line_items_data[] = array(
 					'id' => $item->get_id(),
@@ -322,11 +318,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 		$fees = $this->object->get_fees();
 		if ( !empty( $fees ) ) {
 			foreach( $fees as $fee ) {
-				$tax_class = explode( '-', $fee->get_tax_class() );
-				$tax_code = '';
-				if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
-					$tax_code = end( $tax_class );
-				}
+				$tax_code = WC_Taxjar_Integration::get_tax_code_from_class( $fee->get_tax_class() );
 
 				if ( method_exists( $fee, 'get_amount' ) ) {
 					$fee_amount = $fee->get_amount();

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -211,12 +211,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 				}
 
 				$discount = $item->get_subtotal() - $item->get_total();
-				$tax_class = explode( '-', $item->get_tax_class() );
-				$tax_code = '';
-
-				if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
-					$tax_code = end( $tax_class );
-				}
+				$tax_code = WC_Taxjar_Integration::get_tax_code_from_class( $item->get_tax_class() );
 
 				$line_items_data[] = array(
 					'id' => $item->get_id(),
@@ -240,11 +235,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		$fees = $this->object->get_fees();
 		if ( !empty( $fees ) ) {
 			foreach( $fees as $fee ) {
-				$tax_class = explode( '-', $fee->get_tax_class() );
-				$tax_code = '';
-				if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
-					$tax_code = end( $tax_class );
-				}
+				$tax_code = WC_Taxjar_Integration::get_tax_code_from_class( $fee->get_tax_class() );
 
 				if ( method_exists( $fee, 'get_amount' ) ) {
 					$fee_amount = $fee->get_amount();

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1069,12 +1069,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			$unit_price = wc_format_decimal( $product->get_price() );
 			$line_subtotal = wc_format_decimal( $cart_item['line_subtotal'] );
 			$discount = wc_format_decimal( $cart_item['line_subtotal'] - $cart_item['line_total'] );
-			$tax_class = explode( '-', $product->get_tax_class() );
-			$tax_code = '';
-
-			if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
-				$tax_code = end( $tax_class );
-			}
+			$tax_code = self::get_tax_code_from_class( $product->get_tax_class() );
 
 			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
 				$tax_code = '99999';
@@ -1134,11 +1129,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			$this->backend_tax_classes[$id] = $tax_class_name;
 
 			$tax_class = explode( '-', $tax_class_name );
-			$tax_code = '';
-
-            if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
-                $tax_code = end( $tax_class );
-            }
+			$tax_code = self::get_tax_code_from_class( $tax_class_name );
 
 			if ( 'taxable' !== $tax_status ) {
 				$tax_code = '99999';
@@ -1582,6 +1573,23 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 	static function is_valid_exemption_type( $exemption_type ) {
 		$valid_types = array( 'wholesale', 'government', 'other', 'non_exempt' );
 		return in_array( $exemption_type, $valid_types );
+    }
+
+    /**
+     * Parse tax code from product
+     *
+     * @param $product - WC_Product
+     * @return string - tax code
+     */
+    static function get_tax_code_from_class( $tax_class ) {
+	    $tax_class = explode( '-', $tax_class );
+	    $tax_code = '';
+
+	    if ( isset( $tax_class ) ) {
+		    $tax_code = end( $tax_class );
+	    }
+
+        return $tax_code;
     }
 
 }

--- a/tests/specs/test-customer-sync.php
+++ b/tests/specs/test-customer-sync.php
@@ -250,10 +250,11 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		$this->assertEquals( 'Greenwood Village', $body->customer->city );
 		$this->assertEquals( '123 Test St', $body->customer->street );
 
+		$valid_states = array( 'UT', 'CO' );
+		$this->assertContains( $body->customer->exempt_regions[ 0 ]->state, $valid_states );
+		$this->assertContains( $body->customer->exempt_regions[ 1 ]->state, $valid_states );
 		$this->assertEquals( 'US', $body->customer->exempt_regions[ 0 ]->country );
-		$this->assertEquals( 'CO', $body->customer->exempt_regions[ 0 ]->state );
 		$this->assertEquals( 'US', $body->customer->exempt_regions[ 1 ]->country );
-		$this->assertEquals( 'UT', $body->customer->exempt_regions[ 1 ]->state );
 
 		// test delete customer from TaxJar
 		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
@@ -330,10 +331,12 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		$this->assertEquals( 200, $response['response']['code'] );
 		$body = json_decode( $response[ 'body' ] );
 		$this->assertEquals( 'wholesale', $body->customer->exemption_type );
+
+		$valid_states = array( 'UT', 'CO' );
+		$this->assertContains( $body->customer->exempt_regions[ 0 ]->state, $valid_states );
+		$this->assertContains( $body->customer->exempt_regions[ 1 ]->state, $valid_states );
 		$this->assertEquals( 'US', $body->customer->exempt_regions[ 0 ]->country );
-		$this->assertEquals( 'CO', $body->customer->exempt_regions[ 0 ]->state );
 		$this->assertEquals( 'US', $body->customer->exempt_regions[ 1 ]->country );
-		$this->assertEquals( 'UT', $body->customer->exempt_regions[ 1 ]->state );
 
 		$record->delete_in_taxjar();
 	}

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -541,7 +541,7 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$record = new TaxJar_Order_Record( $order->get_id(), true );
 		$record->load_object( $order );
 		$fee_line_items = $record->get_fee_line_items();
-		$this->assertEquals( '', $fee_line_items[ 0 ][ 'product_tax_code' ] );
+		$this->assertEquals( 'rate', $fee_line_items[ 0 ][ 'product_tax_code' ] );
 
 		$order = TaxJar_Order_Helper::create_order( 1 );
 		$fee = new WC_Order_Item_Fee();


### PR DESCRIPTION
With new updates to the TaxJar API, some alphanumeric tax codes were introduced (previously all were numeric). In order to support these codes the numeric validation we performed on the tax class had to be removed.

**Click-Test Versions**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
