### PR TITLE
Nexus Check Filter

### DIFF
--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -50,6 +50,7 @@ class WC_Taxjar_Nexus {
 	}
 
 	public function has_nexus_check( $country, $state = null ) {
+		$has_nexus = false;
 		$store_settings   = $this->integration->get_store_settings();
 		$from_country     = $store_settings['country'];
 		$from_state       = $store_settings['state'];
@@ -57,7 +58,7 @@ class WC_Taxjar_Nexus {
 		$nexus_areas = $this->get_or_update_cached_nexus();
 
 		if ( count( $nexus_areas ) == 0 ) {
-			return true;
+			$has_nexus = true;
 		}
 
 		array_push(
@@ -71,24 +72,24 @@ class WC_Taxjar_Nexus {
 		foreach ( $nexus_areas as $key => $nexus ) {
 			if ( isset( $nexus->country_code ) && isset( $nexus->region_code ) && 'US' == $nexus->country_code ) {
 				if ( $country == $nexus->country_code && $state == $nexus->region_code ) {
-					return true;
+					$has_nexus = true;
 				}
 			} elseif ( isset( $nexus->country_code ) ) {
 				if ( $country == $nexus->country_code ) {
-					return true;
+					$has_nexus = true;
 				}
 
 				if ( 'GB' == $country && 'UK' == $nexus->country_code ) {
-					return true;
+					$has_nexus = true;
 				}
 
 				if ( 'GR' == $country && 'EL' == $nexus->country_code ) {
-					return true;
+					$has_nexus = true;
 				}
 			}
 		}
 
-		return apply_filters( 'taxjar_nexus_check', false, $country, $state, $nexus_areas );
+		return apply_filters( 'taxjar_nexus_check', $has_nexus, $country, $state, $nexus_areas );
 	}
 
 	public function get_or_update_cached_nexus( $force_update = false ) {

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -88,7 +88,7 @@ class WC_Taxjar_Nexus {
 			}
 		}
 
-		return false;
+		return apply_filters( 'taxjar_nexus_check', false, $country, $state, $nexus_areas );
 	}
 
 	public function get_or_update_cached_nexus( $force_update = false ) {

--- a/tests/specs/test-class-taxjar-nexus.php
+++ b/tests/specs/test-class-taxjar-nexus.php
@@ -102,7 +102,7 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 		$this->assertFalse( $this->tj_nexus->has_nexus_check( 'AA' ) );
 
 		add_filter( 'taxjar_nexus_check', function( $has_nexus, $country, $state, $nexus_areas ) {
-			if ($country !== 'US' ) {
+			if ( $country !== 'US' ) {
 				return true;
 			}
 			return $has_nexus;

--- a/tests/specs/test-class-taxjar-nexus.php
+++ b/tests/specs/test-class-taxjar-nexus.php
@@ -98,4 +98,21 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 		$this->assertFalse( $this->tj_nexus->has_nexus_check( 'US', 'XO' ) );
 	}
 
+	function test_nexus_filter() {
+		$this->assertFalse( $this->tj_nexus->has_nexus_check( 'AA' ) );
+
+		add_filter( 'taxjar_nexus_check', function( $has_nexus, $country, $state, $nexus_areas ) {
+			if ($country !== 'US' ) {
+				return true;
+			}
+			return $has_nexus;
+		}, 10, 4 );
+
+		$has_nexus = $this->tj_nexus->has_nexus_check( 'AA' );
+		remove_all_filters( 'taxjar_nexus_check', 10 );
+
+		$this->assertTrue( $has_nexus );
+	}
+
+
 }


### PR DESCRIPTION
There are scenarios where merchants may need to dynamically alter the nexus check logic. For instance adding additional international nexus areas. Currently there is no way for that to be accomplished. This PR adds a filter to allow these customizations. 

**Click-Test Versions**

- [X] Woo 4.5
- [X] Woo 4.4
- [X] Woo 4.3
- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2

**Specs Passing**

- [X] Woo 4.5
- [X] Woo 4.4
- [X] Woo 4.3
- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
