### PR TITLE
Decouple tax calc and sync settings

### DIFF
--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -31,6 +31,7 @@ class WC_Taxjar_Transaction_Sync {
 	public function init() {
 		$sales_tax_enabled = apply_filters( 'taxjar_enabled', isset( $this->taxjar_integration->settings['enabled'] ) && 'yes' == $this->taxjar_integration->settings['enabled'] );
 		$transaction_sync_enabled = isset( $this->taxjar_integration->settings['taxjar_download'] ) && 'yes' == $this->taxjar_integration->settings['taxjar_download'];
+
 		if ( $sales_tax_enabled || $transaction_sync_enabled ) {
 			add_action( 'init', array( __CLASS__, 'schedule_process_queue' ) );
 			add_action( self::PROCESS_QUEUE_HOOK, array( $this, 'process_queue' ) );

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -29,10 +29,14 @@ class WC_Taxjar_Transaction_Sync {
 	 * Add actions and filters
 	 */
 	public function init() {
-		if ( isset( $this->taxjar_integration->settings['taxjar_download'] ) && 'yes' == $this->taxjar_integration->settings['taxjar_download'] ) {
+		$sales_tax_enabled = apply_filters( 'taxjar_enabled', isset( $this->taxjar_integration->settings['enabled'] ) && 'yes' == $this->taxjar_integration->settings['enabled'] );
+		$transaction_sync_enabled = isset( $this->taxjar_integration->settings['taxjar_download'] ) && 'yes' == $this->taxjar_integration->settings['taxjar_download'];
+		if ( $sales_tax_enabled || $transaction_sync_enabled ) {
 			add_action( 'init', array( __CLASS__, 'schedule_process_queue' ) );
 			add_action( self::PROCESS_QUEUE_HOOK, array( $this, 'process_queue' ) );
+		}
 
+		if ( $transaction_sync_enabled ) {
 			add_action( 'woocommerce_new_order', array( __CLASS__, 'order_updated' ) );
 			add_action( 'woocommerce_update_order', array( __CLASS__, 'order_updated' ) );
 

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -29,29 +29,27 @@ class WC_Taxjar_Transaction_Sync {
 	 * Add actions and filters
 	 */
 	public function init() {
-		if ( apply_filters( 'taxjar_enabled', isset( $this->taxjar_integration->settings['enabled'] ) && 'yes' == $this->taxjar_integration->settings['enabled'] ) ) {
+		if ( isset( $this->taxjar_integration->settings['taxjar_download'] ) && 'yes' == $this->taxjar_integration->settings['taxjar_download'] ) {
 			add_action( 'init', array( __CLASS__, 'schedule_process_queue' ) );
 			add_action( self::PROCESS_QUEUE_HOOK, array( $this, 'process_queue' ) );
 
-			if ( isset( $this->taxjar_integration->settings['taxjar_download'] ) && 'yes' == $this->taxjar_integration->settings['taxjar_download'] ) {
-				add_action( 'woocommerce_new_order', array( __CLASS__, 'order_updated' ) );
-				add_action( 'woocommerce_update_order', array( __CLASS__, 'order_updated' ) );
+			add_action( 'woocommerce_new_order', array( __CLASS__, 'order_updated' ) );
+			add_action( 'woocommerce_update_order', array( __CLASS__, 'order_updated' ) );
 
-				add_action( 'woocommerce_order_refunded', array( __CLASS__, 'refund_created' ), 10, 2 );
+			add_action( 'woocommerce_order_refunded', array( __CLASS__, 'refund_created' ), 10, 2 );
 
-				add_filter( 'woocommerce_order_actions', array( $this, 'add_order_meta_box_action' ) );
-				add_action( 'woocommerce_order_action_taxjar_sync_action', array( $this, 'manual_order_sync' ) );
+			add_filter( 'woocommerce_order_actions', array( $this, 'add_order_meta_box_action' ) );
+			add_action( 'woocommerce_order_action_taxjar_sync_action', array( $this, 'manual_order_sync' ) );
 
-				add_action( 'wp_trash_post', array( $this, 'maybe_delete_transaction_from_taxjar' ), 9, 1 );
-				add_action( 'before_delete_post', array( $this, 'maybe_delete_transaction_from_taxjar' ), 9, 1 );
-				add_action( 'before_delete_post', array( $this, 'maybe_delete_refund_from_taxjar' ), 9, 1 );
-				add_action( 'untrashed_post', array( $this, 'untrash_post' ), 11 );
+			add_action( 'wp_trash_post', array( $this, 'maybe_delete_transaction_from_taxjar' ), 9, 1 );
+			add_action( 'before_delete_post', array( $this, 'maybe_delete_transaction_from_taxjar' ), 9, 1 );
+			add_action( 'before_delete_post', array( $this, 'maybe_delete_refund_from_taxjar' ), 9, 1 );
+			add_action( 'untrashed_post', array( $this, 'untrash_post' ), 11 );
 
-				add_action( 'woocommerce_order_status_cancelled', array( $this, 'order_cancelled' ), 10, 2 );
+			add_action( 'woocommerce_order_status_cancelled', array( $this, 'order_cancelled' ), 10, 2 );
 
-				add_action( 'woocommerce_product_options_tax', array( $this, 'display_notice_after_product_options_tax' ), 5 );
-				add_action( 'woocommerce_variation_options_tax', array( $this, 'display_notice_after_product_options_tax' ), 5 );
-			}
+			add_action( 'woocommerce_product_options_tax', array( $this, 'display_notice_after_product_options_tax' ), 5 );
+			add_action( 'woocommerce_variation_options_tax', array( $this, 'display_notice_after_product_options_tax' ), 5 );
 		}
 	}
 


### PR DESCRIPTION
Previously, transaction sync required two settings for it to work, the sales tax calculation setting as well as the sales tax reporting setting. This was counter intuitive and made it so merchants couldn't sync transactions without also calculating sales tax. This PR resolves the issue by making transaction sync solely reliant on the sales tax reporting setting.

**Click-Test Versions**

- [X] Woo 4.5
- [X] Woo 4.4
- [X] Woo 4.3
- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2

**Specs Passing**

- [X] Woo 4.5
- [X] Woo 4.4
- [X] Woo 4.3
- [X] Woo 4.2
- [X] Woo 4.1
- [X] Woo 4.0
- [X] Woo 3.9
- [X] Woo 3.8
- [X] Woo 3.7
- [X] Woo 3.6
- [X] Woo 3.5
- [X] Woo 3.4
- [X] Woo 3.3
- [X] Woo 3.2
