### PR TITLE
Update WooCommerce support to 3.8.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Stable tag: 3.0.10
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 3.0.0
-WC tested up to: 3.7.0
+WC tested up to: 3.8.0
 
 Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculations, reporting, and filing.
 

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -7,7 +7,7 @@
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 3.0.0
- * WC tested up to: 3.7.0
+ * WC tested up to: 3.8.0
  *
  * Copyright: © 2014-2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc.
  * License: GNU General Public License v2.0 or later


### PR DESCRIPTION
WooCommerce recently released version 3.8.0. After fully testing to verify compatibility, this PR updates the declared support in our plugin to this version.

**Click-Test Versions**

- [X] Woo 3.8

**Specs Passing**

- [X] Woo 3.8

