### PR TITLE
Fix issue with tax codes being lowercased when sent to TaxJar API

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1185,8 +1185,6 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			}
 
 			$this->backend_tax_classes[$id] = $tax_class_name;
-
-			$tax_class = explode( '-', $tax_class_name );
 			$tax_code = self::get_tax_code_from_class( $tax_class_name );
 
 			if ( 'taxable' !== $tax_status ) {
@@ -1660,7 +1658,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 		    $tax_code = end( $tax_class );
 	    }
 
-        return $tax_code;
+        return strtoupper( $tax_code );
     }
 
     /**

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -494,7 +494,7 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$record = new TaxJar_Order_Record( $order->get_id(), true );
 		$record->load_object( $order );
 		$fee_line_items = $record->get_fee_line_items();
-		$this->assertEquals( 'rate', $fee_line_items[ 0 ][ 'product_tax_code' ] );
+		$this->assertEquals( 'RATE', $fee_line_items[ 0 ][ 'product_tax_code' ] );
 
 		$order = TaxJar_Order_Helper::create_order( 1 );
 		$fee = new WC_Order_Item_Fee();


### PR DESCRIPTION
WooCommerce lowercases product tax code before storing them in the database. When the plugin pulls these codes to send them to TaxJar it uses the lowercased version which sometimes does not exactly match the TaxJar exemption code. This can cause products which should have been exempted to be taxed. This PR ensures the exemption code sent to TaxJar will match.

**Steps to Reproduce**

1. Create a tax class using the TaxJar giftcard exemption code (14111803A0001).
2. Apply this class to a product
3. Add the product to the cart and go to checkout. Tax will be calculated for the product

**Expected Result**

After applying the PR, in step 3 the product will be exempt from tax.

**Click-Test Versions**

- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
