### PR TITLE
Improve Security of Ajax Requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,20 +12,28 @@ After applying the PR, this should happen.
 
 **Click-Test Versions**
 
+- [ ] Woo 4.0
+- [ ] Woo 3.9
+- [ ] Woo 3.8
+- [ ] Woo 3.7
+- [ ] Woo 3.6
 - [ ] Woo 3.5
 - [ ] Woo 3.4
 - [ ] Woo 3.3
 - [ ] Woo 3.2
 - [ ] Woo 3.1
 - [ ] Woo 3.0
-- [ ] Woo 2.6
 
 **Specs Passing**
 
+- [ ] Woo 4.0
+- [ ] Woo 3.9
+- [ ] Woo 3.8
+- [ ] Woo 3.7
+- [ ] Woo 3.6
 - [ ] Woo 3.5
 - [ ] Woo 3.4
 - [ ] Woo 3.3
 - [ ] Woo 3.2
 - [ ] Woo 3.1
 - [ ] Woo 3.0
-- [ ] Woo 2.6

--- a/includes/class-wc-taxjar-ajax.php
+++ b/includes/class-wc-taxjar-ajax.php
@@ -35,6 +35,7 @@ class WC_Taxjar_AJAX {
 		$response = array(
 			'success' => 1
 		);
+
 		wp_send_json( $response );
 	}
 

--- a/includes/class-wc-taxjar-ajax.php
+++ b/includes/class-wc-taxjar-ajax.php
@@ -23,12 +23,28 @@ class WC_Taxjar_AJAX {
 	}
 
 	public function wc_taxjar_update_nexus_cache() {
+		check_admin_referer( 'taxjar-update-nexus', 'security' );
+
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+			wp_die();
+		}
+
 		$taxjar_nexus = new WC_Taxjar_Nexus( new WC_Taxjar_Integration );
 		$taxjar_nexus->get_or_update_cached_nexus( true );
-		die();
+
+		$response = array(
+			'success' => 1
+		);
+		wp_send_json( $response );
 	}
 
 	public function wc_taxjar_run_transaction_backfill() {
+		check_admin_referer( 'taxjar-transaction-backfill', 'security' );
+
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+			wp_die();
+		}
+
 		$date_format = 'Y-m-d';
 
 		$start_date = current_time( $date_format );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1543,11 +1543,11 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			'wc-taxjar-admin',
 			'woocommerce_taxjar_admin',
 			array(
-				'ajax_url'         => admin_url( 'admin-ajax.php' ),
-				'update_api_nonce' => wp_create_nonce( 'update-api-key' ),
-				'current_user'     => get_current_user_id(),
-				'integration_uri'  => $this->integration_uri,
-				'api_token'        => $this->post_or_setting( 'api_token' ),
+				'ajax_url'                      => admin_url( 'admin-ajax.php' ),
+				'transaction_backfill_nonce'    => wp_create_nonce( 'taxjar-transaction-backfill' ),
+				'update_nexus_nonce'            => wp_create_nonce( 'taxjar-update-nexus' ),
+				'current_user'                  => get_current_user_id(),
+				'integration_uri'               => $this->integration_uri,
 			)
 		);
 

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -25,9 +25,9 @@ jQuery( document ).ready( function() {
 					action: 'wc_taxjar_update_nexus_cache',
 					security: woocommerce_taxjar_admin.update_nexus_nonce,
 				}
-			}).done(function( data ) {
+			}).done( function( data ) {
 				if ( data ) {
-					if (data.success == 1) {
+					if ( data.success == 1 ) {
 						alert( 'Nexus Addresses Synced' );
 					} else {
 						alert( 'Error occurred during nexus sync. Please try again.' );
@@ -62,20 +62,20 @@ jQuery( document ).ready( function() {
 							alert( 'No records found to add to queue.' );
 						} else {
 							if ( data.records_updated == 1 ) {
-								alert(data.records_updated + ' record added to queue and will sync to TaxJar shortly.');
+								alert( data.records_updated + ' record added to queue and will sync to TaxJar shortly.' );
 							} else {
-								alert(data.records_updated + ' records added to queue and will sync to TaxJar shortly.');
+								alert( data.records_updated + ' records added to queue and will sync to TaxJar shortly.' );
 							}
 						}
 					} else {
 						if ( data.error == "transaction sync disabled" ) {
 							alert( 'Sales tax reporting must be enabled to perform transaction backfill. Please enable this setting and try again.' );
 						} else {
-							alert('Error adding records to queue.');
+							alert( 'Error adding records to queue.' );
 						}
 					}
 				} else {
-					alert('Error occurred during transaction backfill.');
+					alert( 'Error occurred during transaction backfill.' );
 				}
 				$("body").css("cursor", "default");
 			});

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -23,11 +23,18 @@ jQuery( document ).ready( function() {
 				url: woocommerce_taxjar_admin.ajax_url,
 				data: {
 					action: 'wc_taxjar_update_nexus_cache',
-					security: woocommerce_taxjar_admin.update_api_nonce,
-					'woocommerce_taxjar-integration_api_token': woocommerce_taxjar_admin.api_token
+					security: woocommerce_taxjar_admin.update_nexus_nonce,
 				}
-			}).done(function() {
-				alert( 'Nexus Addresses Synced' );
+			}).done(function( data ) {
+				if ( data ) {
+					if (data.success == 1) {
+						alert( 'Nexus Addresses Synced' );
+					} else {
+						alert( 'Error occurred during nexus sync. Please try again.' );
+					}
+				} else {
+					alert( 'Error occurred during nexus sync. Please try again.' );
+				}
 				location.reload();
 			});
 		};
@@ -43,29 +50,32 @@ jQuery( document ).ready( function() {
 				url: woocommerce_taxjar_admin.ajax_url,
 				data: {
 					action: 'wc_taxjar_run_transaction_backfill',
-					security: woocommerce_taxjar_admin.update_api_nonce,
-					'woocommerce_taxjar-integration_api_token': woocommerce_taxjar_admin.api_token,
+					security: woocommerce_taxjar_admin.transaction_backfill_nonce,
 					'start_date': $('input#start_date').val(),
 					'end_date': $('input#end_date').val(),
 					'force_sync': $('input#force_sync').prop( 'checked' ),
 				}
 			}).done( function( data ) {
-				if ( data.records_updated != null ) {
-					if ( data.records_updated == 0 ) {
-						alert( 'No records found to add to queue.' );
-					} else {
-						if ( data.records_updated == 1 ) {
-							alert(data.records_updated + ' record added to queue and will sync to TaxJar shortly.');
+				if ( data ) {
+					if ( data.records_updated != null ) {
+						if ( data.records_updated == 0 ) {
+							alert( 'No records found to add to queue.' );
 						} else {
-							alert(data.records_updated + ' records added to queue and will sync to TaxJar shortly.');
+							if ( data.records_updated == 1 ) {
+								alert(data.records_updated + ' record added to queue and will sync to TaxJar shortly.');
+							} else {
+								alert(data.records_updated + ' records added to queue and will sync to TaxJar shortly.');
+							}
+						}
+					} else {
+						if ( data.error == "transaction sync disabled" ) {
+							alert( 'Sales tax reporting must be enabled to perform transaction backfill. Please enable this setting and try again.' );
+						} else {
+							alert('Error adding records to queue.');
 						}
 					}
 				} else {
-					if ( data.error == "transaction sync disabled" ) {
-						alert( 'Sales tax reporting must be enabled to perform transaction backfill. Please enable this setting and try again.' );
-					} else {
-						alert('Error adding records to queue.');
-					}
+					alert('Error occurred during transaction backfill.');
 				}
 				$("body").css("cursor", "default");
 			});

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,15 +25,11 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		// load WC
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );
 
-		// install WC Subscriptions
-		tests_add_filter( 'plugins_loaded', array( $this, 'install_subscriptions' ), -1 );
-
 		// install WC
 		tests_add_filter( 'setup_theme', array( $this, 'install_wc' ) );
 
 		// load the WP testing environment
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
-
 
 		$this->includes();
 	}
@@ -46,12 +42,6 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
 		update_option( 'woocommerce_db_version', WC_VERSION );
 		require_once $this->plugin_dir . 'taxjar-woocommerce-plugin/taxjar-woocommerce.php';
-	}
-
-	public function install_subscriptions() {
-		// load woocommerce subscriptions
-		update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
-		update_option( 'woocommerce_db_version', WC_VERSION );
 		require_once $this->plugin_dir . 'woocommerce-subscriptions/woocommerce-subscriptions.php';
 	}
 


### PR DESCRIPTION
Currently we have two ajax requests, to update nexus and to trigger a transaction backfill. Right now, neither the page that called the request or the permissons of the user are been validated. This means that there is the potential for anyone to be able to call these methods from outside of the site without having proper permissions.

This PR resolves the issue be creating security nonces that are loaded on the TaxJar settings page. These nonces are then send with the ajax requests and validated. This ensures that the ajax methods can only be called from those pages. This PR also validates the the current user has edit order permissions before the rest of the method runs.

This PR also includes a minor change to the load order when setting up the unit tests (necessary for testing on WooCommerce 4.0) as well as an update to the PR template to account for newer versions of WooCommerce.

**Steps to Reproduce**

1. Create a user with edit orders permissions
2. Attempt to sync nexus
3. Check the logs and confirm nexus was synced

**Expected Result**

After applying the PR, an error message will be displayed when attempting the request from an invalid page or when the user doesn't have the necessary permissions.

**Click-Test Versions**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
