### PR TITLE
Action scheduler 3.0 fix

### DIFF
--- a/includes/class-wc-taxjar-install.php
+++ b/includes/class-wc-taxjar-install.php
@@ -41,6 +41,15 @@ class WC_Taxjar_Install {
 		if ( ! defined( 'IFRAME_REQUEST' ) && version_compare( $current_version, '3.0.10', '<' ) && version_compare( $current_version, '2.3.1', '>' ) ) {
 			self::taxjar_3010_update();
 		}
+
+		if ( ! defined( 'IFRAME_REQUEST' ) && version_compare( $current_version, '3.0.13', '<' ) && version_compare( $current_version, '2.3.1', '>' ) ) {
+			self::taxjar_3013_update();
+		}
+	}
+
+	public static function taxjar_3013_update() {
+		as_unschedule_all_actions( WC_Taxjar_Transaction_Sync::PROCESS_BATCH_HOOK );
+		wp_clear_scheduled_hook( WC_Taxjar_Transaction_Sync::PROCESS_QUEUE_HOOK );
 	}
 
 	public static function taxjar_3010_update() {

--- a/includes/class-wc-taxjar-queue-list.php
+++ b/includes/class-wc-taxjar-queue-list.php
@@ -122,9 +122,6 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 			case 'retry_count':
 				return $record->retry_count;
 
-            case 'batch_id':
-                return ( ! empty( $record->batch_id ) ? $record->batch_id : "" );
-
             case 'last_error':
                 return $record->last_error;
 
@@ -180,7 +177,6 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 			'created_datetime'      => __( 'Created Time', 'wc-taxjar' ),
 			'processed_datetime'    => __( 'Sync Time', 'wc-taxjar' ),
 			'retry_count'           => __( 'Retry Count', 'wc-taxjar' ),
-			'batch_id'              => __( 'Batch ID', 'wc-taxjar' ),
 			'last_error'            => __( 'Last Error', 'wc-taxjar' ),
 			'taxjar_actions'        => __( 'Actions', 'wc-taxjar' ),
 		);

--- a/includes/class-wc-taxjar-record-queue.php
+++ b/includes/class-wc-taxjar-record-queue.php
@@ -22,23 +22,6 @@ class WC_Taxjar_Record_Queue {
 	}
 
 	/**
-	 * Update record status and batch id in queue
-	 *
-	 * @param array $queue_ids - array of queue ids that were added to batch
-	 * @param array $batch_id - id of batch
-	 * @return null
-	 */
-	static function add_records_to_batch( $queue_ids, $batch_id ) {
-		global $wpdb;
-
-		$table_name = self::get_queue_table_name();
-		$queue_ids_string = join( "','", $queue_ids );
-
-		$query = "UPDATE {$table_name} SET batch_id = {$batch_id} WHERE queue_id IN ('{$queue_ids_string}')";
-		$wpdb->get_results( $query );
-	}
-
-	/**
 	 * Get the queue ids of all active (new and awaiting) records in queue that are not in a batch
 	 *
 	 * @return array|bool - if active records are found returns array, otherwise returns false
@@ -48,8 +31,41 @@ class WC_Taxjar_Record_Queue {
 
 		$table_name = self::get_queue_table_name();
 
-		$query = "SELECT queue_id FROM {$table_name} WHERE status IN ( 'new', 'awaiting' ) AND batch_id = 0";
+		$query = "SELECT queue_id FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )";
 		$results = $wpdb->get_results( $query,  ARRAY_A );
+
+		return $results;
+	}
+
+	/**
+	 * Get the queue ids of a set number of active (new and awaiting) records in queue
+	 *
+	 * @param int $number_to_process - number of records to get from queue
+	 * @return array|bool - if active records are found returns array, otherwise returns false
+	 */
+	static function get_active_records_to_process( $number_to_process ) {
+		global $wpdb;
+
+		$table_name = self::get_queue_table_name();
+
+		$query = "SELECT * FROM {$table_name} WHERE status IN ( 'new', 'awaiting' ) LIMIT {$number_to_process}";
+		$results = $wpdb->get_results( $query,  ARRAY_A );
+
+		return $results;
+	}
+
+	/**
+	 * Gets the total number of records in queue that need processing
+	 *
+	 * @return int
+	 */
+	static function get_active_record_count() {
+		global $wpdb;
+
+		$table_name = self::get_queue_table_name();
+
+		$query = "SELECT COUNT(*) FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )";
+		$results = $wpdb->get_var( $query );
 
 		return $results;
 	}

--- a/includes/class-wc-taxjar-record-queue.php
+++ b/includes/class-wc-taxjar-record-queue.php
@@ -32,7 +32,7 @@ class WC_Taxjar_Record_Queue {
 		$table_name = self::get_queue_table_name();
 
 		$query = "SELECT queue_id FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )";
-		$results = $wpdb->get_results( $query,  ARRAY_A );
+		$results = $wpdb->get_results( $query, ARRAY_A );
 
 		return $results;
 	}
@@ -49,7 +49,7 @@ class WC_Taxjar_Record_Queue {
 		$table_name = self::get_queue_table_name();
 
 		$query = "SELECT * FROM {$table_name} WHERE status IN ( 'new', 'awaiting' ) LIMIT {$number_to_process}";
-		$results = $wpdb->get_results( $query,  ARRAY_A );
+		$results = $wpdb->get_results( $query, ARRAY_A );
 
 		return $results;
 	}
@@ -96,7 +96,7 @@ class WC_Taxjar_Record_Queue {
 		$table_name = self::get_queue_table_name();
 
 		$query = "SELECT queue_id, record_id FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )";
-		$results = $wpdb->get_results( $query,  ARRAY_A );
+		$results = $wpdb->get_results( $query, ARRAY_A );
 
 		return $results;
 	}
@@ -113,7 +113,7 @@ class WC_Taxjar_Record_Queue {
 		$queue_ids_string = join( "','", $queue_ids );
 
 		$query = "SELECT * FROM {$table_name} WHERE queue_id IN ('{$queue_ids_string}')";
-		$results = $wpdb->get_results( $query,  ARRAY_A );
+		$results = $wpdb->get_results( $query, ARRAY_A );
 
 		return $results;
 	}

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 3.0.12
+ * Version: 3.0.13
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 3.0.0
@@ -42,7 +42,7 @@ if ( ! $woocommerce_active || version_compare( get_option( 'woocommerce_db_versi
  */
 final class WC_Taxjar {
 
-	static $version = '3.0.12';
+	static $version = '3.0.13';
 	public static $minimum_woocommerce_version = '3.0.0';
 
 	/**

--- a/tests/specs/test-customer-sync.php
+++ b/tests/specs/test-customer-sync.php
@@ -485,16 +485,7 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		$record->load_object();
 		$record->save();
 
-		$batches = $this->tj->transaction_sync->process_queue();
-		$batch_timestamp = as_next_scheduled_action( WC_Taxjar_Transaction_Sync::PROCESS_BATCH_HOOK );
-		$this->assertNotFalse( $batch_timestamp );
-		foreach( $batches as $batch_id ) {
-			$batch = get_post( $batch_id );
-			$args = json_decode( $batch->post_content, true );
-			$this->assertContains( $record->get_queue_id(), $args[ 'queue_ids' ] );
-		}
-
-		$this->tj->transaction_sync->process_batch(  $args[ 'queue_ids' ] );
+		$this->tj->transaction_sync->process_queue();
 
 		$new_record = TaxJar_Customer_Record::find_active_in_queue( $customer->get_id() );
 		$this->assertFalse( $new_record );


### PR DESCRIPTION
Action Scheduler 3.0 changes how scheduled actions are stored in the database. Instead of being a custom post they are now stored in their own table. As part of this change they have limit the arguments field to 190 characters. Previously this was a longtext field used for storing a JSON string of the action arguments. With this change, TaxJar transaction sync batches with lots of orders would fail to migrate since their arguments JSON string was over the character limit. This would cause those batches to never run and sync to TaxJar.

In order to fix this we have changed our approach to using Action Scheduler. Instead of processing the queue and then running the transactions in batches in a later scheduled action, we have simplified our approach to process the queue and immediately begin syncing a set number of records from the queue (the batch size). Then if more transactions remain to be synced it will trigger the queue to process again at the next possible moment. Otherwise it will process the queue again at the normal schedule (every 20 minutes). 

This both makes the plugin fully compatible with Action Scheduler 3.0. It also resolves a previous issue where when batches timed out they would never retry and those orders in the batch would never be synced. (Now if a batch fails, the transactions will be resynced on the next queue process action).

**Steps to Reproduce**

1. Create or update 50 records so the sync queue has a least 50 records awaiting to be synced.
2. Process the queue so that there is a full batch
3. Install a plugin that uses action scheduler 3.0 and let the migration run
4. There will be a notice that the batch action failed to migrate

**Expected Result**

After applying the PR, this should happen.

Since we are no longer syncing in batches, when this version is installed it will remove all the batch scheduled actions and will process the queue every 20 minutes. So following the steps above the notification will not be given and then the transactions will sync normally.

**Click-Test Versions**

- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
