### PR TITLE
Prevent unnecessary logging after calculating tax

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -793,6 +793,10 @@ class WC_Taxjar_Integration extends WC_Settings_API {
             'exemption_type' => $exemption_type,
 		) );
 
+		if ( $taxes === false ) {
+			return;
+		}
+
 		$this->response_rate_ids = $taxes['rate_ids'];
 		$this->response_line_items = $taxes['line_items'];
 
@@ -887,6 +891,10 @@ class WC_Taxjar_Integration extends WC_Settings_API {
             'exemption_type' => $exemption_type,
 		) );
 
+		if ( $taxes === false ) {
+			return;
+		}
+
 		if ( class_exists( 'WC_Order_Item_Tax' ) ) { // Add tax rates manually for Woo 3.0+
 			foreach ( $order->get_items() as $item_key => $item ) {
 				$product_id = $item->get_product_id();
@@ -968,6 +976,10 @@ class WC_Taxjar_Integration extends WC_Settings_API {
             'customer_id' => $customer_id,
             'exemption_type' => $exemption_type,
 	    ) );
+
+	    if ( $taxes === false ) {
+		    return;
+	    }
 
 	    if ( class_exists( 'WC_Order_Item_Tax' ) ) { // Add tax rates manually for Woo 3.0+
 		    foreach ( $order->get_items() as $item_key => $item ) {


### PR DESCRIPTION
There are situations where the plugin's calculate tax method returns false (Vat exempt, not enough data to perform request to TaxJar, etc). In these situations unnecessary messages would be logged to the error log. There were also situations where unnecessary processing would occur. This PR resolves the issue by exiting the method when no tax is calculated through TaxJar.
 
**Steps to Reproduce**

1. Empty the error log
2. Create a VAT exempt customer
3. Add a product to the cart and go to cart/checkout so that the tax calculation is run.
4. Check error log to see unnecessary messages

**Expected Result**

After applying the PR, in step 4 there will no longer be any messages in the error log.

**Click-Test Versions**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
