### PR TITLE
Fix connect display with older woo versions

### DIFF
--- a/includes/css/admin.css
+++ b/includes/css/admin.css
@@ -55,6 +55,17 @@ div.taxjar-connected .dashicons-yes-alt {
 	margin-right: 10px;
 }
 
+div.taxjar-connected .dashicons-yes-alt:before {
+	content: "\2713";
+	color: white;
+	background-color: #3FAE2A;
+	border-radius: 50%;
+	padding: 3px 10px;
+	position: relative;
+	top: -3px;
+	padding-bottom: 8px;
+}
+
 div.taxjar-connected {
 	display: inline-block;
 	padding: 20px;
@@ -75,17 +86,6 @@ div.taxjar-connected p {
 
 #disconnect-from-taxjar {
 	margin-top: 20px;
-}
-
-div.taxjar-connected .dashicons-yes-alt:before {
-	content: "\2713";
-	color: white;
-	background-color: #3FAE2A;
-	border-radius: 50%;
-	padding: 3px 10px;
-	position: relative;
-	top: -3px;
-	padding-bottom: 8px;
 }
 
 .woocommerce table.form-table th label[for="woocommerce_taxjar-integration_settings[api_token]"] {

--- a/includes/css/admin.css
+++ b/includes/css/admin.css
@@ -48,14 +48,14 @@
 	content: "\f177";
 }
 
-#connected-to-taxjar-description .dashicons-yes-alt {
+div.taxjar-connected .dashicons-yes-alt {
 	color: #3FAE2A;
 	font-size: 32px;
 	display: inline-block;
 	margin-right: 10px;
 }
 
-div#connected-to-taxjar-description div {
+div.taxjar-connected {
 	display: inline-block;
 	padding: 20px;
 	padding-right: 40px;
@@ -65,7 +65,7 @@ div#connected-to-taxjar-description div {
 	border-color: #3FAE2A;
 }
 
-div#connected-to-taxjar-description p {
+div.taxjar-connected p {
 	display: inline-block;
 	margin-left: 10px;
 	font-size: 1.3em;
@@ -77,7 +77,7 @@ div#connected-to-taxjar-description p {
 	margin-top: 20px;
 }
 
-.dashicons-yes-alt:before {
+div.taxjar-connected .dashicons-yes-alt:before {
 	content: "\2713";
 	color: white;
 	background-color: #3FAE2A;

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -50,7 +50,7 @@ jQuery( document ).ready( function() {
 					window.popup.postMessage( 'Data received', woocommerce_taxjar_admin.app_url );
 					$( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).val( data.api_token );
 					$( '#woocommerce_taxjar-integration_settings\\[connected_email\\]' ).val( data.email );
-					$( '#mainform button.woocommerce-save-button' ).click();
+					$( '#mainform .woocommerce-save-button' ).click();
 				} else {
 					throw 'Invalid data';
 				}


### PR DESCRIPTION
On older versions of the the WooCommerce plugin some of the smart calcs connect javascript and css were not working properly. This PR resolves the issue.

**Click-Test Versions**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
