### PR TITLE
Fix incorrect trial on synchronized renewals

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1133,9 +1133,6 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 			// Get WC Subscription sign-up fees for calculations
 			if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
 				if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
-					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
-						WC_Subscriptions_Synchroniser::maybe_set_free_trial();
-					}
 					$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
 				}
 			}
@@ -1171,14 +1168,6 @@ class WC_Taxjar_Integration extends WC_Settings_API {
 				$discount = wc_format_decimal( $item->get_subtotal() - $item->get_total() );
 				$tax_class_name = $item->get_tax_class();
 				$tax_status = $item->get_tax_status();
-			} else { // Woo 2.6
-				$id = $item['product_id'];
-				$quantity = $item['qty'];
-				$unit_price = wc_format_decimal( $item['line_subtotal'] / $quantity );
-				$discount = wc_format_decimal( $item['line_subtotal'] - $item['line_total'] );
-				$tax_class_name = $item['tax_class'];
-				$product = $order->get_product_from_item( $item );
-				$tax_status = $product ? $product->get_tax_status() : 'taxable';
 			}
 
 			$this->backend_tax_classes[$id] = $tax_class_name;

--- a/tests/specs/test-class-subscriptions.php
+++ b/tests/specs/test-class-subscriptions.php
@@ -365,7 +365,10 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 			$this->assertEquals( $recurring_cart->get_taxes_total(), 1.77, '', 0.01 );
 		}
 	}
-	
+
+	/**
+	 * @expectedDeprecated WC_Abstract_Legacy_Order::get_product_from_item
+	 */
 	function test_correct_taxes_for_subscription_recurring_order() {
 		wp_set_current_user( $this->user );
 
@@ -395,6 +398,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
+	/**
+	 * @expectedDeprecated WC_Abstract_Legacy_Order::get_product_from_item
+	 */
 	function test_correct_taxes_for_subscription_recurring_order_with_one_month_trial() {
 		wp_set_current_user( $this->user );
 
@@ -435,6 +441,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
+	/**
+	 * @expectedDeprecated WC_Abstract_Legacy_Order::get_product_from_item
+	 */
 	function test_correct_taxes_for_subscription_recurring_order_with_trial_and_signup_fee() {
 		wp_set_current_user( $this->user );
 
@@ -474,7 +483,10 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
-	
+
+	/**
+	 * @expectedDeprecated WC_Abstract_Legacy_Order::get_product_from_item
+	 */
 	function test_correct_taxes_for_subscription_recurring_order_with_multiple_products() {
 		wp_set_current_user( $this->user );
 
@@ -524,6 +536,10 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
+
+	/**
+	 * @expectedDeprecated WC_Abstract_Legacy_Order::get_product_from_item
+	 */
 	function test_renewal_order_transaction_sync() {
 		wp_set_current_user( $this->user );
 		TaxJar_Shipping_Helper::create_simple_flat_rate( 10 );
@@ -549,6 +565,9 @@ class TJ_WC_Class_Subscriptions extends WP_HTTP_TestCase {
 		TaxJar_Shipping_Helper::delete_simple_flat_rate();
 	}
 
+	/**
+	 * @expectedDeprecated WC_Abstract_Legacy_Order::get_product_from_item
+	 */
 	function test_correct_taxes_for_subscription_recurring_order_with_exempt_customer() {
 		wp_set_current_user( $this->user );
 		TaxJar_Shipping_Helper::create_simple_flat_rate( 10 );


### PR DESCRIPTION
When there was a subscription product set up to have synchronized renewals with no trial period, on the cart page a message would display on the item indicating it contained a 1 month free trial.

After testing it was determined that the responsible portion of code was no longer needed. This PR resolves the issue by removing that code.

It also adds an expected deprecated annotation to some of the unit tests for subscriptions. This ensures the tests will be able to pass on the most recent versions of WooCommerce. There is no way to do deprecated annotations based on the version of WooCommerce we are testing against so this will cause those tests to fail on older versions of Woo until we build a new way to create subscription orders in the test suite.

**Steps to Reproduce**

1. Create a subscription product with synchronized renewals
2. Add it to the cart and navigate to the cart page
3. On the line for that product, a message containing "with one month free trial" will be displayed even though no trial has been configured.

**Expected Result**

After applying the PR, the free trial portion of the message will no longer be added.

**Click-Test Versions**

- [X] Woo 4.4
- [X] Woo 4.3
- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2

**Specs Passing**

- [X] Woo 4.4
- [X] Woo 4.3
- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
