### PR TITLE
Fix undefined index on TaxJar settings when wp_debug is enabled

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1399,7 +1399,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 
         if ( isset( $_POST[ 'woocommerce_taxjar-integration_settings' ][ $key ] ) ) {
             $val = $_POST[ 'woocommerce_taxjar-integration_settings' ][ $key ];
-        } else {
+        } elseif ( isset( $this->settings[ $key ] ) ) {
             $val = $this->settings[ $key ];
         }
 


### PR DESCRIPTION
_Describe the problem ([reference the issue](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) if applicable) and what the PR accomplishes._

Loading the TaxJar settings page with wp_debug enabled can generate notices for undefined array keys.  This PR checks if the array key exists before utilizing it.

**Steps to Reproduce**

1. Ensure php's error_reporting is set to E_ALL in php.ini and wp_debug is set to true 
2. Load the TaxJar settings page 
3. A PHP Notice is generated for undefined array keys

**Expected Result**

Loading the TaxJar settings page with wp_debug enabled generates zero notices.  

**Click-Test Versions**
- [X] Woo 4.2
- [ ] Woo 4.0
- [ ] Woo 3.9
- [ ] Woo 3.8
- [ ] Woo 3.7
- [ ] Woo 3.6
- [ ] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0

**Specs Passing**

- [ ] Woo 4.0
- [ ] Woo 3.9
- [ ] Woo 3.8
- [ ] Woo 3.7
- [ ] Woo 3.6
- [ ] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
