### PR TITLE
Handle non existent record queue table during transaction backfill

### DIFF
--- a/includes/class-wc-taxjar-ajax.php
+++ b/includes/class-wc-taxjar-ajax.php
@@ -76,9 +76,17 @@ class WC_Taxjar_AJAX {
 		$integration = TaxJar();
 		if ( isset( $integration->settings['taxjar_download'] ) && 'yes' == $integration->settings['taxjar_download'] ) {
 			$result   = $integration->transaction_sync->transaction_backfill( $start_date, $end_date, $force_sync );
-			$response = array(
-				'records_updated' => $result
-			);
+
+			if ( is_int( $result ) ) {
+				$response = array(
+					'records_updated' => $result
+				);
+			} else {
+				$response = array(
+					'error' => $result
+				);
+			}
+
 		} else {
 			$response = array(
 				'error' => 'transaction sync disabled'

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -518,7 +518,13 @@ class WC_Taxjar_Transaction_Sync {
 					$count++;
 				}
 			}
+
 			$wpdb->query( $query );
+
+			if ( $wpdb->last_error === "Table 'wordpress.wp_taxjar_record_queue' doesn't exist" ) {
+				return 'record queue table does not exist';
+			}
+
 		}
 
 		$refunds_diff = array_diff( $refund_ids, $record_ids );

--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -139,6 +139,8 @@ jQuery( document ).ready( function() {
 					} else {
 						if ( data.error == "transaction sync disabled" ) {
 							alert( 'Sales tax reporting must be enabled to perform transaction backfill. Please enable this setting and try again.' );
+						} else if ( data.error == "record queue table does not exist" ) {
+							alert( 'The TaxJar record queue database table does not exist. Please try to reinstall the TaxJar plugin in order to fix the installation.' );
 						} else {
 							alert( 'Error adding records to queue.' );
 						}


### PR DESCRIPTION
There is a rare issue that occurs if a problem happens during plugin installation, that may cause the record queue database table to not be installed. In this case the user does not know there is an issue, however transaction sync will not ever work.

This PR fixes the issue by checking for this and adding an error message during backfill that indicates the problem and how to fix it.

**Steps to Reproduce**

1. Drop the record queue database table
2. Run transaction backfill (it needs to find at least one record to update).
3. A message will display indicating that records have been added to the queue, however the queue list view will be empty.

**Expected Result**

After applying the PR, the message should display that the database table was missing and give a suggestion for fixing it.

**Click-Test Versions**

- [X] Woo 4.8
- [X] Woo 3.6

**Specs Passing**

- [X] Woo 4.8
- [X] Woo 3.6
