### PR TITLE
Skip Tax Calc API Request For Zero Total Orders

### DIFF
--- a/includes/class-wc-taxjar-api-calculation.php
+++ b/includes/class-wc-taxjar-api-calculation.php
@@ -70,6 +70,16 @@ class WC_Taxjar_API_Calculation {
 			}
 		}
 
+		$total = 0;
+
+		foreach( $order->get_items( 'line_item', 'tax', 'shipping' ) as $item ) {
+			$total += floatval( $item->get_total() );
+		}
+
+		if ( $total <= 0 ) {
+			$needs_tax_calculated = false;
+		}
+
 		return apply_filters( 'taxjar_api_order_needs_tax_calculated', $needs_tax_calculated, $order, $request, $creating );
 	}
 

--- a/includes/class-wc-taxjar-api-calculation.php
+++ b/includes/class-wc-taxjar-api-calculation.php
@@ -72,7 +72,7 @@ class WC_Taxjar_API_Calculation {
 
 		$total = 0;
 
-		foreach( $order->get_items( 'line_item', 'tax', 'shipping' ) as $item ) {
+		foreach( $order->get_items( array( 'line_item', 'fee', 'shipping' ) ) as $item ) {
 			$total += floatval( $item->get_total() );
 		}
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -861,7 +861,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 				$should_calculate = false;
             }
 
-		    return apply_filters( 'taxjar_should_calculate_cart_tax', $should_calculate );
+		    return apply_filters( 'taxjar_should_calculate_cart_tax', $should_calculate, $wc_cart_object );
         }
 
 		/**
@@ -1086,7 +1086,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 				$should_calculate = false;
 			}
 
-			return apply_filters( 'taxjar_should_calculate_order_tax', $should_calculate );
+			return apply_filters( 'taxjar_should_calculate_order_tax', $should_calculate, $order );
 		}
 
 		/**

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1086,7 +1086,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 			$should_calculate = true;
 			$total = 0;
 
-			foreach( $order->get_items( 'line_item', 'tax', 'shipping' ) as $item ) {
+			foreach( $order->get_items( array( 'line_item', 'fee', 'shipping' ) ) as $item ) {
 				$total += floatval( $item->get_total() );
 			}
 

--- a/tests/framework/class-tj-wc-rest-unit-test-case.php
+++ b/tests/framework/class-tj-wc-rest-unit-test-case.php
@@ -314,4 +314,36 @@ class TJ_WC_REST_Unit_Test_Case extends WP_HTTP_TestCase {
 			}
 		}
 	}
+
+	function test_zero_total_api_order_tax_calculation() {
+		TaxJar_Shipping_Helper::delete_simple_flat_rate();
+		TaxJar_Shipping_Helper::create_simple_flat_rate( 0 );
+		$product_id = TaxJar_Product_Helper::create_product( 'simple', array( 'price' => 0 ) )->get_id();
+
+		$request      = new WP_REST_Request( 'POST', $this->order_endpoint . 'orders' );
+		$request_body = TaxJar_API_Order_Helper::create_order_request_body(
+			array(
+				'line_items' => array(
+					array(
+						'product_id' => $product_id,
+						'quantity'   => 1,
+					),
+				),
+				'shipping_lines'       => array(
+					array(
+						'method_id'    => 'flat_rate',
+						'method_title' => 'Flat rate',
+						'total'        => '0',
+					),
+				)
+			)
+		);
+		$request->set_body_params( $request_body );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$order    = wc_get_order( $data['id'] );
+
+		$this->assertFalse( $this->tj->should_calculate_order_tax( $order ) );
+	}
 }

--- a/tests/framework/class-tj-wc-rest-unit-test-case.php
+++ b/tests/framework/class-tj-wc-rest-unit-test-case.php
@@ -327,6 +327,7 @@ class TJ_WC_REST_Unit_Test_Case extends WP_HTTP_TestCase {
 					array(
 						'product_id' => $product_id,
 						'quantity'   => 1,
+						'total'      => '0',
 					),
 				),
 				'shipping_lines'       => array(
@@ -344,6 +345,6 @@ class TJ_WC_REST_Unit_Test_Case extends WP_HTTP_TestCase {
 		$data     = $response->get_data();
 		$order    = wc_get_order( $data['id'] );
 
-		$this->assertFalse( $this->tj->should_calculate_order_tax( $order ) );
+		$this->assertFalse( $this->tj->api_calculation->api_order_needs_tax_calculated( $order, $request, true ) );
 	}
 }

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -1150,4 +1150,15 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 		$this->assertEquals( $rate_id, $found_rate_id );
 	}
+
+	function test_should_calculate_cart_zero_total() {
+		$product = TaxJar_Product_Helper::create_product( 'simple', array( 'price' => 0 ) )->get_id();
+		WC()->cart->add_to_cart( $product );
+
+		WC()->cart->calculate_totals();
+		$this->assertEquals( 0, WC()->cart->get_total( null ) );
+		$should_calculate = $this->tj->should_calculate_cart_tax( WC()->cart );
+
+		$this->assertFalse( $should_calculate );
+	}
 }

--- a/tests/specs/test-api-calculation.php
+++ b/tests/specs/test-api-calculation.php
@@ -68,15 +68,24 @@ class TJ_WC_Tests_API_Calculation extends WP_UnitTestCase {
 	}
 
 	function test_api_order_needs_tax_calculated() {
-		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( null, null, true ) );
-		$this->assertFalse( $this->tj->api_calculation->api_order_needs_tax_calculated( null, null, false ) );
+		$order = new WC_Order();
+		$item = new WC_Order_Item_Product( '' );
+		$product_id = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
+		$product = wc_get_product( $product_id );
+		$item->set_total( '10.00' );
+		$item->set_subtotal( '10.0' );
+		$item->set_quantity( 1 );
+		$order->add_item( $item );
 
-		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( null, array( 'billing' => 1 ), true ) );
-		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( null, array( 'shipping' => 1 ), true ) );
-		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( null, array( 'line_items' => 1 ), true ) );
-		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( null, array( 'shipping_lines' => 1 ), true ) );
-		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( null, array( 'fee_lines' => 1 ), true ) );
-		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( null, array( 'coupon_lines' => 1 ), true ) );
+		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( $order, null, true ) );
+		$this->assertFalse( $this->tj->api_calculation->api_order_needs_tax_calculated( $order, null, false ) );
+
+		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( $order, array( 'billing' => 1 ), true ) );
+		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( $order, array( 'shipping' => 1 ), true ) );
+		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( $order, array( 'line_items' => 1 ), true ) );
+		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( $order, array( 'shipping_lines' => 1 ), true ) );
+		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( $order, array( 'fee_lines' => 1 ), true ) );
+		$this->assertTrue( $this->tj->api_calculation->api_order_needs_tax_calculated( $order, array( 'coupon_lines' => 1 ), true ) );
 	}
 
 }


### PR DESCRIPTION
The plugin currently calculates tax even for orders with a $0 total. This is not necessary. This PR stops the plugin from sending an API request to TaxJar when the order total is $0. This applies to orders created through the cart, in the dashboard, subscription renewals and orders created through the Woo REST API.

**Steps to Reproduce**

1. Place a order with a $0 total
2. Look in the logs and you will see an API request was sent to TaxJar.

**Expected Result**

After applying the PR, no API request will have been sent for those orders.

**Click-Test Versions**

- [X] Woo 4.9
- [X] Woo 4.3

**Specs Passing**

- [X] Woo 4.9
- [X] Woo 4.3

