### PR TITLE
Fix international from address validation

### DIFF
--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -427,6 +427,26 @@ abstract class TaxJar_Record {
 		return apply_filters( 'taxjar_sync_allowed_currencies', array ( 'USD' ) );
 	}
 
+	/**
+	 * Validates that required fields are present on records prior to syncing
+	 * @return bool
+	 */
+	public function has_valid_ship_from_address() {
+		$order_data = $this->get_data();
+
+		if ( empty( $order_data[ 'from_country' ] ) || empty( $order_data[ 'from_zip' ] ) || empty( $order_data[ 'from_city' ] ) ) {
+			return false;
+		}
+
+		if ( in_array( $order_data[ 'from_country' ], array( 'US', 'CA' ) ) ) {
+			if ( empty( $order_data['from_state'] ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	public function set_queue_id( $queue_id ) {
 		$this->queue_id = $queue_id;
 	}

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -69,7 +69,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 			return false;
 		}
 
-		if ( empty( $order_data[ 'from_country' ] ) || empty( $order_data[ 'from_state' ] ) || empty( $order_data[ 'from_zip' ] ) || empty( $order_data[ 'from_city' ] ) ) {
+		if ( ! $this->has_valid_ship_from_address() ) {
 			$this->add_error( __( 'Order failed validation, missing required ship from field', 'wc-taxjar' ) );
 			return false;
 		}

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -57,8 +57,8 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 			return false;
 		}
 
-		if ( empty( $data[ 'from_country' ] ) || empty( $data[ 'from_state' ] ) || empty( $data[ 'from_zip' ] ) || empty( $data[ 'from_city' ] ) ) {
-			$this->add_error( __( 'Refund failed validation - missing required ship from field on parent order.', 'wc-taxjar' ) );
+		if ( ! $this->has_valid_ship_from_address() ) {
+			$this->add_error( __( 'Order failed validation, missing required ship from field', 'wc-taxjar' ) );
 			return false;
 		}
 

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -58,7 +58,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		}
 
 		if ( ! $this->has_valid_ship_from_address() ) {
-			$this->add_error( __( 'Order failed validation, missing required ship from field', 'wc-taxjar' ) );
+			$this->add_error( __( 'Refund failed validation - missing required ship from field on parent order', 'wc-taxjar' ) );
 			return false;
 		}
 

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -1679,4 +1679,65 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$record->read();
 		$this->assertEquals( 0, $record->get_batch_id() );
 	}
+
+	function test_has_valid_ship_from_address() {
+		$record = new TaxJar_Order_Record( null, false );
+
+		// test US address will all necessary data
+		$record->data = array(
+			'from_country' => 'US',
+			'from_city' => 'from city',
+			'from_zip' => 'from zip',
+			'from_state' => 'UT'
+		);
+		$this->assertTrue( $record->has_valid_ship_from_address() );
+
+		// test missing state in US from address
+		$record->data = array(
+			'from_country' => 'US',
+			'from_city' => 'from city',
+			'from_zip' => '11111',
+		);
+		$this->assertFalse( $record->has_valid_ship_from_address() );
+
+		// test missing zip
+		$record->data = array(
+			'from_country' => 'US',
+			'from_city' => 'from city',
+			'from_state' => 'UT',
+		);
+		$this->assertFalse( $record->has_valid_ship_from_address() );
+
+		// test missing city
+		$record->data = array(
+			'from_country' => 'US',
+			'from_zip' => '11111',
+			'from_state' => 'UT',
+		);
+		$this->assertFalse( $record->has_valid_ship_from_address() );
+
+		// test missing country
+		$record->data = array(
+			'from_city' => 'test',
+			'from_zip' => '11111',
+			'from_state' => 'UT',
+		);
+		$this->assertFalse( $record->has_valid_ship_from_address() );
+
+		// test missing state in international address
+		$record->data = array(
+			'from_country' => 'UK',
+			'from_city' => 'test',
+			'from_zip' => '11111',
+		);
+		$this->assertTrue( $record->has_valid_ship_from_address() );
+
+		// test missing state in Canada address
+		$record->data = array(
+			'from_country' => 'CA',
+			'from_city' => 'test',
+			'from_zip' => '11111',
+		);
+		$this->assertFalse( $record->has_valid_ship_from_address() );
+	}
 }


### PR DESCRIPTION
There is validation is place in order to prevent attempting to sync transactions to TaxJar, when the transactions have known missing or bad data. One of those validations is for the ship from address and it confirms that there is a country, state, city and zip code present before attempting to sync the transaction. This causes issues with international address that do not have states or provinces as they failed the validation.

This PR resolves the issue by only requiring the from state if the country is US or Canada. 

**Steps to Reproduce**

1. Set store settings to an international address with no state (UK address for example)
2. Place a test order
3. Manually sync the order. The sync will fail and the logs will have the message indicating a required ship from field is missing.

**Expected Result**

After applying the PR, the order will sync correctly.

**Click-Test Versions**

- [X] Woo 4.4
- [X] Woo 4.3
- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2

**Specs Passing**

- [X] Woo 4.4
- [X] Woo 4.3
- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
