### PR TITLE
Fix bad url in connect notification

### DIFF
--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -291,8 +291,7 @@ final class WC_Taxjar {
 	public function get_settings_url() {
 		$url = admin_url( 'admin.php' );
 		$url = add_query_arg( 'page', 'wc-settings', $url );
-		$url = add_query_arg( 'tab', 'integration', $url );
-		$url = add_query_arg( 'section', 'taxjar-integration', $url );
+		$url = add_query_arg( 'tab', 'taxjar-integration', $url );
 
 		return $url;
 	}


### PR DESCRIPTION
There is a bad link in the connection notification that appears when the TaxJar plugin has been installed but has not yet been connected to TaxJar. This PR fixes the link to go to the correct settings page.

**Steps to Reproduce**

1. Install TaxJar plugin
2. Click the link the in the connect to TaxJar notification
3. It will go to a settings page that does not exist 

**Expected Result**

After applying the PR, the link will take you to the correct settings page.

**Click-Test Versions**

- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
