### PR TITLE
Fix no unit price of fee created through API issue

### DIFF
--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -322,7 +322,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 			foreach( $fees as $fee ) {
 				$tax_code = WC_Taxjar_Integration::get_tax_code_from_class( $fee->get_tax_class() );
 
-				if ( method_exists( $fee, 'get_amount' ) ) {
+				if ( method_exists( $fee, 'get_amount' ) && $fee->get_amount() ) {
 					$fee_amount = $fee->get_amount();
 				} else {
 					$fee_amount = $fee->get_total();


### PR DESCRIPTION
When an order is created through the WooCommerce API and contains a fee, our plugin was not getting a value for the unit price when submitting the order to the TaxJar API. This caused the API request to fail and the order to not be synced to TaxJar. This PR resolves the issue but ensuring that if there is not an amount set on the fee, it will utilize the fee total.

**Steps to Reproduce**

1. Create an order containing a fee through the Woo API and mark the order as completed.
2. Manually trigger the sync queue to process
3.  Check the sync queue for the order created in step one, and there will be an error indicating the order could not sync due to mismatching order and line totals.

**Expected Result**

After applying the PR, in step 3 the order will have synced successfully.

**Click-Test Versions**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

