### PR TITLE
If we don't have any $taxes, bail early

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -793,6 +793,10 @@ class WC_Taxjar_Integration extends WC_Settings_API {
             'exemption_type' => $exemption_type,
 		) );
 
+		if ( ! $taxes ) {
+			return;
+		}
+
 		$this->response_rate_ids = $taxes['rate_ids'];
 		$this->response_line_items = $taxes['line_items'];
 


### PR DESCRIPTION
Please see the [note in the community forums](https://wordpress.org/support/topic/calculate_tax-return-type/): we're getting unwanted 'noise' in the error logs, because a potentially false value is treated like an array. If it is not an array, there are no taxes to work with so we can just bail out early :-)