### PR TITLE
Sync Queue Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.0.10 (2019-10-2)
+* Fix record stuck in awaiting status in sync queue
+* Display last sync error in sync queue
+* Clear regions not in nexus from rate table when nexus is updated
+* Improve error messaging in logs
+* Set synced date on orders when sync is manually triggered
+* Display batch ID in sync queue table
+* Handle unexpected exemptions during sync
+
 # 3.0.9 (2019-09-18)
 * Update validation to support new TaxJar product categories
 * Fix missing filter on refund reference IDs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.0.10 (2019-10-2)
+# 3.0.10 (2019-10-04)
 * Fix record stuck in awaiting status in sync queue
 * Display last sync error in sync queue
 * Clear regions not in nexus from rate table when nexus is updated

--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -224,7 +224,6 @@ abstract class TaxJar_Record {
 			}
 
 			if ( in_array( $response[ 'response' ][ 'code' ], $error_responses ) ) {
-
 				switch( $response[ 'response' ][ 'code' ] ) {
 					case 400:
 						if ( ! empty( $response['body'] ) ) {

--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -93,7 +93,7 @@ abstract class TaxJar_Record {
 			$insert[ 'processed_datetime' ] = $this->get_processed_datetime();
 		}
 
-		if ( $this->get_last_error() === "" | ! empty( $this->get_last_error() ) ) {
+		if ( $this->get_last_error() === "" || ! empty( $this->get_last_error() ) ) {
 			$insert[ 'last_error' ] = $this->get_last_error();
 		}
 
@@ -139,7 +139,7 @@ abstract class TaxJar_Record {
 			$data[ 'retry_count' ] =  $this->get_retry_count();
 		}
 
-		if ( $this->get_last_error() === "" | ! empty( $this->get_last_error() ) ) {
+		if ( $this->get_last_error() === "" || ! empty( $this->get_last_error() ) ) {
 			$data[ 'last_error' ] =  $this->get_last_error();
 		}
 

--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -256,6 +256,7 @@ abstract class TaxJar_Record {
 	public function sync_success() {
 		$current_datetime =  gmdate( 'Y-m-d H:i:s' );
 		$this->set_processed_datetime( $current_datetime );
+		$this->set_last_error( "" );
 		$this->set_status( 'completed' );
 		$this->save();
 	}

--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -121,7 +121,7 @@ abstract class TaxJar_Record {
 			$data[ 'processed_datetime' ] =  $this->get_processed_datetime();
 		}
 
-		if ( ! empty( $this->get_batch_id() ) ) {
+		if ( $this->get_batch_id() === 0 || $this->get_batch_id() === '0' || ! empty( $this->get_batch_id() ) ) {
 			$data[ 'batch_id' ] =  $this->get_batch_id();
 		}
 

--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -16,6 +16,7 @@ abstract class TaxJar_Record {
 	protected $created_datetime;
 	protected $processed_datetime;
 	protected $retry_count;
+	protected $last_error;
 	protected $force_push;
 
 	public $error = array();
@@ -70,6 +71,7 @@ abstract class TaxJar_Record {
 		$this->set_retry_count( $record_data[ 'retry_count' ] );
 		$this->set_status( $record_data[ 'status' ] );
 		$this->set_force_push( $record_data[ 'force_push' ] );
+		$this->set_last_error( $record_data[ 'last_error' ] );
 	}
 
 	public function create() {
@@ -89,6 +91,10 @@ abstract class TaxJar_Record {
 
 		if ( ! empty( $this->get_processed_datetime() ) ) {
 			$insert[ 'processed_datetime' ] = $this->get_processed_datetime();
+		}
+
+		if ( $this->get_last_error() === "" | ! empty( $this->get_last_error() ) ) {
+			$insert[ 'last_error' ] = $this->get_last_error();
 		}
 
 		$result = $wpdb->insert( self::get_queue_table_name(), $insert );
@@ -131,6 +137,10 @@ abstract class TaxJar_Record {
 
 		if ( ! empty( $this->get_retry_count() ) ) {
 			$data[ 'retry_count' ] =  $this->get_retry_count();
+		}
+
+		if ( $this->get_last_error() === "" | ! empty( $this->get_last_error() ) ) {
+			$data[ 'last_error' ] =  $this->get_last_error();
 		}
 
 		$where = array(
@@ -354,6 +364,7 @@ abstract class TaxJar_Record {
 		$record->set_batch_id( $record_row[ 'batch_id' ] );
 		$record->set_processed_datetime( $record_row[ 'processed_datetime' ] );
 		$record->set_force_push( $record_row[ 'force_push' ] );
+		$record->set_last_error( $record_row[ 'last_error' ] );
 		$record->load_object();
 
 		// handle records deleted after being added to queue
@@ -480,5 +491,13 @@ abstract class TaxJar_Record {
 
 	public function set_last_request( $last_request ) {
 		$this->last_request = $last_request;
+	}
+
+	public function get_last_error() {
+		return $this->last_error;
+	}
+
+	public function set_last_error( $last_error ) {
+		$this->last_error = $last_error;
 	}
 }

--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -79,13 +79,17 @@ abstract class TaxJar_Record {
 
 		global $wpdb;
 		$insert = array(
-			'record_id'        => $this->get_record_id(),
-			'record_type'      => $this->get_record_type(),
-			'status'           => $this->get_status(),
-			'batch_id'         => $this->get_batch_id(),
-			'created_datetime' => $this->get_created_datetime(),
-			'force_push'       => $this->get_force_push()
+			'record_id'          => $this->get_record_id(),
+			'record_type'        => $this->get_record_type(),
+			'status'             => $this->get_status(),
+			'batch_id'           => $this->get_batch_id(),
+			'created_datetime'   => $this->get_created_datetime(),
+			'force_push'         => $this->get_force_push()
 		);
+
+		if ( ! empty( $this->get_processed_datetime() ) ) {
+			$insert[ 'processed_datetime' ] = $this->get_processed_datetime();
+		}
 
 		$result = $wpdb->insert( self::get_queue_table_name(), $insert );
 		$this->set_queue_id( $wpdb->insert_id );

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -38,7 +38,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 			$status = $this->object->get_status();
 			$valid_statuses = apply_filters( 'taxjar_valid_order_statuses_for_sync', array( 'completed', 'refunded' ) );
 			if ( ! in_array( $status, $valid_statuses ) ) {
-				$this->add_error( __( 'Order failed validation - invalid status.', 'wc-taxjar' ) );
+				$this->add_error( __( 'Order failed validation - invalid order status.', 'wc-taxjar' ) );
 				return false;
 			}
 

--- a/includes/class-wc-taxjar-install.php
+++ b/includes/class-wc-taxjar-install.php
@@ -141,7 +141,7 @@ CREATE TABLE {$wpdb->prefix}taxjar_record_queue (
   created_datetime datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   processed_datetime datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   retry_count smallint(4) NOT NULL DEFAULT 0,
-  last_error longtext NOT NULL DEFAULT '',
+  last_error text NOT NULL DEFAULT '',
   PRIMARY KEY  (queue_id),
   KEY record_id (record_id)
   ) $collate;

--- a/includes/class-wc-taxjar-install.php
+++ b/includes/class-wc-taxjar-install.php
@@ -141,6 +141,7 @@ CREATE TABLE {$wpdb->prefix}taxjar_record_queue (
   created_datetime datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   processed_datetime datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   retry_count smallint(4) NOT NULL DEFAULT 0,
+  last_error longtext NOT NULL,
   PRIMARY KEY  (queue_id),
   KEY record_id (record_id)
   ) $collate;

--- a/includes/class-wc-taxjar-install.php
+++ b/includes/class-wc-taxjar-install.php
@@ -141,7 +141,7 @@ CREATE TABLE {$wpdb->prefix}taxjar_record_queue (
   created_datetime datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   processed_datetime datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   retry_count smallint(4) NOT NULL DEFAULT 0,
-  last_error longtext NOT NULL,
+  last_error longtext NOT NULL DEFAULT '',
   PRIMARY KEY  (queue_id),
   KEY record_id (record_id)
   ) $collate;

--- a/includes/class-wc-taxjar-install.php
+++ b/includes/class-wc-taxjar-install.php
@@ -37,6 +37,14 @@ class WC_Taxjar_Install {
 		if ( ! defined( 'IFRAME_REQUEST' ) && version_compare( $current_version, '3.0.8', '<' ) && version_compare( $current_version, '2.3.1', '>' ) ) {
 			self::taxjar_308_update();
 		}
+
+		if ( ! defined( 'IFRAME_REQUEST' ) && version_compare( $current_version, '3.0.10', '<' ) && version_compare( $current_version, '2.3.1', '>' ) ) {
+			self::taxjar_3010_update();
+		}
+	}
+
+	public static function taxjar_3010_update() {
+		WC_Taxjar_Record_Queue::clean_orphaned_records();
 	}
 
 	public static function taxjar_308_update() {

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -37,7 +37,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 		$this->integration_uri    = $this->app_uri . 'account/apps/add/woo';
 		$this->regions_uri        = $this->app_uri . 'account#states';
 		$this->uri                = 'https://api.taxjar.com/v2/';
-		$this->ua                 = 'TaxJarWordPressPlugin/3.0.9/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' );
+		$this->ua                 = 'TaxJarWordPressPlugin/3.0.10/WordPress/' . get_bloginfo( 'version' ) . '+WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' );
 		$this->debug              = filter_var( $this->get_option( 'debug' ), FILTER_VALIDATE_BOOLEAN );
 		$this->download_orders    = new WC_Taxjar_Download_Orders( $this );
 		$this->transaction_sync   = new WC_Taxjar_Transaction_Sync( $this );

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -152,7 +152,7 @@ class WC_Taxjar_Nexus {
 		$nexus_states = array();
 
 		foreach( $regions as $region ) {
-			if ( ! empty( $region->country_code ) && $region->country_code === 'US' ){
+			if ( ! empty( $region->country_code ) && $region->country_code === 'US' ) {
 				if ( ! empty( $region->region_code ) ) {
 					$nexus_states[] = $region->region_code;
 				}

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -120,6 +120,7 @@ class WC_Taxjar_Nexus {
 		if ( ! is_wp_error( $response ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300 ) {
 			$this->integration->_log( ':::: Nexus addresses updated ::::' );
 			$body = json_decode( $response['body'] );
+			$this->clear_non_nexus_rates( $body->regions );
 			return $body->regions;
 		}
 
@@ -140,6 +141,27 @@ class WC_Taxjar_Nexus {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Clear non US nexus states from rates table to prevent tax calculation when nexus is removed in a state
+	 * @param $regions - array of nexus regions from API request
+	 */
+	public function clear_non_nexus_rates( $regions ) {
+		global $wpdb;
+		$nexus_states = array();
+
+		foreach( $regions as $region ) {
+			if ( ! empty( $region->country_code ) && $region->country_code === 'US' ){
+				if ( ! empty( $region->region_code ) ) {
+					$nexus_states[] = $region->region_code;
+				}
+			}
+		}
+
+		$nexus_states_string = join( "','", $nexus_states );
+		$query = "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_country = 'US' AND tax_rate_state NOT IN ('{$nexus_states_string}')";
+		$results = $wpdb->query( $query );
 	}
 
 } // End WC_Taxjar_Nexus.

--- a/includes/class-wc-taxjar-queue-list.php
+++ b/includes/class-wc-taxjar-queue-list.php
@@ -181,7 +181,7 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 			'processed_datetime'    => __( 'Sync Time', 'wc-taxjar' ),
 			'retry_count'           => __( 'Retry Count', 'wc-taxjar' ),
 			'batch_id'              => __( 'Batch ID', 'wc-taxjar' ),
-			'last_error'              => __( 'Last Error', 'wc-taxjar' ),
+			'last_error'            => __( 'Last Error', 'wc-taxjar' ),
 			'taxjar_actions'        => __( 'Actions', 'wc-taxjar' ),
 		);
 

--- a/includes/class-wc-taxjar-queue-list.php
+++ b/includes/class-wc-taxjar-queue-list.php
@@ -125,6 +125,9 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
             case 'batch_id':
                 return ( ! empty( $record->batch_id ) ? $record->batch_id : "" );
 
+            case 'last_error':
+                return $record->last_error;
+
 			case 'taxjar_actions':
 				ob_start();
 				?><p>
@@ -178,6 +181,7 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 			'processed_datetime'    => __( 'Sync Time', 'wc-taxjar' ),
 			'retry_count'           => __( 'Retry Count', 'wc-taxjar' ),
 			'batch_id'              => __( 'Batch ID', 'wc-taxjar' ),
+			'last_error'              => __( 'Last Error', 'wc-taxjar' ),
 			'taxjar_actions'        => __( 'Actions', 'wc-taxjar' ),
 		);
 

--- a/includes/class-wc-taxjar-queue-list.php
+++ b/includes/class-wc-taxjar-queue-list.php
@@ -122,6 +122,9 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 			case 'retry_count':
 				return $record->retry_count;
 
+            case 'batch_id':
+                return ( ! empty( $record->batch_id ) ? $record->batch_id : "" );
+
 			case 'taxjar_actions':
 				ob_start();
 				?><p>
@@ -174,6 +177,7 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 			'created_datetime'      => __( 'Created Time', 'wc-taxjar' ),
 			'processed_datetime'    => __( 'Sync Time', 'wc-taxjar' ),
 			'retry_count'           => __( 'Retry Count', 'wc-taxjar' ),
+			'batch_id'              => __( 'Batch ID', 'wc-taxjar' ),
 			'taxjar_actions'        => __( 'Actions', 'wc-taxjar' ),
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 4.2
 Tested up to: 5.2.2
-Stable tag: 3.0.9
+Stable tag: 3.0.10
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 3.0.0
@@ -90,6 +90,15 @@ Yes. The fee is $19.95 per state, per filing.
 1. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 3.0.10 (2019-10-2)
+* Fix record stuck in awaiting status in sync queue
+* Display last sync error in sync queue
+* Clear regions not in nexus from rate table when nexus is updated
+* Improve error messaging in logs
+* Set synced date on orders when sync is manually triggered
+* Display batch ID in sync queue table
+* Handle unexpected exemptions during sync
 
 = 3.0.9 (2019-09-18)
 * Update validation to support new TaxJar product categories

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ Yes. The fee is $19.95 per state, per filing.
 
 == Changelog ==
 
-= 3.0.10 (2019-10-2)
+= 3.0.10 (2019-10-04)
 * Fix record stuck in awaiting status in sync queue
 * Display last sync error in sync queue
 * Clear regions not in nexus from rate table when nexus is updated

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 3.0.9
+ * Version: 3.0.10
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 3.0.0
@@ -42,7 +42,7 @@ if ( ! $woocommerce_active || version_compare( get_option( 'woocommerce_db_versi
  */
 final class WC_Taxjar {
 
-	static $version = '3.0.9';
+	static $version = '3.0.10';
 	public static $minimum_woocommerce_version = '3.0.0';
 
 	/**

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -243,7 +243,7 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$order = TaxJar_Order_Helper::create_order( 1 );
 		$record = new TaxJar_Order_Record( $order->get_id(), true );
 		$record->load_object();
-		$record->sync_failure();
+		$record->sync_failure( "Last Error" );
 
 		$updated_record = new TaxJar_Order_Record( $order->get_id() );
 		$updated_record->set_queue_id( $record->get_queue_id() );
@@ -251,9 +251,10 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 
 		$this->assertEquals( 0, $updated_record->get_batch_id() );
 		$this->assertEquals( 'new', $updated_record->get_status() );
+		$this->assertEquals( 'Last Error', $updated_record->get_last_error() );
 
 		$updated_record->set_retry_count( 2 );
-		$updated_record->sync_failure();
+		$updated_record->sync_failure( "Last Error" );
 
 		$updated_record = new TaxJar_Order_Record( $order->get_id() );
 		$updated_record->set_queue_id( $record->get_queue_id() );
@@ -261,6 +262,7 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 
 		$this->assertEquals( 0, $updated_record->get_batch_id() );
 		$this->assertEquals( 'failed', $updated_record->get_status() );
+		$this->assertEquals( 'Last Error', $updated_record->get_last_error() );
 
 		// Ensure updated order is not re-added to queue on failed sync
 		$active_record = TaxJar_Order_Record::find_active_in_queue( $order->get_id() );


### PR DESCRIPTION
The main issue that this PR resolves is fixing records that get stuck in awaiting status in the sync queue. This was happening due to a validation on the batch ID that caused it to not be able to be updated to 0 after a record failed to sync. Since the batch ID remained set to the initial batch ID that processed it, it would never get picked up and placed into another batch and so would stay stuck in the awaiting status.

This PR fixes the issue by altering the validation to allow the batch ID to be reset to 0. It also includes an update function that will run once upon updating and will located all of the records that meet this stuck condition and resolve their batch IDs to 0, allowing them to continue in the sync process.

This PR also includes various other improvements, such as:

- Adding the last error to the sync queue view to allow customers to immediately determine the cause of orders failing to sync.
- Improved error messaging.
- Displaying the batch ID in the sync queue view (can help in troubleshooting issues).
- Additional error handling in sync process.
- Ensuring sync date is set when orders are manually synced.
- Clearing rates from table when they no longer have nexus and nexus is updated.

**Steps to Reproduce**

1. Place an order with the shipping address zip code that is not in the shipping state.
2. Wait for order to sync through normal sync process.
3. Order will attempt to sync and fail, but will stay in "awaiting" status. 
4. Order will have retry attempts of 1 but will never attempt to sync again.

**Expected Result**

After applying the PR, order will retry syncing up to 3 times and then will be placed into failed status.

**Click-Test Versions**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0


**Specs Passing**

- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
