### PR TITLE
Skip tax calculation on $0 renewal orders and API created orders

### DIFF
--- a/includes/class-wc-taxjar-api-calculation.php
+++ b/includes/class-wc-taxjar-api-calculation.php
@@ -70,6 +70,10 @@ class WC_Taxjar_API_Calculation {
 			}
 		}
 
+		if ( 0 == $order->get_total() ) {
+			$needs_tax_calculated = false;
+		}
+
 		return apply_filters( 'taxjar_api_order_needs_tax_calculated', $needs_tax_calculated, $order, $request, $creating );
 	}
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1027,6 +1027,16 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		 */
 		public function calculate_renewal_order_totals( $order, $subscription, $type ) {
 
+			// Skip tax calculation if order total is 0.
+			if ( 0 == $order->get_total() ) {
+				return $order;
+			}
+
+			// Tax is calculated by default but can be overridden if needed.
+			if ( ! apply_filters( 'taxjar_renewal_order_should_calculate_tax', true, $order, $subscription ) ) {
+				return $order;
+			}
+
 			if ( ! is_object( $subscription ) ) {
 				$subscription = wcs_get_subscription( $subscription );
 			}
@@ -1053,6 +1063,12 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		 * @return null
 		 */
 		public function calculate_order_tax( $order ) {
+
+			// Tax is calculated by default but can be overridden if needed.
+			if ( ! apply_filters( 'taxjar_order_should_calculate_tax', true, $order ) ) {
+				return;
+			}
+
 			$address    = $this->get_address_from_order( $order );
 			$line_items = $this->get_backend_line_items( $order );
 			$shipping   = $order->get_shipping_total(); // Woo 3.0+


### PR DESCRIPTION
Resolves #173. This update skips tax calculation for subscription renewal orders that total 0, which can be common for gift subscription orders which have a signup fee but no recurring cost.

It also adds two filters for `taxjar_renewal_order_should_calculate_tax` and `taxjar_order_should_calculate_tax` for the event that some stores may want to skip tax calculation for other types of orders.

**Steps to Reproduce**

Currrently whem a $0 renewal order is generated, an API call is made to TaxJar.

[Still working on unit tests for filters and to verify API call is not made.]

**Expected Result**

When a $0 renewal order is generated, no API call is made to TaxJar.

**Click-Test Versions**

- [ ] Woo 4.0
- [ ] Woo 3.9
- [ ] Woo 3.8
- [ ] Woo 3.7
- [ ] Woo 3.6
- [ ] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0

**Specs Passing**

- [ ] Woo 4.0
- [ ] Woo 3.9
- [ ] Woo 3.8
- [ ] Woo 3.7
- [ ] Woo 3.6
- [ ] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
