### PR TITLE
INT-1043 Shipping Rate Fix

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -638,9 +638,14 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			$taxes['freight_taxable']    = (int) $taxjar_response->freight_taxable;
 			$taxes['has_nexus']          = (int) $taxjar_response->has_nexus;
 			$taxes['tax_rate']           = $taxjar_response->rate;
-			$taxes['shipping_rate']      = $taxjar_response->breakdown->shipping->combined_tax_rate;
+			$taxes['shipping_rate']      = $taxjar_response->rate;
 
 			if ( ! empty( $taxjar_response->breakdown ) ) {
+
+			    if ( ! empty( $taxjar_response->breakdown->shipping ) ) {
+				    $taxes['shipping_rate'] = $taxjar_response->breakdown->shipping->combined_tax_rate;
+                }
+
 				if ( ! empty( $taxjar_response->breakdown->line_items ) ) {
 					$line_items = array();
 					foreach ( $taxjar_response->breakdown->line_items as $line_item ) {

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -638,6 +638,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			$taxes['freight_taxable']    = (int) $taxjar_response->freight_taxable;
 			$taxes['has_nexus']          = (int) $taxjar_response->has_nexus;
 			$taxes['tax_rate']           = $taxjar_response->rate;
+			$taxes['shipping_rate']      = $taxjar_response->breakdown->shipping->combined_tax_rate;
 
 			if ( ! empty( $taxjar_response->breakdown ) ) {
 				if ( ! empty( $taxjar_response->breakdown->line_items ) ) {
@@ -689,7 +690,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			// Add shipping tax rate
 			$taxes['rate_ids']['shipping'] = $this->create_or_update_tax_rate(
 				$location,
-				$taxes['tax_rate'] * 100,
+				$taxes['shipping_rate'] * 100,
 				'',
 				$taxes['freight_taxable']
 			);
@@ -825,6 +826,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 
 		$address = $this->get_address( $wc_cart_object );
 		$line_items = $this->get_line_items( $wc_cart_object );
+		$shipping_total = $wc_cart_object->get_shipping_total();
 
 		$customer_id = 0;
 		if ( is_object( WC()->customer ) ) {
@@ -839,7 +841,7 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			'to_state' => $address['to_state'],
 			'to_city' => $address['to_city'],
 			'to_street' => $address['to_street'],
-			'shipping_amount' => WC()->shipping->shipping_total,
+			'shipping_amount' => $shipping_total,
 			'line_items' => $line_items,
             'customer_id' => $customer_id,
             'exemption_type' => $exemption_type,

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -637,7 +637,6 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			// Update Properties based on Response
 			$taxes['freight_taxable']    = (int) $taxjar_response->freight_taxable;
 			$taxes['has_nexus']          = (int) $taxjar_response->has_nexus;
-			$taxes['tax_rate']           = $taxjar_response->rate;
 			$taxes['shipping_rate']      = $taxjar_response->rate;
 
 			if ( ! empty( $taxjar_response->breakdown ) ) {

--- a/tests/framework/class-tj-wc-rest-unit-test-case.php
+++ b/tests/framework/class-tj-wc-rest-unit-test-case.php
@@ -123,9 +123,9 @@ class TJ_WC_REST_Unit_Test_Case extends WP_HTTP_TestCase {
 					'last_name'  => 'Customer',
 					'address_1'  => '123 Main St.',
 					'address_2'  => '',
-					'city'       => 'Greenwood Village',
-					'state'      => 'CO',
-					'postcode'   => '80111',
+					'city'       => 'New York City',
+					'state'      => 'NY',
+					'postcode'   => '10001',
 					'country'    => 'US',
 				),
 				'line_items' => array(
@@ -143,11 +143,11 @@ class TJ_WC_REST_Unit_Test_Case extends WP_HTTP_TestCase {
 		$order    = wc_get_order( $data['id'] );
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( 1.46, $order->get_total_tax(), '', 0.02 );
-		$this->assertEquals( 0.73, $order->get_shipping_tax(), '', 0.01 );
+		$this->assertEquals( 1.78, $order->get_total_tax(), '', 0.02 );
+		$this->assertEquals( 0.89, $order->get_shipping_tax(), '', 0.01 );
 
 		foreach ( $order->get_items() as $item ) {
-			$this->assertEquals( 0.73, $item->get_total_tax(), '', 0.01 );
+			$this->assertEquals( 0.89, $item->get_total_tax(), '', 0.01 );
 		}
 	}
 

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -52,7 +52,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		WC()->cart->calculate_totals();
 
 		$this->assertEquals( WC()->cart->tax_total, 0.73, '', 0.01 );
-		$this->assertEquals( WC()->cart->shipping_tax_total, 0.36, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_shipping_tax(), 0.36, '', 0.01 );
 
 		if ( method_exists( WC()->cart, 'get_shipping_taxes' ) ) {
 			$this->assertEquals( array_values( WC()->cart->get_shipping_taxes() )[0], 0.36, '', 0.01 );

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -18,7 +18,6 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 			define( 'WOOCOMMERCE_CHECKOUT', true );
 		}
 
-
 	}
 
 	function tearDown() {
@@ -47,23 +46,29 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		TaxJar_Shipping_Helper::create_simple_flat_rate( 5 );
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 
+		WC()->customer = TaxJar_Customer_Helper::create_customer( array(
+			'state' => 'NY',
+			'zip' => '10001',
+			'city' => 'New York City',
+		) );
+
 		WC()->cart->add_to_cart( $product );
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
 		WC()->cart->calculate_totals();
 
-		$this->assertEquals( WC()->cart->tax_total, 0.73, '', 0.01 );
-		$this->assertEquals( WC()->cart->get_shipping_tax(), 0.36, '', 0.01 );
+		$this->assertEquals( WC()->cart->tax_total, 0.89, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_shipping_tax(), 0.44, '', 0.01 );
 
 		if ( method_exists( WC()->cart, 'get_shipping_taxes' ) ) {
-			$this->assertEquals( array_values( WC()->cart->get_shipping_taxes() )[0], 0.36, '', 0.01 );
+			$this->assertEquals( array_values( WC()->cart->get_shipping_taxes() )[0], 0.44, '', 0.01 );
 		} else {
-			$this->assertEquals( array_values( WC()->cart->shipping_taxes )[0], 0.36, '', 0.01 );
+			$this->assertEquals( array_values( WC()->cart->shipping_taxes )[0], 0.44, '', 0.01 );
 		}
 
-		$this->assertEquals( WC()->cart->get_taxes_total(), 1.09, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_taxes_total(), 1.33, '', 0.01 );
 
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
-			$this->assertEquals( $item['line_tax'], 0.73, '', 0.01 );
+			$this->assertEquals( $item['line_tax'], 0.89, '', 0.01 );
 		}
 
 		WC()->session->set( 'chosen_shipping_methods', array() );

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -76,11 +76,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 	}
 
 	function test_taxes_with_different_shipping_and_item_rates() {
-		update_option( 'woocommerce_tax_classes', "Reduced rate\nZero Rate\nnon-prescription-51010" );
+		update_option( 'woocommerce_tax_classes', "Reduced rate\nZero Rate\nNon-Prescription-51010" );
 		TaxJar_Shipping_Helper::create_simple_flat_rate();
 
 		if ( version_compare( WC()->version, '3.7.0', '>=' ) ) {
-			WC_Tax::create_tax_class( 'non-prescription-51010' );
+			WC_Tax::create_tax_class( 'Non-Prescription-51010' );
 		}
 
 		TaxJar_Woocommerce_Helper::set_shipping_origin( $this->tj, array(
@@ -97,7 +97,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		) );
 
 		$product_options = array(
-			'tax_class' => 'non-prescription-51010',
+			'tax_class' => 'Non-Prescription-51010',
 			'name'          => 'Test Prescription',
 			'price'         => 11.99,
 			'sku'           => 'TEST-PRES'

--- a/tests/specs/test-class-subscriptions.php
+++ b/tests/specs/test-class-subscriptions.php
@@ -381,16 +381,16 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		$subscription_id = $data['id'];
 		$renewal_order = wcs_create_order_from_subscription( $subscription_id, 'renewal_order' );
 
-		$this->assertEquals( $renewal_order->get_shipping_tax(), 0.73, '', 0.01 );
+		$this->assertEquals( $renewal_order->get_shipping_tax(), 0, '', 0.01 );
 		$this->assertEquals( $renewal_order->get_cart_tax(), 7.25, '', 0.01 );
-		$this->assertEquals( $renewal_order->get_total(), 117.98 , '', 0.01 );
+		$this->assertEquals( $renewal_order->get_total(), 117.25 , '', 0.01 );
 
 		$subscription = wcs_get_subscription( $subscription_id );
 
 		// test to ensure subscription tax has been correctly calculated and updated
-		$this->assertEquals( $subscription->get_shipping_tax(), 0.73, '', 0.01 );
+		$this->assertEquals( $subscription->get_shipping_tax(), 0, '', 0.01 );
 		$this->assertEquals( $subscription->get_cart_tax(), 7.25, '', 0.01 );
-		$this->assertEquals( $subscription->get_total(), 117.98 , '', 0.01 );
+		$this->assertEquals( $subscription->get_total(), 117.25 , '', 0.01 );
 
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
@@ -428,9 +428,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		$subscription_id = $data['id'];
 		$renewal_order = wcs_create_order_from_subscription( $subscription_id, 'renewal_order' );
 
-		$this->assertEquals( $renewal_order->get_shipping_tax(), 0.73, '', 0.01 );
+		$this->assertEquals( $renewal_order->get_shipping_tax(), 0, '', 0.01 );
 		$this->assertEquals( $renewal_order->get_cart_tax(), 7.25, '', 0.01 );
-		$this->assertEquals( $renewal_order->get_total(), 117.98 , '', 0.01 );
+		$this->assertEquals( $renewal_order->get_total(), 117.25 , '', 0.01 );
 
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
@@ -468,9 +468,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		$subscription_id = $data['id'];
 		$renewal_order = wcs_create_order_from_subscription( $subscription_id, 'renewal_order' );
 
-		$this->assertEquals( $renewal_order->get_shipping_tax(), 0.73, '', 0.01 );
+		$this->assertEquals( $renewal_order->get_shipping_tax(), 0, '', 0.01 );
 		$this->assertEquals( $renewal_order->get_cart_tax(), 7.25, '', 0.01 );
-		$this->assertEquals( $renewal_order->get_total(), 117.98 , '', 0.01 );
+		$this->assertEquals( $renewal_order->get_total(), 117.25 , '', 0.01 );
 
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
@@ -517,15 +517,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		$subscription_id = $data['id'];
 		$renewal_order = wcs_create_order_from_subscription( $subscription_id, 'renewal_order' );
 
-		$this->assertEquals( $renewal_order->get_shipping_tax(), 0.73, '', 0.01 );
+		$this->assertEquals( $renewal_order->get_shipping_tax(), 0, '', 0.01 );
 		$this->assertEquals( $renewal_order->get_cart_tax(), 10.88, '', 0.01 );
-
-		// handle rounding difference is woocommerce versions
-		if ( version_compare( WC()->version, '3.2.0', '<=' ) ) {
-			$this->assertEquals( $renewal_order->get_total(), 171.60, '', 0.01 );
-		} else {
-			$this->assertEquals( $renewal_order->get_total(), 171.61, '', 0.01 );
-		}
+		$this->assertEquals( $renewal_order->get_total(), 170.88, '', 0.01 );
 
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}

--- a/tests/specs/test-customer-sync.php
+++ b/tests/specs/test-customer-sync.php
@@ -351,9 +351,9 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		WC()->shipping->shipping_total = 10;
 		WC()->cart->calculate_totals();
 
-		$this->assertEquals( .73, WC()->cart->tax_total, '', 0.01 );
-		$this->assertEquals( .73, WC()->cart->shipping_tax_total, '', 0.01 );
-		$this->assertEquals( 1.46, WC()->cart->get_taxes_total(), '', 0.01 );
+		$this->assertEquals( .73, WC()->cart->get_total_tax(), '', 0.01 );
+		$this->assertEquals( 0, WC()->cart->get_shipping_tax(), '', 0.01 );
+		$this->assertEquals( .73, WC()->cart->get_taxes_total(), '', 0.01 );
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
 			$this->assertEquals( .73, $item['line_tax'], '', 0.01 );
 		}
@@ -368,8 +368,8 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 
 		WC()->customer = $customer;
 		WC()->cart->calculate_totals();
-		$this->assertEquals( 0, WC()->cart->tax_total, '', 0.01 );
-		$this->assertEquals( 0, WC()->cart->shipping_tax_total, '', 0.01 );
+		$this->assertEquals( 0, WC()->cart->get_total_tax(), '', 0.01 );
+		$this->assertEquals( 0, WC()->cart->get_shipping_tax(), '', 0.01 );
 		$this->assertEquals( 0, WC()->cart->get_taxes_total(), '', 0.01 );
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
 			$this->assertEquals( 0, $item['line_tax'], '', 0.01 );
@@ -419,9 +419,9 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		WC()->customer = $customer;
 		WC()->cart->calculate_totals();
 
-		$this->assertEquals( 1.45, WC()->cart->tax_total, '', 0.01 );
-		$this->assertEquals( .73, WC()->cart->shipping_tax_total, '', 0.01 );
-		$this->assertEquals( 2.19, WC()->cart->get_taxes_total(), '', 0.01 );
+		$this->assertEquals( 1.45, WC()->cart->get_total_tax(), '', 0.01 );
+		$this->assertEquals( 0, WC()->cart->get_shipping_tax(), '', 0.01 );
+		$this->assertEquals( 1.45, WC()->cart->get_taxes_total(), '', 0.01 );
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
 			$this->assertEquals( 1.45, $item['line_tax'], '', 0.01 );
 		}
@@ -449,9 +449,9 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		WC()->shipping->shipping_total = 10;
 		WC()->cart->calculate_totals();
 
-		$this->assertEquals( .73, WC()->cart->tax_total, '', 0.01 );
-		$this->assertEquals( .73, WC()->cart->shipping_tax_total, '', 0.01 );
-		$this->assertEquals( 1.46, WC()->cart->get_taxes_total(), '', 0.01 );
+		$this->assertEquals( .73, WC()->cart->get_total_tax(), '', 0.01 );
+		$this->assertEquals( 0, WC()->cart->get_shipping_tax(), '', 0.01 );
+		$this->assertEquals( .73, WC()->cart->get_taxes_total(), '', 0.01 );
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
 			$this->assertEquals( .73, $item['line_tax'], '', 0.01 );
 		}


### PR DESCRIPTION
In certain scenarios, when a cart has a reduced rate tax code and shipping is fully taxable, the shipping may not get taxed at the correct rate. This PR resolves this issue.

Also, Colorado was recently changed in TaxJar to have shipping not be taxable by default. This change broke some of the integration tests that tested the shipping tax on orders to Colorado. This PR fixes those integration tests.

**Steps to Reproduce**

The test_taxes_with_different_shipping_and_item_rates integration test simulates the scenario where the issue was occurring. Adding and then running this test in an older version of the integration will cause the test to fail (this can also be done on the front end of a store by using the address, store address and product data contained in the integration test).

**Expected Result**

After apply this PR that test will pass successfully.

**Click-Test Versions**

- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2

**Specs Passing**

- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
