### PR TITLE
Exempt Customers Not Syncing Fix

### DIFF
--- a/includes/class-taxjar-customer-record.php
+++ b/includes/class-taxjar-customer-record.php
@@ -184,36 +184,8 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 		$customer_data = array();
 
 		$customer_data[ 'customer_id' ] = $this->get_customer_id();
+		$customer_data[ 'name' ] = $this->get_customer_name();
 		$customer_data[ 'exemption_type' ] = $this->get_exemption_type();
-
-		$first_name = $this->object->get_shipping_first_name();
-		$last_name = $this->object->get_shipping_last_name();
-
-		if ( empty( $first_name ) ) {
-			$first_name = $this->object->get_billing_first_name();
-			if ( empty( $first_name ) ) {
-				$first_name = $this->object->get_first_name();
-			}
-		}
-
-		if ( empty( $last_name ) ) {
-			$last_name = $this->object->get_billing_last_name();
-			if ( empty( $last_name ) ) {
-				$last_name = $this->object->get_last_name();
-			}
-		}
-
-		if ( empty( $first_name ) && empty( $last_name ) ) {
-			$name = '';
-		} else if ( empty( $first_name ) ) {
-			$name = $last_name;
-		} else if ( empty( $last_name ) ) {
-			$name = $first_name;
-		} else {
-			$name = $first_name . ' ' . $last_name;
-		}
-		$customer_data[ 'name' ] = $name;
-
 		$customer_data[ 'exempt_regions' ] = $this->get_exempt_regions();
 
 		$country = $this->object->get_shipping_country();
@@ -259,6 +231,47 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 		$customer_data = apply_filters( 'taxjar_customer_sync_data', $customer_data, $this->object );
 		$this->data = $customer_data;
 		return $customer_data;
+	}
+
+	/**
+	 * Retrieves the name of the customer.
+	 * Falls back to username if no shipping, billing or account names are available.
+	 *
+	 * @return string - Customer's name
+	 */
+	public function get_customer_name() {
+		$first_name = $this->object->get_shipping_first_name();
+		$last_name = $this->object->get_shipping_last_name();
+
+		if ( empty( $first_name ) ) {
+			$first_name = $this->object->get_billing_first_name();
+			if ( empty( $first_name ) ) {
+				$first_name = $this->object->get_first_name();
+			}
+		}
+
+		if ( empty( $last_name ) ) {
+			$last_name = $this->object->get_billing_last_name();
+			if ( empty( $last_name ) ) {
+				$last_name = $this->object->get_last_name();
+			}
+		}
+
+		if ( empty( $first_name ) && empty( $last_name ) ) {
+			$name = '';
+		} else if ( empty( $first_name ) ) {
+			$name = $last_name;
+		} else if ( empty( $last_name ) ) {
+			$name = $first_name;
+		} else {
+			$name = $first_name . ' ' . $last_name;
+		}
+
+		if ( empty( $name ) ) {
+			$name = $this->object->get_username();
+		}
+
+		return $name;
 	}
 
 	/**

--- a/includes/class-taxjar-customer-record.php
+++ b/includes/class-taxjar-customer-record.php
@@ -14,7 +14,7 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 			$this->object = $object;
 		} else {
 			try {
-				$customer =  new WC_Customer( $this->get_record_id() );
+				$customer = new WC_Customer( $this->get_record_id() );
 				if ( $customer instanceof WC_Customer ) {
 					$this->object = $customer;
 				} else {
@@ -49,17 +49,17 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 		}
 
 		$data = $this->get_data();
-		if ( empty( $data[ 'customer_id' ] ) ) {
+		if ( empty( $data['customer_id'] ) ) {
 			$this->add_error( __( 'Customer failed validation, customer missing required field: customer_id.', 'wc-taxjar' ) );
 			return false;
 		}
 
-		if ( empty( $data[ 'exemption_type' ] ) ) {
+		if ( empty( $data['exemption_type'] ) ) {
 			$this->add_error( __( 'Customer failed validation, customer missing required field: exemption_type.', 'wc-taxjar' ) );
 			return false;
 		}
 
-		if ( empty( $data[ 'name' ] ) ) {
+		if ( empty( $data['name'] ) ) {
 			$this->add_error( __( 'Customer failed validation, customer missing required field: name.', 'wc-taxjar' ) );
 			return false;
 		}
@@ -88,17 +88,20 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 */
 	public function create_in_taxjar() {
 		$data = $this->get_data();
-		$url = self::API_URI . 'customers';
+		$url  = self::API_URI . 'customers';
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_post( $url, array(
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-			'body' => $body,
-		) );
+		$response = wp_remote_post(
+			$url,
+			array(
+				'headers'    => array(
+					'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
+					'Content-Type'  => 'application/json',
+				),
+				'user-agent' => $this->taxjar_integration->ua,
+				'body'       => $body,
+			)
+		);
 
 		$this->set_last_request( $body );
 		return $response;
@@ -108,22 +111,25 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 * Update customer API request
 	 * @return array|WP_Error - API response or WP_Error if request fails
 	 */
-	public function update_in_taxjar(){
+	public function update_in_taxjar() {
 		$customer_id = $this->get_customer_id();
-		$data = $this->get_data();
+		$data        = $this->get_data();
 
-		$url = self::API_URI . 'customers/' . $customer_id;
+		$url  = self::API_URI . 'customers/' . $customer_id;
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_request( $url, array(
-			'method' => 'PUT',
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-			'body' => $body,
-		) );
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'     => 'PUT',
+				'headers'    => array(
+					'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
+					'Content-Type'  => 'application/json',
+				),
+				'user-agent' => $this->taxjar_integration->ua,
+				'body'       => $body,
+			)
+		);
 
 		$this->set_last_request( $body );
 		return $response;
@@ -133,23 +139,26 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 * Delete customer API request
 	 * @return array|WP_Error - API response or WP_Error if request fails
 	 */
-	public function delete_in_taxjar(){
+	public function delete_in_taxjar() {
 		$customer_id = $this->get_customer_id();
-		$url = self::API_URI . 'customers/' . $customer_id;
-		$data = array(
+		$url         = self::API_URI . 'customers/' . $customer_id;
+		$data        = array(
 			'customer_id' => $customer_id,
 		);
-		$body = wp_json_encode( $data );
+		$body        = wp_json_encode( $data );
 
-		$response = wp_remote_request( $url, array(
-			'method' => 'DELETE',
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-			'body' => $body,
-		) );
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'     => 'DELETE',
+				'headers'    => array(
+					'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
+					'Content-Type'  => 'application/json',
+				),
+				'user-agent' => $this->taxjar_integration->ua,
+				'body'       => $body,
+			)
+		);
 
 		$this->set_last_request( $body );
 		return $response;
@@ -161,16 +170,19 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 */
 	public function get_from_taxjar() {
 		$customer_id = $this->get_customer_id();
-		$url = self::API_URI . 'customers/' . $customer_id;
+		$url         = self::API_URI . 'customers/' . $customer_id;
 
-		$response = wp_remote_request( $url, array(
-			'method' => 'GET',
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-		) );
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'     => 'GET',
+				'headers'    => array(
+					'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
+					'Content-Type'  => 'application/json',
+				),
+				'user-agent' => $this->taxjar_integration->ua,
+			)
+		);
 
 		$this->set_last_request( $customer_id );
 		return $response;
@@ -183,17 +195,17 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	public function get_data_from_object() {
 		$customer_data = array();
 
-		$customer_data[ 'customer_id' ] = $this->get_customer_id();
-		$customer_data[ 'name' ] = $this->get_customer_name();
-		$customer_data[ 'exemption_type' ] = $this->get_exemption_type();
-		$customer_data[ 'exempt_regions' ] = $this->get_exempt_regions();
+		$customer_data['customer_id']    = $this->get_customer_id();
+		$customer_data['name']           = $this->get_customer_name();
+		$customer_data['exemption_type'] = $this->get_exemption_type();
+		$customer_data['exempt_regions'] = $this->get_exempt_regions();
 
 		$country = $this->object->get_shipping_country();
 		if ( empty( $country ) ) {
 			$country = $this->object->get_billing_country();
 		}
 		if ( ! empty( $country ) ) {
-			$customer_data[ 'country' ] = $country;
+			$customer_data['country'] = $country;
 		}
 
 		$state = $this->object->get_shipping_state();
@@ -201,7 +213,7 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 			$state = $this->object->get_billing_state();
 		}
 		if ( ! empty( $state ) ) {
-			$customer_data[ 'state' ] = $state;
+			$customer_data['state'] = $state;
 		}
 
 		$postcode = $this->object->get_shipping_postcode();
@@ -209,7 +221,7 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 			$postcode = $this->object->get_billing_postcode();
 		}
 		if ( ! empty( $postcode ) ) {
-			$customer_data[ 'zip' ] = $postcode;
+			$customer_data['zip'] = $postcode;
 		}
 
 		$city = $this->object->get_shipping_city();
@@ -217,7 +229,7 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 			$city = $this->object->get_billing_city();
 		}
 		if ( ! empty( $city ) ) {
-			$customer_data[ 'city' ] = $city;
+			$customer_data['city'] = $city;
 		}
 
 		$address = $this->object->get_shipping_address();
@@ -225,11 +237,11 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 			$address = $this->object->get_billing_address();
 		}
 		if ( ! empty( $address ) ) {
-			$customer_data[ 'street' ] = $address;
+			$customer_data['street'] = $address;
 		}
 
 		$customer_data = apply_filters( 'taxjar_customer_sync_data', $customer_data, $this->object );
-		$this->data = $customer_data;
+		$this->data    = $customer_data;
 		return $customer_data;
 	}
 
@@ -241,7 +253,7 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 */
 	public function get_customer_name() {
 		$first_name = $this->object->get_shipping_first_name();
-		$last_name = $this->object->get_shipping_last_name();
+		$last_name  = $this->object->get_shipping_last_name();
 
 		if ( empty( $first_name ) ) {
 			$first_name = $this->object->get_billing_first_name();
@@ -259,9 +271,9 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 
 		if ( empty( $first_name ) && empty( $last_name ) ) {
 			$name = '';
-		} else if ( empty( $first_name ) ) {
+		} elseif ( empty( $first_name ) ) {
 			$name = $last_name;
-		} else if ( empty( $last_name ) ) {
+		} elseif ( empty( $last_name ) ) {
 			$name = $first_name;
 		} else {
 			$name = $first_name . ' ' . $last_name;
@@ -275,34 +287,46 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	}
 
 	/**
+	 * Gets the user ID of the record (customer)
+	 *
 	 * @return int|string
 	 */
 	public function get_customer_id() {
 		return apply_filters( 'taxjar_get_customer_id', $this->get_record_id(), $this->object );
 	}
 
+	/**
+	 * Gets the exemption type saved on the user
+	 *
+	 * @return mixed|string - exemption type
+	 */
 	public function get_exemption_type() {
-		$valid_types = array( 'wholesale', 'government', 'other', 'non_exempt' );
+		$valid_types    = array( 'wholesale', 'government', 'other', 'non_exempt' );
 		$exemption_type = get_user_meta( $this->object->get_id(), 'tax_exemption_type', true );
-		if ( ! in_array( $exemption_type, $valid_types ) ) {
+		if ( ! in_array( $exemption_type, $valid_types, true ) ) {
 			$exemption_type = 'non_exempt';
 		}
 		return $exemption_type;
 	}
 
+	/**
+	 * Get the exempt regions saved on the user
+	 *
+	 * @return array - array of exemption regions
+	 */
 	public function get_exempt_regions() {
-		$states = WC_Taxjar_Customer_Sync::get_all_exempt_regions();
+		$states               = WC_Taxjar_Customer_Sync::get_all_exempt_regions();
 		$valid_exempt_regions = array_keys( $states );
-		$exempt_meta = get_user_meta( $this->object->get_id(), 'tax_exempt_regions', true );
-		$saved_regions = explode( ',', $exempt_meta );
-		$intersect = array_intersect( $valid_exempt_regions, $saved_regions );
-		$exempt_regions = array();
+		$exempt_meta          = get_user_meta( $this->object->get_id(), 'tax_exempt_regions', true );
+		$saved_regions        = explode( ',', $exempt_meta );
+		$intersect            = array_intersect( $valid_exempt_regions, $saved_regions );
+		$exempt_regions       = array();
 
 		if ( ! empty( $intersect ) ) {
-			foreach( $intersect as $region ) {
+			foreach ( $intersect as $region ) {
 				$exempt_regions[] = array(
 					'country' => 'US',
-					'state'   => $region
+					'state'   => $region,
 				);
 			}
 		}

--- a/includes/class-taxjar-customer-record.php
+++ b/includes/class-taxjar-customer-record.php
@@ -252,38 +252,25 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 * @return string - Customer's name
 	 */
 	public function get_customer_name() {
-		$first_name = $this->object->get_shipping_first_name();
-		$last_name  = $this->object->get_shipping_last_name();
+		$name = $this->object->get_shipping_first_name() . ' ' . $this->object->get_shipping_last_name();
 
-		if ( empty( $first_name ) ) {
-			$first_name = $this->object->get_billing_first_name();
-			if ( empty( $first_name ) ) {
-				$first_name = $this->object->get_first_name();
-			}
+		if ( ! empty( trim( $name ) ) ) {
+			return $name;
 		}
 
-		if ( empty( $last_name ) ) {
-			$last_name = $this->object->get_billing_last_name();
-			if ( empty( $last_name ) ) {
-				$last_name = $this->object->get_last_name();
-			}
+		$name = $this->object->get_billing_first_name() . ' ' . $this->object->get_billing_last_name();
+
+		if ( ! empty( trim( $name ) ) ) {
+			return $name;
 		}
 
-		if ( empty( $first_name ) && empty( $last_name ) ) {
-			$name = '';
-		} elseif ( empty( $first_name ) ) {
-			$name = $last_name;
-		} elseif ( empty( $last_name ) ) {
-			$name = $first_name;
-		} else {
-			$name = $first_name . ' ' . $last_name;
+		$name = $this->object->get_first_name() . ' ' . $this->object->get_last_name();
+
+		if ( ! empty( trim( $name ) ) ) {
+			return $name;
 		}
 
-		if ( empty( $name ) ) {
-			$name = $this->object->get_username();
-		}
-
-		return $name;
+		return $this->object->get_username();
 	}
 
 	/**

--- a/includes/class-wc-taxjar-customer-sync.php
+++ b/includes/class-wc-taxjar-customer-sync.php
@@ -204,8 +204,8 @@ class WC_Taxjar_Customer_Sync {
 	 */
 	public function have_exempt_regions_changed( $user_id ) {
 		$saved_exempt_regions = self::get_saved_exempt_regions( $user_id );
-		$new_exemption_type   = $this->get_posted_exempt_regions();
-		if ( $new_exemption_type !== $saved_exempt_regions ) {
+		$new_exempt_regions   = $this->get_posted_exempt_regions();
+		if ( $new_exempt_regions !== $saved_exempt_regions ) {
 			return true;
 		}
 

--- a/includes/class-wc-taxjar-customer-sync.php
+++ b/includes/class-wc-taxjar-customer-sync.php
@@ -25,17 +25,17 @@ class WC_Taxjar_Customer_Sync {
 	 * Add actions and filters
 	 */
 	public function init() {
-		if ( apply_filters( 'taxjar_enabled', isset( $this->taxjar_integration->settings['enabled'] ) && 'yes' == $this->taxjar_integration->settings['enabled'] ) ) {
-            add_action( 'show_user_profile', array( $this, 'add_customer_meta_fields' ) );
-            add_action( 'edit_user_profile', array( $this, 'add_customer_meta_fields' ) );
+		if ( apply_filters( 'taxjar_enabled', isset( $this->taxjar_integration->settings['enabled'] ) && 'yes' === $this->taxjar_integration->settings['enabled'] ) ) {
+			add_action( 'show_user_profile', array( $this, 'add_customer_meta_fields' ) );
+			add_action( 'edit_user_profile', array( $this, 'add_customer_meta_fields' ) );
 
-            add_action( 'personal_options_update', array( $this, 'save_customer_meta_fields' ) );
-            add_action( 'edit_user_profile_update', array( $this, 'save_customer_meta_fields' ) );
+			add_action( 'personal_options_update', array( $this, 'save_customer_meta_fields' ) );
+			add_action( 'edit_user_profile_update', array( $this, 'save_customer_meta_fields' ) );
 
-            add_action( 'taxjar_customer_exemption_settings_updated', array( $this, 'maybe_sync_customer_on_update' ) );
+			add_action( 'taxjar_customer_exemption_settings_updated', array( $this, 'maybe_sync_customer_on_update' ) );
 
-            add_action( 'delete_user', array( $this, 'maybe_delete_customer' ) );
-	    }
+			add_action( 'delete_user', array( $this, 'maybe_delete_customer' ) );
+		}
 	}
 
 	/**
@@ -64,11 +64,12 @@ class WC_Taxjar_Customer_Sync {
 	 */
 	public function get_customer_meta_fields() {
 		$show_fields = apply_filters(
-			'taxjar_customer_meta_fields', array(
-				'exemptions'  => array(
+			'taxjar_customer_meta_fields',
+			array(
+				'exemptions' => array(
 					'title'  => __( 'TaxJar Sales Tax Exemptions', 'wc-taxjar' ),
 					'fields' => array(
-						'tax_exemption_type'  => array(
+						'tax_exemption_type' => array(
 							'label'       => __( 'Exemption Type', 'wc-taxjar' ),
 							'description' => __( 'All customers are presumed non-exempt unless otherwise selected.', 'wc-taxjar' ),
 							'class'       => '',
@@ -89,6 +90,11 @@ class WC_Taxjar_Customer_Sync {
 		return $show_fields;
 	}
 
+	/**
+	 * Adds customer exemption fields to edit user page
+	 *
+	 * @param $user
+	 */
 	public function add_customer_meta_fields( $user ) {
 		if ( ! apply_filters( 'taxjar_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user->ID ) ) {
 			return;
@@ -120,14 +126,14 @@ class WC_Taxjar_Customer_Sync {
 								<?php
 								$saved_value = esc_attr( get_user_meta( $user->ID, $key, true ) );
 								if ( ! empty( $saved_value ) ) {
-								    $saved_value = explode( ',', $saved_value );
-                                }
+									$saved_value = explode( ',', $saved_value );
+								}
 								foreach ( $field['options'] as $option_key => $option_value ) :
-                                    if ( ! empty( $saved_value ) && in_array( $option_key, $saved_value ) ) {
-                                        $selected = $option_key;
-                                    } else {
-                                        $selected = false;
-                                    }
+									if ( ! empty( $saved_value ) && in_array( $option_key, $saved_value, true ) ) {
+										$selected = $option_key;
+									} else {
+										$selected = false;
+									}
 									?>
 									<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( $selected, $option_key, true ); ?>><?php echo esc_attr( $option_value ); ?></option>
 								<?php endforeach; ?>
@@ -142,13 +148,13 @@ class WC_Taxjar_Customer_Sync {
 					</tr>
 				<?php endforeach; ?>
 			</table>
-		<?php
+			<?php
 		endforeach;
 	}
 
 	/**
-     * Saves tax exemption user meta if necessary
-     *
+	 * Saves tax exemption user meta if necessary
+	 *
 	 * @param $user_id - Id of user to update
 	 */
 	public function save_customer_meta_fields( $user_id ) {
@@ -164,42 +170,16 @@ class WC_Taxjar_Customer_Sync {
 	}
 
 	/**
-     * Checks if exemption type has changed when saving a user
-     *
+	 * Checks if exemption type has changed when saving a user
+	 *
 	 * @param $user_id - Id of customer
 	 *
 	 * @return bool - Whether or not the exemption type has been changed
 	 */
 	public function has_exemption_type_changed( $user_id ) {
-	    $saved_exemption_type = self::get_saved_exemption_type( $user_id );
-		$new_exemption_type = $this->get_posted_exemption_type();
-		if ( $new_exemption_type != $saved_exemption_type ) {
-		    return true;
-		}
-
-		return false;
-    }
-
-	/**
-     * Gets the submitted tax exemption type during user save
-     *
-	 * @return array|string - value to save
-	 */
-    public function get_posted_exemption_type() {
-	    return wc_clean( $_POST[ 'tax_exemption_type' ] );
-    }
-
-	/**
-     * Checks if exempt regions have changed for a user
-     *
-	 * @param $user_id - Id of user to check
-	 *
-	 * @return bool - Whether or not the exempt regions have changed
-	 */
-	public function have_exempt_regions_changed( $user_id ) {
-		$saved_exempt_regions = self::get_saved_exempt_regions( $user_id );
-		$new_exemption_type = $this->get_posted_exempt_regions();
-		if ( $new_exemption_type != $saved_exempt_regions ) {
+		$saved_exemption_type = self::get_saved_exemption_type( $user_id );
+		$new_exemption_type   = $this->get_posted_exemption_type();
+		if ( $new_exemption_type !== $saved_exemption_type ) {
 			return true;
 		}
 
@@ -207,21 +187,47 @@ class WC_Taxjar_Customer_Sync {
 	}
 
 	/**
-     * Gets the submitted exempt regions value during user save
-     *
+	 * Gets the submitted tax exemption type during user save
+	 *
+	 * @return array|string - value to save
+	 */
+	public function get_posted_exemption_type() {
+		return wc_clean( $_POST['tax_exemption_type'] );
+	}
+
+	/**
+	 * Checks if exempt regions have changed for a user
+	 *
+	 * @param $user_id - Id of user to check
+	 *
+	 * @return bool - Whether or not the exempt regions have changed
+	 */
+	public function have_exempt_regions_changed( $user_id ) {
+		$saved_exempt_regions = self::get_saved_exempt_regions( $user_id );
+		$new_exemption_type   = $this->get_posted_exempt_regions();
+		if ( $new_exemption_type !== $saved_exempt_regions ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Gets the submitted exempt regions value during user save
+	 *
 	 * @return string - Concatenated string containing the exempt regions
 	 */
 	public function get_posted_exempt_regions() {
-		if ( empty( $_POST[ 'tax_exempt_regions' ] ) ) {
+		if ( empty( $_POST['tax_exempt_regions'] ) ) {
 			return '';
 		} else {
-			return implode( ',', wc_clean( $_POST[ 'tax_exempt_regions' ] ) );
+			return implode( ',', wc_clean( $_POST['tax_exempt_regions'] ) );
 		}
 	}
 
 	/**
-     * Gets the exemption type user meta
-     *
+	 * Gets the exemption type user meta
+	 *
 	 * @param $user_id - ID of user
 	 *
 	 * @return mixed
@@ -231,8 +237,8 @@ class WC_Taxjar_Customer_Sync {
 	}
 
 	/**
-     * Gets the exempt regions user metadata
-     * 
+	 * Gets the exempt regions user metadata
+	 *
 	 * @param $user_id - ID of user
 	 *
 	 * @return mixed
@@ -241,6 +247,11 @@ class WC_Taxjar_Customer_Sync {
 		return get_user_meta( $user_id, 'tax_exempt_regions', true );
 	}
 
+	/**
+	 * Syncs customer record to TaxJar if all validation passes
+	 *
+	 * @param $user_id
+	 */
 	public function maybe_sync_customer_on_update( $user_id ) {
 		$record = TaxJar_Customer_Record::find_active_in_queue( $user_id );
 		if ( ! $record ) {
@@ -255,16 +266,26 @@ class WC_Taxjar_Customer_Sync {
 		}
 
 		$result = $record->sync();
-    }
+	}
 
+	/**
+	 * Creates array of valid option for customer exemption type dropdown
+	 *
+	 * @return array - customer exemption type options
+	 */
 	public static function get_customer_exemption_types() {
 		return array(
-			'wholesale' => __( 'Wholesale / Resale', 'wc-taxjar' ),
+			'wholesale'  => __( 'Wholesale / Resale', 'wc-taxjar' ),
 			'government' => __( 'Government', 'wc-taxjar' ),
-			'other' => __( 'Other', 'wc-taxjar' ),
+			'other'      => __( 'Other', 'wc-taxjar' ),
 		);
 	}
 
+	/**
+	 * Creates array of all valid exempt regions (states)
+	 *
+	 * @return array - available exempt regions
+	 */
 	public static function get_all_exempt_regions() {
 		return array(
 			'AL' => 'Alabama',
@@ -321,21 +342,22 @@ class WC_Taxjar_Customer_Sync {
 	}
 
 	/**
-     * Deletes customer from TaxJar when synced customer is deleted in WordPress
+	 * Deletes customer from TaxJar when synced customer is deleted in WordPress
+	 *
 	 * @param $id - user id
 	 */
 	public function maybe_delete_customer( $id ) {
 		$last_sync = get_user_meta( $id, '_taxjar_last_sync', true );
-		$hash = get_user_meta( $id, '_taxjar_hash', true );
+		$hash      = get_user_meta( $id, '_taxjar_hash', true );
 		if ( $last_sync || $hash ) {
-		    $record = TaxJar_Customer_Record::find_active_in_queue( $id );
+			$record = TaxJar_Customer_Record::find_active_in_queue( $id );
 			if ( ! $record ) {
 				$record = new TaxJar_Customer_Record( $id, true );
 			}
 
 			$record->delete_in_taxjar();
 			$record->delete();
-        }
-    }
+		}
+	}
 
 }

--- a/includes/class-wc-taxjar-customer-sync.php
+++ b/includes/class-wc-taxjar-customer-sync.php
@@ -146,42 +146,109 @@ class WC_Taxjar_Customer_Sync {
 		endforeach;
 	}
 
+	/**
+     * Saves tax exemption user meta if necessary
+     *
+	 * @param $user_id - Id of user to update
+	 */
 	public function save_customer_meta_fields( $user_id ) {
 		if ( ! apply_filters( 'taxjar_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user_id ) ) {
 			return;
 		}
 
-		$save_fields = $this->get_customer_meta_fields();
-		$change = false;
-		foreach ( $save_fields as $fieldset ) {
-			foreach ( $fieldset['fields'] as $key => $field ) {
-				if ( isset( $field['type'] ) && 'multi-select' === $field['type'] ) {
-				    $prev_value = get_user_meta( $user_id, $key, true );
-				    if ( empty( $_POST[ $key ] ) ) {
-				        $exempt_regions = '';
-                    } else {
-				        $exempt_regions = array_map( 'wc_clean',  $_POST[ $key ] );
-				        $exempt_regions = implode( ',', $exempt_regions );
-                    }
+		$exemption_settings_changed = false;
 
-				    if ( $exempt_regions != $prev_value ) {
-					    update_user_meta( $user_id, $key, $exempt_regions );
-					    $change = true;
-                    }
-				} elseif ( isset( $_POST[ $key ] ) ) {
-					$prev_value = get_user_meta( $user_id, $key, true );
-					$new_value = wc_clean( $_POST[ $key ] );
-					if ( $prev_value != $new_value ) {
-						update_user_meta( $user_id, $key, $new_value );
-						$change = true;
-                    }
-				}
-			}
+		if ( $this->has_exemption_type_changed( $user_id) ) {
+			update_user_meta( $user_id, 'tax_exemption_type', $this->get_posted_exemption_type() );
+			$exemption_settings_changed = true;
+        }
+
+		if ( $this->have_exempt_regions_changed( $user_id ) ) {
+			update_user_meta( $user_id, 'tax_exempt_regions', $this->get_posted_exempt_regions() );
+			$exemption_settings_changed = true;
 		}
 
-		if ( $change ) {
+		if ( $exemption_settings_changed ) {
 		    do_action( 'taxjar_customer_exemption_settings_updated', $user_id );
         }
+	}
+
+	/**
+     * Checks if exemption type has changed when saving a user
+     *
+	 * @param $user_id - Id of customer
+	 *
+	 * @return bool - Whether or not the exemption type has been changed
+	 */
+	public function has_exemption_type_changed( $user_id ) {
+	    $saved_exemption_type = self::get_saved_exemption_type( $user_id );
+		$new_exemption_type = $this->get_posted_exemption_type();
+		if ( $new_exemption_type != $saved_exemption_type ) {
+		    return true;
+		}
+
+		return false;
+    }
+
+	/**
+     * Gets the submitted tax exemption type during user save
+     *
+	 * @return array|string - value to save
+	 */
+    public function get_posted_exemption_type() {
+	    return wc_clean( $_POST[ 'tax_exemption_type' ] );
+    }
+
+	/**
+     * Checks if exempt regions have changed for a user
+     *
+	 * @param $user_id - Id of user to check
+	 *
+	 * @return bool - Whether or not the exempt regions have changed
+	 */
+	public function have_exempt_regions_changed( $user_id ) {
+		$saved_exempt_regions = self::get_saved_exempt_regions( $user_id );
+		$new_exemption_type = $this->get_posted_exempt_regions();
+		if ( $new_exemption_type != $saved_exempt_regions ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+     * Gets the submitted exempt regions value during user save
+     *
+	 * @return string - Concatenated string containing the exempt regions
+	 */
+	public function get_posted_exempt_regions() {
+		if ( empty( $_POST[ 'tax_exempt_regions' ] ) ) {
+			return '';
+		} else {
+			return implode( ',', wc_clean( $_POST[ 'tax_exempt_regions' ] ) );
+		}
+	}
+
+	/**
+     * Gets the exemption type user meta
+     *
+	 * @param $user_id - ID of user
+	 *
+	 * @return mixed
+	 */
+	public static function get_saved_exemption_type( $user_id ) {
+		return get_user_meta( $user_id, 'tax_exemption_type', true );
+	}
+
+	/**
+     * Gets the exempt regions user metadata
+     * 
+	 * @param $user_id - ID of user
+	 *
+	 * @return mixed
+	 */
+	public static function get_saved_exempt_regions( $user_id ) {
+		return get_user_meta( $user_id, 'tax_exempt_regions', true );
 	}
 
 	public function maybe_sync_customer_on_update( $user_id ) {

--- a/includes/class-wc-taxjar-customer-sync.php
+++ b/includes/class-wc-taxjar-customer-sync.php
@@ -152,7 +152,8 @@ class WC_Taxjar_Customer_Sync {
 	 * @param $user_id - Id of user to update
 	 */
 	public function save_customer_meta_fields( $user_id ) {
-		if ( ! apply_filters( 'taxjar_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user_id ) ) {
+		$has_permission = current_user_can( 'manage_woocommerce' ) || current_user_can( 'edit_users' );
+		if ( ! apply_filters( 'taxjar_current_user_can_edit_customer_meta_fields', $has_permission, $user_id ) ) {
 			return;
 		}
 

--- a/includes/class-wc-taxjar-customer-sync.php
+++ b/includes/class-wc-taxjar-customer-sync.php
@@ -156,21 +156,10 @@ class WC_Taxjar_Customer_Sync {
 			return;
 		}
 
-		$exemption_settings_changed = false;
+		update_user_meta( $user_id, 'tax_exemption_type', $this->get_posted_exemption_type() );
+		update_user_meta( $user_id, 'tax_exempt_regions', $this->get_posted_exempt_regions() );
 
-		if ( $this->has_exemption_type_changed( $user_id) ) {
-			update_user_meta( $user_id, 'tax_exemption_type', $this->get_posted_exemption_type() );
-			$exemption_settings_changed = true;
-        }
-
-		if ( $this->have_exempt_regions_changed( $user_id ) ) {
-			update_user_meta( $user_id, 'tax_exempt_regions', $this->get_posted_exempt_regions() );
-			$exemption_settings_changed = true;
-		}
-
-		if ( $exemption_settings_changed ) {
-		    do_action( 'taxjar_customer_exemption_settings_updated', $user_id );
-        }
+		do_action( 'taxjar_customer_exemption_settings_updated', $user_id );
 	}
 
 	/**

--- a/tests/specs/test-customer-sync.php
+++ b/tests/specs/test-customer-sync.php
@@ -1,6 +1,8 @@
 <?php
 class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 
+	public $tj;
+
 	function setUp() {
 		parent::setUp();
 
@@ -121,11 +123,11 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		$should_sync = $record->should_sync();
 		$this->assertFalse( $should_sync );
 
-		// test no name
+		// test no name, falls back to username and should still sync
 		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
 		$record->load_object();
 		$should_sync = $record->should_sync();
-		$this->assertFalse( $should_sync );
+		$this->assertTrue( $should_sync );
 
 		$customer->set_billing_first_name( 'Test' );
 		$customer->set_billing_last_name( 'Test' );
@@ -184,8 +186,8 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 
 		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
 		$record->load_object();
-		$data = $record->get_data();
-		$this->assertEquals( '' , $data[ 'name' ] );
+		$name = $record->get_customer_name();
+		$this->assertEquals( 'name_fallback' , $name );
 
 		$customer->set_first_name( 'First' );
 		$customer->set_last_name( 'Last' );
@@ -193,8 +195,8 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 
 		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
 		$record->load_object();
-		$data = $record->get_data();
-		$this->assertEquals( 'First Last' , $data[ 'name' ] );
+		$name = $record->get_customer_name();
+		$this->assertEquals( 'First Last' , $name );
 
 		$customer->set_billing_first_name( 'Bfirst' );
 		$customer->set_billing_last_name( 'Blast' );
@@ -202,8 +204,8 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 
 		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
 		$record->load_object();
-		$data = $record->get_data();
-		$this->assertEquals( 'Bfirst Blast' , $data[ 'name' ] );
+		$name = $record->get_customer_name();
+		$this->assertEquals( 'Bfirst Blast' , $name );
 
 		$customer->set_shipping_first_name( 'Sfirst' );
 		$customer->set_shipping_last_name( 'Slast' );
@@ -211,8 +213,8 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 
 		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
 		$record->load_object();
-		$data = $record->get_data();
-		$this->assertEquals( 'Sfirst Slast' , $data[ 'name' ] );
+		$name = $record->get_customer_name();
+		$this->assertEquals( 'Sfirst Slast' , $name );
 
 		TaxJar_Customer_Helper::delete_customer( $customer->get_id() );
 	}

--- a/tests/specs/test-customer-sync.php
+++ b/tests/specs/test-customer-sync.php
@@ -504,4 +504,33 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		$record->delete_in_taxjar();
 		TaxJar_Customer_Helper::delete_customer( $customer->get_id() );
 	}
+
+	function test_sync_validation_on_unchanged_customer() {
+		$customer = TaxJar_Customer_Helper::create_exempt_customer();
+
+		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
+		$record->load_object();
+		$record->delete_in_taxjar();
+
+		// test sync new customer
+		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
+		$record->load_object();
+		$result = $record->sync();
+		$this->assertTrue( $result );
+
+		// test sync validation on already synced unchanged customer record
+		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
+		$record->load_object();
+		$validation_result = $record->should_sync();
+		$this->assertFalse( $validation_result );
+
+		// test sync validation after change to exemption settings
+		$record = new TaxJar_Customer_Record( $customer->get_id(), true );
+		$record->load_object();
+		update_user_meta( $record->get_customer_id(), 'tax_exemption_type', 'government' );
+		$validation_result = $record->should_sync();
+		$this->assertTrue( $validation_result );
+
+		$record->delete_in_taxjar();
+	}
 }


### PR DESCRIPTION
There were multiple issues regarding syncing exempt customers to TaxJar.

1. If the customer was missing a piece of required data (normally a name), it would fail to sync. Later if the data was added, it still would fail to sync unless one of the exemption settings was also changed.

This was fixed by falling back to use the user's username if no name was present. Also, the validation logic was altered so that any change to the user could trigger a sync to TaxJar, and only if all the data that is sent to TaxJar was identical as the last sync would syncing be skipped.

2. Tax exemptions would not save or sync unless the user creating the exemption had the manage_woocommerce capability. By default, this capability is only assigned to admins and store manager roles. In some circumstances stores may have customer service roles that do not have that capability (it also controls changing woocommerce store settings).

To fix this the edit_user capability is now accepted as well.

Note: This PR also contains many fixes to style guide errors and warnings. Comments will be added to the PR to indicate which changes are related to the customer exemption fixes. I also recommend viewing the PR with white space differences turned off.

**Steps to Reproduce**

1. Create a customer without a first or last name.
2. Add an exemption type to the customer and save.
3. Check the customer sync logs, the customer will not have been synced.
4. Add a name to the customer.
5. Check the customer sync logs, the customer still will not have synced.

**Expected Result**

After applying the PR, the customer will have synced in step 3 (since it now falls back to username), and again in step 5.

**Click-Test Versions**

- [X] Woo 4.7
- [X] Woo 3.2

**Specs Passing**

- [X] Woo 4.7
- [X] Woo 3.2
