### PR TITLE
SmartCalcs Connect

### DIFF
--- a/includes/class-wc-taxjar-connection.php
+++ b/includes/class-wc-taxjar-connection.php
@@ -61,7 +61,7 @@ class WC_Taxjar_Connection {
 			if ( $this->integration->post_or_setting( 'api_token' ) && isset( $body->valid ) && false === $body->valid ) {
 				$description .= '<span style="color: #ff0000;"><strong>';
 				$description .= 'It looks like your API token is invalid.';
-				$description .= sprintf( '<br><a href="%s" target="_blank">Please review your API token.</a>', $this->integration->app_uri . 'account#api-access' );
+				$description .= sprintf( '<br><span style="color: black;">Please attempt to reconnect to TaxJar or </span><a href="%s" target="_blank">review your API token here.</a>', $this->integration->app_uri . 'account#api-access' );
 				$description .= '</strong></span>';
 				$this->api_token_valid = false;
 			}

--- a/includes/class-wc-taxjar-connection.php
+++ b/includes/class-wc-taxjar-connection.php
@@ -61,7 +61,7 @@ class WC_Taxjar_Connection {
 			if ( $this->integration->post_or_setting( 'api_token' ) && isset( $body->valid ) && false === $body->valid ) {
 				$description .= '<span style="color: #ff0000;"><strong>';
 				$description .= 'It looks like your API token is invalid.';
-				$description .= sprintf( '<br><span style="color: black;">Please attempt to reconnect to TaxJar or </span><a href="%s" target="_blank">review your API token here.</a>', $this->integration->app_uri . 'account#api-access' );
+				$description .= sprintf( '<br><span style="color: black;">Please attempt to reconnect to TaxJar or </span><a href="%s" target="_blank">review your API token.</a>', $this->integration->app_uri . 'account#api-access' );
 				$description .= '</strong></span>';
 				$this->api_token_valid = false;
 			}

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -32,7 +32,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 	public function __construct() {
 		$this->id                 = 'taxjar-integration';
 		$this->method_title       = __( 'TaxJar', 'wc-taxjar' );
-		$this->method_description = apply_filters( 'taxjar_method_description', __( 'TaxJar is the easiest to use sales tax calculation and reporting engine for WooCommerce. Enter your API token (<a href="https://app.taxjar.com/api_sign_up/" target="_blank">click here to get a token</a>), city, and zip code from which your store ships. Enable TaxJar calculations to automatically collect sales tax at checkout. You may also enable order downloads to begin importing transactions from this store into your TaxJar account, all in one click!<br><br><b>For the fastest help, please email <a href="mailto:support@taxjar.com">support@taxjar.com</a>. We\'ll get back to you within hours.</b>', 'wc-taxjar' ) );
+		$this->method_description = apply_filters( 'taxjar_method_description', __( 'TaxJar is the easiest to use sales tax calculation and reporting engine for WooCommerce. Connect your TaxJar account and enter the city and zip code from which your store ships. Enable TaxJar calculations to automatically collect sales tax at checkout. You may also enable sales tax reporting to begin importing transactions from this store into your TaxJar account, all in one click!<br><br><b>For the fastest help, please email <a href="mailto:support@taxjar.com">support@taxjar.com</a>. We\'ll get back to you within hours.</b>', 'wc-taxjar' ) );
 		$this->app_uri            = 'https://app.taxjar.com/';
 		$this->integration_uri    = $this->app_uri . 'account/apps/add/woo';
 		$this->regions_uri        = $this->app_uri . 'account#states';
@@ -254,7 +254,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 				array(
 					'title' => __( 'TaxJar', 'wc-taxjar' ),
 					'type'  => 'title',
-					'desc'  => __( "TaxJar is the easiest to use sales tax calculation and reporting engine for WooCommerce. Enter your API token", 'wc-taxjar' ) . ' (<a href="https://app.taxjar.com/api_sign_up/" target="_blank">' . __( "click here to get a token", 'wc-taxjar' ) . '</a>)' . __( ", city, and zip code from which your store ships. Enable TaxJar calculations to automatically collect sales tax at checkout. You may also enable order downloads to begin importing transactions from this store into your TaxJar account, all in one click!", 'wc-taxjar' ),
+					'desc'  => __( "TaxJar is the easiest to use sales tax calculation and reporting engine for WooCommerce. Connect your TaxJar account and enter the city and zip code from which your store ships. Enable TaxJar calculations to automatically collect sales tax at checkout. You may also enable sales tax reporting to begin importing transactions from this store into your TaxJar account, all in one click!", 'wc-taxjar' ),
 				),
 				array(
 					'type' => 'sectionend',
@@ -307,9 +307,9 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			}
 
 			array_push( $settings, array(
-				'title'   => '',
+				'title'   => 'TaxJar API Token',
 				'type'	=> 'text',
-				'desc'	=> __( '<p class="hidden tj-api-token-title"><a href="' . $this->app_uri . 'account#api-access" target="_blank">Click here</a> to get your API token.</p>', 'wc-taxjar' ),
+				'desc'	=> __( '<p class="hidden tj-api-token-title"><a href="' . $this->app_uri . 'account#api-access" target="_blank">Get API token</a></p>', 'wc-taxjar' ),
 				'default' => '',
 				'class'   => 'hidden',
 				'id'	  => 'woocommerce_taxjar-integration_settings[api_token]'

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1611,8 +1611,8 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 	  * @return string - TaxJar connect popup url
 	  */
 	public function get_connect_url() {
-		$connect_url =  $this->app_uri . 'smartcalcs/connect/magento/?store=' . urlencode( get_bloginfo( 'url' ) );
-		$connect_url .= '&plugin=magento2&version=' . WC_Taxjar::$version;
+		$connect_url =  $this->app_uri . 'smartcalcs/connect/woo/?store=' . urlencode( get_bloginfo( 'url' ) );
+		$connect_url .= '&plugin=woo&version=' . WC_Taxjar::$version;
 		return esc_url( $connect_url );
 	}
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -281,14 +281,14 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 					array_push( $settings, array(
 						'title' => '',
 						'type'  => 'title',
-						'desc'  => '<div class="taxjar-connected><span class="dashicons dashicons-yes-alt"></span><p>' . $connected_email . '</p></div>',
+						'desc'  => '<div class="taxjar-connected"><span class="dashicons dashicons-yes-alt"></span><p>' . $connected_email . '</p></div>',
 						'id'	=> 'connected-to-taxjar'
 					) );
 				} else {
 					array_push( $settings, array(
 						'title' => '',
 						'type'  => 'title',
-						'desc'  => '<div class="taxjar-connected><span class="dashicons dashicons-yes-alt"></span><p>Connected To TaxJar</p></div>',
+						'desc'  => '<div class="taxjar-connected"><span class="dashicons dashicons-yes-alt"></span><p>Connected To TaxJar</p></div>',
 						'id'	=> 'connected-to-taxjar'
 					) );
 				}
@@ -296,13 +296,13 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 				array_push( $settings, array(
 					'title' => '',
 					'type'  => 'title',
-					'desc'  => __( '<button id="disconnect-from-taxjar" name="disconnect-from-taxjar" class="button-primary" type="submit" value="Disconnect">Disconnect From TaxJar</button><p><a href="#" id="connect-manual-edit">Click here to edit API Token manually.</a></p>', 'wc-taxjar' ),
+					'desc'  => __( '<button id="disconnect-from-taxjar" name="disconnect-from-taxjar" class="button-primary" type="submit" value="Disconnect">Disconnect From TaxJar</button><p><a href="#" id="connect-manual-edit">Edit API Token</a></p>', 'wc-taxjar' ),
 				) );
 			} else {
 				array_push( $settings, array(
 					'title' => '',
 					'type'  => 'title',
-					'desc'  => __( '<button id="connect-to-taxjar" name="connect-to-taxjar" class="button-primary" type="submit" value="Connect">Connect To TaxJar</button><p>Already have an API Token? <a href="#" id="connect-manual-edit">Click here to manually edit.</a></p>', 'wc-taxjar' ),
+					'desc'  => __( '<button id="connect-to-taxjar" name="connect-to-taxjar" class="button-primary" type="submit" value="Connect">Connect To TaxJar</button><p>Already have an API Token? <a href="#" id="connect-manual-edit">Edit API Token.</a></p>', 'wc-taxjar' ),
 				) );
 			}
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -375,7 +375,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 						'type' => 'title',
 					);
 					$settings[] = array(
-						'title'	=> __( 'Ship From Address', 'wc-taxjar' ),
+						'title'    => __( 'Ship From Address', 'wc-taxjar' ),
 						'type'     => 'text',
 						'desc'     => __( 'Enter the street address where your store ships from.', 'wc-taxjar' ),
 						'desc_tip' => true,
@@ -1611,7 +1611,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 	  * @return string - TaxJar connect popup url
 	  */
 	public function get_connect_url() {
-		$connect_url =  $this->app_uri . 'smartcalcs/connect/woo/?store=' . urlencode( get_bloginfo( 'url' ) );
+		$connect_url = $this->app_uri . 'smartcalcs/connect/woo/?store=' . urlencode( get_bloginfo( 'url' ) );
 		$connect_url .= '&plugin=woo&version=' . WC_Taxjar::$version;
 		return esc_url( $connect_url );
 	}

--- a/includes/css/admin.css
+++ b/includes/css/admin.css
@@ -47,3 +47,31 @@
 .widefat .column-taxjar_actions a.view::after {
 	content: "\f177";
 }
+
+#connected-to-taxjar-description .dashicons-yes-alt {
+	color: #3FAE2A;
+	font-size: 32px;
+	display: inline-block;
+}
+
+div#connected-to-taxjar-description div {
+	display: inline-block;
+	padding: 20px;
+	padding-right: 40px;
+	padding-left: 20px;
+	background-color: white;
+	border-left: 4px solid;
+	border-color: #3FAE2A;
+}
+
+div#connected-to-taxjar-description p {
+	display: inline-block;
+	margin-left: 10px;
+	font-size: 1.3em;
+	margin-top: 3px;
+	margin-bottom: 3px;
+}
+
+#disconnect-from-taxjar {
+	margin-top: 20px;
+}

--- a/includes/css/admin.css
+++ b/includes/css/admin.css
@@ -52,6 +52,7 @@
 	color: #3FAE2A;
 	font-size: 32px;
 	display: inline-block;
+	margin-right: 10px;
 }
 
 div#connected-to-taxjar-description div {
@@ -74,4 +75,19 @@ div#connected-to-taxjar-description p {
 
 #disconnect-from-taxjar {
 	margin-top: 20px;
+}
+
+.dashicons-yes-alt:before {
+	content: "\2713";
+	color: white;
+	background-color: #3FAE2A;
+	border-radius: 50%;
+	padding: 3px 10px;
+	position: relative;
+	top: -3px;
+	padding-bottom: 8px;
+}
+
+.woocommerce table.form-table th label[for="woocommerce_taxjar-integration_settings[api_token]"] {
+	display: none;
 }

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -27,7 +27,6 @@ jQuery( document ).ready( function() {
 
 			var input = $( "<input>" ).attr( "type", "hidden" ).attr( "name", "save" ).val( "Save changes" );
 			$( '#mainform' ).append( input );
-			//$( '#mainform button.woocommerce-save-button' ).click();
 			$( '#mainform' ).submit();
 		};
 
@@ -74,7 +73,9 @@ jQuery( document ).ready( function() {
 
 			window.popup = window.open(url, title, 'scrollbars=yes, width=' + w + ', height=' + h + ', top=' + top + ', left=' + left);
 
-			if (window.focus) window.popup.focus();
+			if (window.focus) {
+				window.popup.focus();
+			}
 		};
 
 		var clean_api_key = function() {

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -33,13 +33,14 @@ jQuery( document ).ready( function() {
 		var connect_manual_edit = function( e ) {
 			e.preventDefault();
 			$( '.tj-api-token-title' ).parent().parent().find( 'label' ).text( 'API Token' );
-			$( '.tj-api-token-title' ).removeClass('hidden');
-			$( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).removeClass('hidden');
+			$( '.tj-api-token-title' ).removeClass( 'hidden' );
+			$( 'label[for="woocommerce_taxjar-integration_settings[api_token]"]' ).show();
+			$( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).removeClass( 'hidden' );
 			$( 'p.submit' ).show();
 		};
 
-		var handle_connect_callback = function(e) {
-			if (e.origin !== woocommerce_taxjar_admin.app_url ) {
+		var handle_connect_callback = function( e ) {
+			if ( e.origin !== woocommerce_taxjar_admin.app_url ) {
 				return;
 			}
 
@@ -47,33 +48,33 @@ jQuery( document ).ready( function() {
 				var data = JSON.parse( e.data );
 				if ( data.api_token && data.email ) {
 					window.popup.postMessage( 'Data received', woocommerce_taxjar_admin.app_url );
-					$( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).val( data.api_token )
+					$( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).val( data.api_token );
 					$( '#woocommerce_taxjar-integration_settings\\[connected_email\\]' ).val( data.email );
 					$( '#mainform button.woocommerce-save-button' ).click();
 				} else {
 					throw 'Invalid data';
 				}
-			} catch(e) {
-				alert('Invalid API token or email provided. Please try connecting to TaxJar again or contact support@taxjar.com.');
-			}
-		};
+			} catch( e ) {
+			alert( 'Invalid API token or email provided. Please try connecting to TaxJar again or contact support@taxjar.com.' );
+		}
+	};
 
 		var open_connect_popup = function( e ) {
 			e.preventDefault();
 			openPopup( woocommerce_taxjar_admin.connect_url, "Connect to TaxJar", 400, 500 );
 		};
 
-		var openPopup = function(url, title, w, h) {
+		var openPopup = function( url, title, w, h ) {
 			var dualScreenLeft = window.screenLeft != undefined ? window.screenLeft : screen.left;
 			var dualScreenTop = window.screenTop != undefined ? window.screenTop : screen.top;
 			var width = window.innerWidth ? window.innerWidth : document.documentElement.clientWidth ? document.documentElement.clientWidth : screen.width;
 			var height = window.innerHeight ? window.innerHeight : document.documentElement.clientHeight ? document.documentElement.clientHeight : screen.height;
-			var left = ((width / 2) - (w / 2)) + dualScreenLeft;
-			var top = ((height / 2) - (h / 2)) + dualScreenTop;
+			var left = ( ( width / 2 ) - ( w / 2 ) ) + dualScreenLeft;
+			var top = ( ( height / 2 ) - ( h / 2 ) ) + dualScreenTop;
 
-			window.popup = window.open(url, title, 'scrollbars=yes, width=' + w + ', height=' + h + ', top=' + top + ', left=' + left);
+			window.popup = window.open( url, title, 'scrollbars=yes, width=' + w + ', height=' + h + ', top=' + top + ', left=' + left );
 
-			if (window.focus) {
+			if ( window.focus ) {
 				window.popup.focus();
 			}
 		};

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -8,6 +8,73 @@ jQuery( document ).ready( function() {
 			$( '.js-wc-taxjar-sync-nexus-addresses' ).on( 'click', sync_nexus_addresses );
 			$( '.taxjar-datepicker' ).datepicker({ dateFormat: 'yy-mm-dd' });
 			$( '.js-wc-taxjar-transaction-backfill' ).on( 'click', trigger_backfill );
+			$( '#connect-to-taxjar' ).on( 'click', open_connect_popup );
+			$( '#disconnect-from-taxjar' ).on( 'click', disconnect_taxjar );
+			$( 'a#connect-manual-edit' ).on( 'click', connect_manual_edit );
+			window.addEventListener( 'message', handle_connect_callback, false );
+			hide_save_on_connect();
+		};
+
+		var hide_save_on_connect = function() {
+			if ( ! $( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).is( ':visible' ) && $( '#connect-to-taxjar' ).length ) {
+				$( 'p.submit' ).hide();
+			}
+		};
+
+		var disconnect_taxjar = function( e ) {
+			$( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).val( '' )
+			$( '#woocommerce_taxjar-integration_settings\\[connected_email\\]' ).val( '' );
+
+			var input = $( "<input>" ).attr( "type", "hidden" ).attr( "name", "save" ).val( "Save changes" );
+			$( '#mainform' ).append( input );
+			//$( '#mainform button.woocommerce-save-button' ).click();
+			$( '#mainform' ).submit();
+		};
+
+		var connect_manual_edit = function( e ) {
+			e.preventDefault();
+			$( '.tj-api-token-title' ).parent().parent().find( 'label' ).text( 'API Token' );
+			$( '.tj-api-token-title' ).removeClass('hidden');
+			$( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).removeClass('hidden');
+			$( 'p.submit' ).show();
+		};
+
+		var handle_connect_callback = function(e) {
+			if (e.origin !== woocommerce_taxjar_admin.app_url ) {
+				return;
+			}
+
+			try {
+				var data = JSON.parse( e.data );
+				if ( data.api_token && data.email ) {
+					window.popup.postMessage( 'Data received', woocommerce_taxjar_admin.app_url );
+					$( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).val( data.api_token )
+					$( '#woocommerce_taxjar-integration_settings\\[connected_email\\]' ).val( data.email );
+					$( '#mainform button.woocommerce-save-button' ).click();
+				} else {
+					throw 'Invalid data';
+				}
+			} catch(e) {
+				alert('Invalid API token or email provided. Please try connecting to TaxJar again or contact support@taxjar.com.');
+			}
+		};
+
+		var open_connect_popup = function( e ) {
+			e.preventDefault();
+			openPopup( woocommerce_taxjar_admin.connect_url, "Connect to TaxJar", 400, 500 );
+		};
+
+		var openPopup = function(url, title, w, h) {
+			var dualScreenLeft = window.screenLeft != undefined ? window.screenLeft : screen.left;
+			var dualScreenTop = window.screenTop != undefined ? window.screenTop : screen.top;
+			var width = window.innerWidth ? window.innerWidth : document.documentElement.clientWidth ? document.documentElement.clientWidth : screen.width;
+			var height = window.innerHeight ? window.innerHeight : document.documentElement.clientHeight ? document.documentElement.clientHeight : screen.height;
+			var left = ((width / 2) - (w / 2)) + dualScreenLeft;
+			var top = ((height / 2) - (h / 2)) + dualScreenTop;
+
+			window.popup = window.open(url, title, 'scrollbars=yes, width=' + w + ', height=' + h + ', top=' + top + ', left=' + left);
+
+			if (window.focus) window.popup.focus();
 		};
 
 		var clean_api_key = function() {


### PR DESCRIPTION
Currently when setting up the plugin the user is required to navigate to the TaxJar app, get their API token, and then return to the plugin setting page to save the token and link their store with TaxJar. This PR provides a UI that allows the customer to simple click a connect button during setup, which will open a login to TaxJar, after signing in their API token will be automatically added and saved.

**Click-Test Versions**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
