### PR TITLE
Add plugin parameter to all transactions requests to TaxJar API

### DIFF
--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -527,4 +527,12 @@ abstract class TaxJar_Record {
 	public function set_last_error( $last_error ) {
 		$this->last_error = $last_error;
 	}
+
+	/**
+	 * Generates the plugin parameter used to identify requests in the TaxJar API
+	 * @return string
+	 */
+	public function get_plugin_parameter() {
+		return 'woo';
+	}
 }

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -95,6 +95,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 		$data = $this->get_data();
 		$url = self::API_URI . 'transactions/orders';
 		$data[ 'provider' ] = $this->get_provider();
+		$data[ 'plugin' ] = $this->get_plugin_parameter();
 		$body = wp_json_encode( $data );
 
 		$response = wp_remote_post( $url, array(
@@ -116,6 +117,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 
 		$url = self::API_URI . 'transactions/orders/' . $order_id;
 		$data[ 'provider' ] = $this->get_provider();
+		$data[ 'plugin' ] = $this->get_plugin_parameter();
 		$body = wp_json_encode( $data );
 
 		$response = wp_remote_request( $url, array(
@@ -137,7 +139,8 @@ class TaxJar_Order_Record extends TaxJar_Record {
 		$url = self::API_URI . 'transactions/orders/' . $order_id;
 		$data = array(
 			'transaction_id' => $order_id,
-			'provider' => $this->get_provider()
+			'provider' => $this->get_provider(),
+			'plugin' => $this->get_plugin_parameter()
 		);
 		$body = wp_json_encode( $data );
 
@@ -157,7 +160,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 
 	public function get_from_taxjar() {
 		$order_id = $this->get_transaction_id();
-		$url = self::API_URI . 'transactions/orders/' . $order_id . '?provider=woo';
+		$url = self::API_URI . 'transactions/orders/' . $order_id . '?provider=' . $this->get_provider() . '&plugin=' . $this->get_plugin_parameter();
 
 		$response = wp_remote_request( $url, array(
 			'method' => 'GET',

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -262,6 +262,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		$data = $this->get_data();
 		$url = self::API_URI . 'transactions/refunds';
 		$data[ 'provider' ] = $this->get_provider();
+		$data[ 'plugin' ] = $this->get_plugin_parameter();
 		$body = wp_json_encode( $data );
 
 		$response = wp_remote_post( $url, array(
@@ -283,6 +284,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 
 		$url = self::API_URI . 'transactions/refunds/' . $refund_id;
 		$data[ 'provider' ] = $this->get_provider();
+		$data[ 'plugin' ] = $this->get_plugin_parameter();
 		$body = wp_json_encode( $data );
 
 		$response = wp_remote_request( $url, array(
@@ -304,7 +306,8 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		$url = self::API_URI . 'transactions/refunds/' . $refund_id;
 		$data = array(
 			'transaction_id' => $refund_id,
-			'provider' => $this->get_provider()
+			'provider' => $this->get_provider(),
+			'plugin' => $this->get_plugin_parameter()
 		);
 		$body = wp_json_encode( $data );
 
@@ -324,7 +327,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 
 	public function get_from_taxjar() {
 		$refund_id = $this->get_transaction_id();
-		$url = self::API_URI . 'transactions/refunds/' . $refund_id . '?provider=woo';
+		$url = self::API_URI . 'transactions/refunds/' . $refund_id . '?provider=' . $this->get_provider() . '&plugin=' . $this->get_plugin_parameter();
 
 		$response = wp_remote_request( $url, array(
 			'method' => 'GET',


### PR DESCRIPTION
An additional parameter was needed to identify requests within the TaxJar API. This parameter has now been added.

**Click-Test Versions**

- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0

**Specs Passing**

- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
- [X] Woo 3.1
- [X] Woo 3.0
