### PR TITLE
Disable Date Validation Filters

### DIFF
--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -42,7 +42,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 				return false;
 			}
 
-			if ( apply_filters( 'taxjar_should_validate_order_completed_date', true ) ) {
+			if ( WC_Taxjar_Transaction_Sync::should_validate_order_completed_date() ) {
 				if ( empty( $this->object->get_date_completed() ) ) {
 					$this->add_error( __( 'Order failed validation - order has no completed date', 'wc-taxjar' ) );
 					return false;

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -42,9 +42,11 @@ class TaxJar_Order_Record extends TaxJar_Record {
 				return false;
 			}
 
-			if ( empty( $this->object->get_date_completed() ) ) {
-				$this->add_error( __( 'Order failed validation - order has no completed date', 'wc-taxjar' ) );
-				return false;
+			if ( apply_filters( 'taxjar_should_validate_order_completed_date', true ) ) {
+				if ( empty( $this->object->get_date_completed() ) ) {
+					$this->add_error( __( 'Order failed validation - order has no completed date', 'wc-taxjar' ) );
+					return false;
+				}
 			}
 		}
 

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -27,9 +27,11 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 			return false;
 		}
 
-		if ( empty( $this->order_completed_date ) ) {
-			$this->add_error( __( 'Refund failed validation - parent order has no completed date.', 'wc-taxjar' ) );
-			return false;
+		if ( apply_filters( 'taxjar_should_validate_order_completed_date', true ) ) {
+			if ( empty( $this->order_completed_date ) ) {
+				$this->add_error( __( 'Refund failed validation - parent order has no completed date.', 'wc-taxjar' ) );
+				return false;
+			}
 		}
 
 		$valid_order_statuses = apply_filters( 'taxjar_valid_order_statuses_for_sync', array( 'completed', 'refunded' ) );

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -27,7 +27,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 			return false;
 		}
 
-		if ( apply_filters( 'taxjar_should_validate_order_completed_date', true ) ) {
+		if ( WC_Taxjar_Transaction_Sync::should_validate_order_completed_date() ) {
 			if ( empty( $this->order_completed_date ) ) {
 				$this->add_error( __( 'Refund failed validation - parent order has no completed date.', 'wc-taxjar' ) );
 				return false;

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -70,7 +70,7 @@ class WC_Taxjar_Transaction_Sync {
 			return $actions;
 		}
 
-		if ( apply_filters( 'taxjar_should_validate_order_completed_date', true ) ) {
+		if ( WC_Taxjar_Transaction_Sync::should_validate_order_completed_date() ) {
 			if ( empty( $theorder->get_date_completed() ) ) {
 				return $actions;
 			}
@@ -471,7 +471,7 @@ class WC_Taxjar_Transaction_Sync {
 
 		if ( $record->get_object_hash() || $record->get_last_sync_time() ) {
 			$should_delete = true;
-		} else if ( apply_filters( 'taxjar_should_validate_order_completed_date', true ) ) {
+		} else if ( WC_Taxjar_Transaction_Sync::should_validate_order_completed_date() ) {
 			if ( $order->get_date_completed() ) {
 				if ( $record->should_sync( true ) ) {
 					$should_delete = true;
@@ -625,7 +625,7 @@ class WC_Taxjar_Transaction_Sync {
 		$valid_post_statuses = apply_filters( 'taxjar_valid_post_statuses_for_sync', array( 'wc-completed', 'wc-refunded' ) );
 		$post_status_string = "( '" . implode( "', '", $valid_post_statuses ) . " ')";
 
-		$should_validate_completed_date = apply_filters( 'taxjar_should_validate_order_completed_date', true );
+		$should_validate_completed_date = WC_Taxjar_Transaction_Sync::should_validate_order_completed_date();
 
 		if ( $force ) {
 			$query = "SELECT p.id FROM {$wpdb->posts} AS p ";
@@ -723,5 +723,15 @@ class WC_Taxjar_Transaction_Sync {
 		$notice .= __( 'this article', 'wc-taxjar' );
 		$notice .= '</a>.</p>';
 		echo $notice;
+	}
+
+	/**
+	 * Checks whether or not completed date should be validated before syncing order or refund to TaxJar
+	 *
+	 * @return bool
+	 */
+	public static function should_validate_order_completed_date() {
+		$default_value = true;
+		return apply_filters( 'taxjar_should_validate_order_completed_date', $default_value );
 	}
 }

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -70,9 +70,12 @@ class WC_Taxjar_Transaction_Sync {
 			return $actions;
 		}
 
-		if ( empty( $theorder->get_date_completed() ) ) {
-			return $actions;
+		if ( apply_filters( 'taxjar_should_validate_order_completed_date', true ) ) {
+			if ( empty( $theorder->get_date_completed() ) ) {
+				return $actions;
+			}
 		}
+
 
 		$actions['taxjar_sync_action'] = __( 'Sync order to TaxJar', 'taxjar' );
 		return $actions;
@@ -468,9 +471,11 @@ class WC_Taxjar_Transaction_Sync {
 
 		if ( $record->get_object_hash() || $record->get_last_sync_time() ) {
 			$should_delete = true;
-		} else if ( $order->get_date_completed() ) {
-			if ( $record->should_sync( true ) ) {
-				$should_delete = true;
+		} else if ( apply_filters( 'taxjar_should_validate_order_completed_date', true ) ) {
+			if ( $order->get_date_completed() ) {
+				if ( $record->should_sync( true ) ) {
+					$should_delete = true;
+				}
 			}
 		}
 
@@ -620,39 +625,40 @@ class WC_Taxjar_Transaction_Sync {
 		$valid_post_statuses = apply_filters( 'taxjar_valid_post_statuses_for_sync', array( 'wc-completed', 'wc-refunded' ) );
 		$post_status_string = "( '" . implode( "', '", $valid_post_statuses ) . " ')";
 
+		$should_validate_completed_date = apply_filters( 'taxjar_should_validate_order_completed_date', true );
+
 		if ( $force ) {
-			$posts = $wpdb->get_results(
-					"
-				SELECT p.id 
-				FROM {$wpdb->posts} AS p 
-				INNER JOIN {$wpdb->postmeta} AS order_meta_completed_date ON ( p.id = order_meta_completed_date.post_id )  AND ( order_meta_completed_date.meta_key = '_completed_date' ) 
-				WHERE p.post_type = 'shop_order' 
-				AND p.post_status IN {$post_status_string} 
-				AND p.post_date >= '{$start_date}' 
-				AND p.post_date < '{$end_date}' 
-				AND order_meta_completed_date.meta_value IS NOT NULL 
-				AND order_meta_completed_date.meta_value != '' 
-				ORDER BY p.post_date ASC
-				", ARRAY_N
-			);
+			$query = "SELECT p.id FROM {$wpdb->posts} AS p ";
+
+			if ( $should_validate_completed_date ) {
+				$query .= "INNER JOIN {$wpdb->postmeta} AS order_meta_completed_date ON ( p.id = order_meta_completed_date.post_id )  AND ( order_meta_completed_date.meta_key = '_completed_date' ) ";
+			}
+
+			$query .= "WHERE p.post_type = 'shop_order' AND p.post_status IN {$post_status_string} AND p.post_date >= '{$start_date}' AND p.post_date < '{$end_date}' ";
+
+			if ( $should_validate_completed_date ) {
+				$query .= "AND order_meta_completed_date.meta_value IS NOT NULL AND order_meta_completed_date.meta_value != '' ";
+			}
+
+			$query .= "ORDER BY p.post_date ASC";
 		} else {
-			$posts = $wpdb->get_results(
-					"
-				SELECT p.id 
-				FROM {$wpdb->posts} AS p 
-				INNER JOIN {$wpdb->postmeta} AS order_meta_completed_date ON ( p.id = order_meta_completed_date.post_id )  AND ( order_meta_completed_date.meta_key = '_completed_date' ) 
-				LEFT JOIN {$wpdb->postmeta} AS order_meta_last_sync ON ( p.id = order_meta_last_sync.post_id )  AND ( order_meta_last_sync.meta_key = '_taxjar_last_sync' )
-				WHERE p.post_type = 'shop_order' 
-				AND p.post_status IN {$post_status_string} 
-				AND p.post_date >= '{$start_date}' 
-				AND p.post_date < '{$end_date}' 
-				AND order_meta_completed_date.meta_value IS NOT NULL 
-				AND order_meta_completed_date.meta_value != '' 
-				AND ((order_meta_last_sync.meta_value IS NULL) OR (p.post_modified_gmt > order_meta_last_sync.meta_value)) 
-				ORDER BY p.post_date ASC
-				", ARRAY_N
-			);
+			$query = "SELECT p.id FROM {$wpdb->posts} AS p ";
+
+			if ( $should_validate_completed_date ) {
+				$query .= "INNER JOIN {$wpdb->postmeta} AS order_meta_completed_date ON ( p.id = order_meta_completed_date.post_id )  AND ( order_meta_completed_date.meta_key = '_completed_date' ) ";
+			}
+
+			$query .= "LEFT JOIN {$wpdb->postmeta} AS order_meta_last_sync ON ( p.id = order_meta_last_sync.post_id )  AND ( order_meta_last_sync.meta_key = '_taxjar_last_sync' ) ";
+			$query .= "WHERE p.post_type = 'shop_order' AND p.post_status IN {$post_status_string} AND p.post_date >= '{$start_date}' AND p.post_date < '{$end_date}' ";
+
+			if ( $should_validate_completed_date ) {
+				$query .= "AND order_meta_completed_date.meta_value IS NOT NULL AND order_meta_completed_date.meta_value != '' ";
+			}
+
+			$query .= "AND ((order_meta_last_sync.meta_value IS NULL) OR (p.post_modified_gmt > order_meta_last_sync.meta_value)) ORDER BY p.post_date ASC";
 		}
+
+		$posts = $wpdb->get_results( $query, ARRAY_N );
 
 		if ( empty( $posts ) ) {
 			return array();

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -76,7 +76,6 @@ class WC_Taxjar_Transaction_Sync {
 			}
 		}
 
-
 		$actions['taxjar_sync_action'] = __( 'Sync order to TaxJar', 'taxjar' );
 		return $actions;
 	}
@@ -631,7 +630,7 @@ class WC_Taxjar_Transaction_Sync {
 			$query = "SELECT p.id FROM {$wpdb->posts} AS p ";
 
 			if ( $should_validate_completed_date ) {
-				$query .= "INNER JOIN {$wpdb->postmeta} AS order_meta_completed_date ON ( p.id = order_meta_completed_date.post_id )  AND ( order_meta_completed_date.meta_key = '_completed_date' ) ";
+				$query .= "INNER JOIN {$wpdb->postmeta} AS order_meta_completed_date ON ( p.id = order_meta_completed_date.post_id ) AND ( order_meta_completed_date.meta_key = '_completed_date' ) ";
 			}
 
 			$query .= "WHERE p.post_type = 'shop_order' AND p.post_status IN {$post_status_string} AND p.post_date >= '{$start_date}' AND p.post_date < '{$end_date}' ";
@@ -645,10 +644,10 @@ class WC_Taxjar_Transaction_Sync {
 			$query = "SELECT p.id FROM {$wpdb->posts} AS p ";
 
 			if ( $should_validate_completed_date ) {
-				$query .= "INNER JOIN {$wpdb->postmeta} AS order_meta_completed_date ON ( p.id = order_meta_completed_date.post_id )  AND ( order_meta_completed_date.meta_key = '_completed_date' ) ";
+				$query .= "INNER JOIN {$wpdb->postmeta} AS order_meta_completed_date ON ( p.id = order_meta_completed_date.post_id ) AND ( order_meta_completed_date.meta_key = '_completed_date' ) ";
 			}
 
-			$query .= "LEFT JOIN {$wpdb->postmeta} AS order_meta_last_sync ON ( p.id = order_meta_last_sync.post_id )  AND ( order_meta_last_sync.meta_key = '_taxjar_last_sync' ) ";
+			$query .= "LEFT JOIN {$wpdb->postmeta} AS order_meta_last_sync ON ( p.id = order_meta_last_sync.post_id ) AND ( order_meta_last_sync.meta_key = '_taxjar_last_sync' ) ";
 			$query .= "WHERE p.post_type = 'shop_order' AND p.post_status IN {$post_status_string} AND p.post_date >= '{$start_date}' AND p.post_date < '{$end_date}' ";
 
 			if ( $should_validate_completed_date ) {


### PR DESCRIPTION
Currently the plugin only supports syncing orders that have completed or refunded status. Previously there were filters added to enable merchants to sync other statuses. However there is also a completed date validation that prevents orders that have never reached completed status from syncing. This prevented merchants from syncing orders with pending or other non complete statuses. This PR adds additional filters to allow merchants to bypass the date validation in these cases.

**Click-Test Versions**

- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
