### PR TITLE
X API Version Support

### DIFF
--- a/includes/class-taxjar-api-request.php
+++ b/includes/class-taxjar-api-request.php
@@ -12,16 +12,18 @@ class TaxJar_API_Request {
 	private $request_type;
 	private $request_body;
 	private $base_url;
+	private $content_type;
 
 	public static $x_api_version = '2020-08-07';
 
-	public function __construct( $endpoint, $body = null, $type = 'post' ) {
+	public function __construct( $endpoint, $body = null, $type = 'post', $content_type = 'application/json' ) {
 		$this->set_api_token( TaxJar()->settings['api_token'] );
 		$this->set_user_agent( TaxJar()->ua );
 		$this->set_base_url( TaxJar()->uri );
 		$this->set_request_type( $type );
 		$this->set_endpoint( $endpoint );
 		$this->set_request_body( $body );
+		$this->set_content_type( $content_type );
 	}
 
 	public function _log( $message ) {
@@ -45,11 +47,19 @@ class TaxJar_API_Request {
 		$request_args = array(
 			'headers'    => array(
 				'Authorization' => 'Token token="' . $this->get_api_token() . '"',
-				'Content-Type'  => 'application/json',
+				'Content-Type'  => $this->get_content_type(),
 				'x-api-version' => self::get_x_api_version()
 			),
 			'user-agent' => $this->ua
 		);
+
+		if ( $this->get_request_type() === 'put' ) {
+			$request_args[ 'method' ] = 'PUT';
+		}
+
+		if ( $this->get_request_type() === 'delete' ) {
+			$request_args[ 'method' ] = 'DELETE';
+		}
 
 		if ( !empty( $this->get_request_body() ) ) {
 			$request_args[ 'body' ] = $this->get_request_body();
@@ -65,6 +75,9 @@ class TaxJar_API_Request {
 				break;
 			case 'put':
 				return $this->send_put_request();
+				break;
+			case 'delete':
+				return $this->send_delete_request();
 				break;
 			default:
 				return $this->send_post_request();
@@ -83,7 +96,13 @@ class TaxJar_API_Request {
 	}
 
 	public function send_put_request() {
+		$url = $this->get_full_url();
+		return wp_remote_request( $url, $this->get_request_args() );
+	}
 
+	public function send_delete_request() {
+		$url = $this->get_full_url();
+		return wp_remote_request( $url, $this->get_request_args() );
 	}
 
 	public static function get_x_api_version() {
@@ -140,6 +159,14 @@ class TaxJar_API_Request {
 
 	public function set_base_url( $url ) {
 		$this->base_url = $url;
+	}
+
+	public function get_content_type() {
+		return $this->content_type;
+	}
+
+	public function set_content_type( $content_type ) {
+		$this->content_type = $content_type;
 	}
 
 

--- a/includes/class-taxjar-api-request.php
+++ b/includes/class-taxjar-api-request.php
@@ -1,0 +1,148 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class TaxJar_API_Request {
+
+	private $ua;
+	private $api_token;
+	private $endpoint;
+	private $request_type;
+	private $request_body;
+	private $base_url;
+
+	public static $x_api_version = '2020-08-07';
+
+	public function __construct( $endpoint, $body = null, $type = 'post' ) {
+		$this->set_api_token( TaxJar()->settings['api_token'] );
+		$this->set_user_agent( TaxJar()->ua );
+		$this->set_base_url( TaxJar()->uri );
+		$this->set_request_type( $type );
+		$this->set_endpoint( $endpoint );
+		$this->set_request_body( $body );
+	}
+
+	public function _log( $message ) {
+
+		if ( $this->endpoint === 'taxes' ) {
+			do_action( 'taxjar_log', $message );
+
+			if ( TaxJar()->debug ) {
+				$logger = new WC_Logger();
+
+				if ( is_array( $message ) || is_object( $message ) ) {
+					$logger->add( 'taxjar', print_r( $message, true ) );
+				} else {
+					$logger->add( 'taxjar', $message );
+				}
+			}
+		}
+	}
+
+	public function get_request_args() {
+		$request_args = array(
+			'headers'    => array(
+				'Authorization' => 'Token token="' . $this->get_api_token() . '"',
+				'Content-Type'  => 'application/json',
+				'x-api-version' => self::get_x_api_version()
+			),
+			'user-agent' => $this->ua
+		);
+
+		if ( !empty( $this->get_request_body() ) ) {
+			$request_args[ 'body' ] = $this->get_request_body();
+		}
+
+		return $request_args;
+	}
+
+	public function send_request() {
+		switch( $this->get_request_type() ) {
+			case 'get':
+				return $this->send_get_request();
+				break;
+			case 'put':
+				return $this->send_put_request();
+				break;
+			default:
+				return $this->send_post_request();
+		}
+	}
+
+	public function send_post_request() {
+		$url = $this->get_full_url();
+		$this->_log( 'Requesting: ' . $url . ' - ' . $this->get_request_body() );
+		return wp_remote_post( $url, $this->get_request_args() );
+	}
+
+	public function send_get_request() {
+		$url = $this->get_full_url();
+		return wp_remote_get( $url, $this->get_request_args() );
+	}
+
+	public function send_put_request() {
+
+	}
+
+	public static function get_x_api_version() {
+		return apply_filters( 'taxjar_x_api_version', self::$x_api_version );
+	}
+
+	public function get_full_url() {
+		return $this->base_url . $this->endpoint;
+	}
+
+	public function get_request_body() {
+		return $this->request_body;
+	}
+
+	public function set_request_body( $body ) {
+		$this->request_body = $body;
+	}
+
+	public function get_api_token() {
+		return $this->api_token;
+	}
+
+	public function set_api_token( $token ) {
+		$this->api_token = $token;
+	}
+
+	public function get_user_agent() {
+		return $this->user_agent;
+	}
+
+	public function set_user_agent( $user_agent ) {
+		$this->ua = $user_agent;
+	}
+
+	public function get_request_type() {
+		return $this->request_type;
+	}
+
+	public function set_request_type( $type ) {
+		$this->request_type = $type;
+	}
+
+	public function get_endpoint() {
+		return $this->endpoint;
+	}
+
+	public function set_endpoint( $endpoint ) {
+		$this->endpoint = $endpoint;
+	}
+
+	public function get_base_url() {
+		return $this->base_url;
+	}
+
+	public function set_base_url( $url ) {
+		$this->base_url = $url;
+	}
+
+
+
+
+}

--- a/includes/class-taxjar-api-request.php
+++ b/includes/class-taxjar-api-request.php
@@ -48,7 +48,7 @@ class TaxJar_API_Request {
 				'Content-Type'  => $this->get_content_type(),
 				'x-api-version' => $this->get_x_api_version()
 			),
-			'user-agent' => $this->ua
+			'user-agent' => $this->get_user_agent()
 		);
 
 		if ( $this->get_request_type() === 'put' ) {
@@ -205,7 +205,7 @@ class TaxJar_API_Request {
 	 * @return mixed
 	 */
 	public function get_user_agent() {
-		return $this->user_agent;
+		return $this->ua;
 	}
 
 	/**

--- a/includes/class-taxjar-api-request.php
+++ b/includes/class-taxjar-api-request.php
@@ -37,29 +37,7 @@ class TaxJar_API_Request {
 	}
 
 	/**
-	 * Logs message to error log
-	 *
-	 * @param string|array $message
-	 */
-	public function _log( $message ) {
-
-		if ( $this->endpoint === 'taxes' ) {
-			do_action( 'taxjar_log', $message );
-
-			if ( TaxJar()->debug ) {
-				$logger = new WC_Logger();
-
-				if ( is_array( $message ) || is_object( $message ) ) {
-					$logger->add( 'taxjar', print_r( $message, true ) );
-				} else {
-					$logger->add( 'taxjar', $message );
-				}
-			}
-		}
-	}
-
-	/**
-	 * Generates the request log to use with wp_remote_request
+	 * Generates the request args to use with wp_remote_request
 	 *
 	 * @return array
 	 */
@@ -116,7 +94,6 @@ class TaxJar_API_Request {
 	 */
 	public function send_post_request() {
 		$url = $this->get_full_url();
-		$this->_log( 'Requesting: ' . $url . ' - ' . $this->get_request_body() );
 		return wp_remote_post( $url, $this->get_request_args() );
 	}
 

--- a/includes/class-taxjar-customer-record.php
+++ b/includes/class-taxjar-customer-record.php
@@ -88,20 +88,10 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 */
 	public function create_in_taxjar() {
 		$data = $this->get_data();
-		$url  = self::API_URI . 'customers';
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_post(
-			$url,
-			array(
-				'headers'    => array(
-					'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-					'Content-Type'  => 'application/json',
-				),
-				'user-agent' => $this->taxjar_integration->ua,
-				'body'       => $body,
-			)
-		);
+		$request = new TaxJar_API_Request( 'customers', $body, 'post' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $body );
 		return $response;
@@ -112,24 +102,11 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 * @return array|WP_Error - API response or WP_Error if request fails
 	 */
 	public function update_in_taxjar() {
-		$customer_id = $this->get_customer_id();
 		$data        = $this->get_data();
-
-		$url  = self::API_URI . 'customers/' . $customer_id;
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_request(
-			$url,
-			array(
-				'method'     => 'PUT',
-				'headers'    => array(
-					'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-					'Content-Type'  => 'application/json',
-				),
-				'user-agent' => $this->taxjar_integration->ua,
-				'body'       => $body,
-			)
-		);
+		$request = new TaxJar_API_Request( 'customers/' . $this->get_customer_id(), $body, 'put' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $body );
 		return $response;
@@ -140,25 +117,13 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 * @return array|WP_Error - API response or WP_Error if request fails
 	 */
 	public function delete_in_taxjar() {
-		$customer_id = $this->get_customer_id();
-		$url         = self::API_URI . 'customers/' . $customer_id;
 		$data        = array(
-			'customer_id' => $customer_id,
+			'customer_id' => $this->get_customer_id(),
 		);
 		$body        = wp_json_encode( $data );
 
-		$response = wp_remote_request(
-			$url,
-			array(
-				'method'     => 'DELETE',
-				'headers'    => array(
-					'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-					'Content-Type'  => 'application/json',
-				),
-				'user-agent' => $this->taxjar_integration->ua,
-				'body'       => $body,
-			)
-		);
+		$request = new TaxJar_API_Request( 'customers/' . $this->get_customer_id(), $body, 'delete' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $body );
 		return $response;
@@ -169,22 +134,10 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 * @return array|WP_Error - API response or WP_Error if request fails
 	 */
 	public function get_from_taxjar() {
-		$customer_id = $this->get_customer_id();
-		$url         = self::API_URI . 'customers/' . $customer_id;
+		$request = new TaxJar_API_Request( 'customers/' . $this->get_customer_id(), null, 'get' );
+		$response = $request->send_request();
 
-		$response = wp_remote_request(
-			$url,
-			array(
-				'method'     => 'GET',
-				'headers'    => array(
-					'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-					'Content-Type'  => 'application/json',
-				),
-				'user-agent' => $this->taxjar_integration->ua,
-			)
-		);
-
-		$this->set_last_request( $customer_id );
+		$this->set_last_request( $this->get_customer_id() );
 		return $response;
 	}
 

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -93,42 +93,26 @@ class TaxJar_Order_Record extends TaxJar_Record {
 
 	public function create_in_taxjar() {
 		$data = $this->get_data();
-		$url = self::API_URI . 'transactions/orders';
 		$data[ 'provider' ] = $this->get_provider();
 		$data[ 'plugin' ] = $this->get_plugin_parameter();
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_post( $url, array(
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-			'body' => $body,
-		) );
+		$request = new TaxJar_API_Request( 'transactions/orders', $body, 'post' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $body );
 		return $response;
 	}
 
 	public function update_in_taxjar(){
-		$order_id = $this->get_transaction_id();
 		$data = $this->get_data();
-
-		$url = self::API_URI . 'transactions/orders/' . $order_id;
 		$data[ 'provider' ] = $this->get_provider();
 		$data[ 'plugin' ] = $this->get_plugin_parameter();
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_request( $url, array(
-			'method' => 'PUT',
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-			'body' => $body,
-		) );
+		$endpoint = 'transactions/orders/' . $this->get_transaction_id();
+		$request = new TaxJar_API_Request( $endpoint, $body, 'put' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $body );
 		return $response;
@@ -136,7 +120,6 @@ class TaxJar_Order_Record extends TaxJar_Record {
 
 	public function delete_in_taxjar(){
 		$order_id = $this->get_transaction_id();
-		$url = self::API_URI . 'transactions/orders/' . $order_id;
 		$data = array(
 			'transaction_id' => $order_id,
 			'provider' => $this->get_provider(),
@@ -144,15 +127,9 @@ class TaxJar_Order_Record extends TaxJar_Record {
 		);
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_request( $url, array(
-			'method' => 'DELETE',
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-			'body' => $body,
-		) );
+		$endpoint = 'transactions/orders/' . $order_id;
+		$request = new TaxJar_API_Request( $endpoint, $body, 'delete' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $body );
 		return $response;
@@ -160,16 +137,9 @@ class TaxJar_Order_Record extends TaxJar_Record {
 
 	public function get_from_taxjar() {
 		$order_id = $this->get_transaction_id();
-		$url = self::API_URI . 'transactions/orders/' . $order_id . '?provider=' . $this->get_provider() . '&plugin=' . $this->get_plugin_parameter();
-
-		$response = wp_remote_request( $url, array(
-			'method' => 'GET',
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-		) );
+		$endpoint = 'transactions/orders/' . $order_id . '?provider=' . $this->get_provider() . '&plugin=' . $this->get_plugin_parameter();
+		$request = new TaxJar_API_Request( $endpoint, null, 'get' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $order_id );
 		return $response;

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -260,42 +260,25 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 
 	public function create_in_taxjar() {
 		$data = $this->get_data();
-		$url = self::API_URI . 'transactions/refunds';
 		$data[ 'provider' ] = $this->get_provider();
 		$data[ 'plugin' ] = $this->get_plugin_parameter();
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_post( $url, array(
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-			'body' => $body,
-		) );
+		$request = new TaxJar_API_Request( 'transactions/refunds', $body, 'post' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $body );
 		return $response;
 	}
 
 	public function update_in_taxjar() {
-		$refund_id = $this->get_transaction_id();
 		$data = $this->get_data();
-
-		$url = self::API_URI . 'transactions/refunds/' . $refund_id;
 		$data[ 'provider' ] = $this->get_provider();
 		$data[ 'plugin' ] = $this->get_plugin_parameter();
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_request( $url, array(
-			'method' => 'PUT',
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-			'body' => $body,
-		) );
+		$request = new TaxJar_API_Request( 'transactions/refunds/' . $this->get_transaction_id(), $body, 'put' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $body );
 		return $response;
@@ -303,7 +286,6 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 
 	public function delete_in_taxjar() {
 		$refund_id = $this->get_transaction_id();
-		$url = self::API_URI . 'transactions/refunds/' . $refund_id;
 		$data = array(
 			'transaction_id' => $refund_id,
 			'provider' => $this->get_provider(),
@@ -311,34 +293,22 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		);
 		$body = wp_json_encode( $data );
 
-		$response = wp_remote_request( $url, array(
-			'method' => 'DELETE',
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-			'body' => $body,
-		) );
+		$request = new TaxJar_API_Request( 'transactions/refunds/' . $refund_id, $body, 'delete' );
+		$response = $request->send_request();
 
 		$this->set_last_request( $body );
 		return $response;
 	}
 
 	public function get_from_taxjar() {
-		$refund_id = $this->get_transaction_id();
-		$url = self::API_URI . 'transactions/refunds/' . $refund_id . '?provider=' . $this->get_provider() . '&plugin=' . $this->get_plugin_parameter();
+		$request = new TaxJar_API_Request(
+			'transactions/refunds/' . $this->get_transaction_id() . '?provider=' . $this->get_provider() . '&plugin=' . $this->get_plugin_parameter(),
+			null,
+			'get'
+		);
+		$response = $request->send_request();
 
-		$response = wp_remote_request( $url, array(
-			'method' => 'GET',
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->taxjar_integration->settings['api_token'] . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->taxjar_integration->ua,
-		) );
-
-		$this->set_last_request( $refund_id );
+		$this->set_last_request( $this->get_transaction_id() );
 		return $response;
 	}
 

--- a/includes/class-wc-taxjar-ajax.php
+++ b/includes/class-wc-taxjar-ajax.php
@@ -29,7 +29,7 @@ class WC_Taxjar_AJAX {
 			wp_die();
 		}
 
-		$taxjar_nexus = new WC_Taxjar_Nexus( new WC_Taxjar_Integration );
+		$taxjar_nexus = new WC_Taxjar_Nexus( TaxJar() );
 		$taxjar_nexus->get_or_update_cached_nexus( true );
 
 		$response = array(

--- a/includes/class-wc-taxjar-connection.php
+++ b/includes/class-wc-taxjar-connection.php
@@ -32,18 +32,15 @@ class WC_Taxjar_Connection {
 		}
 
 		$description = '';
-		$url         = $this->integration->uri . 'verify';
 		$body_string = 'token=' . $this->integration->post_or_setting( 'api_token' );
 
-		$response = wp_remote_post( $url, array(
-			'timeout'     => 60,
-			'headers'     => array(
-								'Authorization' => 'Token token="' . $this->integration->post_or_setting( 'api_token' ) . '"',
-								'Content-Type' => 'application/x-www-form-urlencoded',
-							),
-			'user-agent'  => $this->integration->ua,
-			'body'        => $body_string,
-		) );
+		$request = new TaxJar_API_Request(
+			'verify',
+			$body_string,
+			'post',
+			'application/x-www-form-urlencoded'
+		);
+		$response = $request->send_request();
 
 		$this->api_token_valid = true;
 

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -36,8 +36,6 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 			$this->app_uri            = 'https://app.taxjar.com/';
 			$this->integration_uri    = $this->app_uri . 'account/apps/add/woo';
 			$this->regions_uri        = $this->app_uri . 'account#states';
-			$this->uri                = 'https://api.taxjar.com/v2/';
-			$this->ua                 = self::get_ua_header();
 			$this->debug              = filter_var( $this->get_option( 'debug' ), FILTER_VALIDATE_BOOLEAN );
 			$this->download_orders    = new WC_Taxjar_Download_Orders( $this );
 			$this->transaction_sync   = new WC_Taxjar_Transaction_Sync( $this );
@@ -619,8 +617,6 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 			$calculation_data['shipping_amount'] = is_null( $calculation_data['shipping_amount'] ) ? 0.0 : $calculation_data['shipping_amount'];
 
 			$this->_log( ':::: TaxJar API called ::::' );
-
-			$url = $this->uri . 'taxes';
 
 			$body = array(
 				'from_country' => $from_country,
@@ -1671,27 +1667,6 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 			}
 
 			return strtoupper( $tax_code );
-		}
-
-		/**
-		 * Create user agent header
-		 *
-		 * @return string - user agent header
-		 */
-		static function get_ua_header() {
-			$curl_version = '';
-			if ( function_exists( 'curl_version' ) ) {
-				$curl_version = curl_version();
-				$curl_version = $curl_version['version'] . '; ' . $curl_version['ssl_version'];
-			}
-
-			$php_version       = phpversion();
-			$taxjar_version    = WC_Taxjar::$version;
-			$woo_version       = WC()->version;
-			$wordpress_version = get_bloginfo( 'version' );
-			$site_url          = get_bloginfo( 'url' );
-			$user_agent        = "TaxJar/WooCommerce (PHP $php_version; cURL $curl_version; WordPress $wordpress_version; WooCommerce $woo_version) WC_Taxjar/$taxjar_version $site_url";
-			return $user_agent;
 		}
 
 	}

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -798,20 +798,9 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		public function smartcalcs_request( $json ) {
 			$response = apply_filters( 'taxjar_smartcalcs_request', false, $json );
 			if ( ! $response ) {
-				$url = $this->uri . 'taxes';
-				$this->_log( 'Requesting: ' . $this->uri . 'taxes - ' . $json );
 
-				$response = wp_remote_post(
-					$url,
-					array(
-						'headers'    => array(
-							'Authorization' => 'Token token="' . $this->settings['api_token'] . '"',
-							'Content-Type'  => 'application/json',
-						),
-						'user-agent' => $this->ua,
-						'body'       => $json,
-					)
-				);
+			    $request = new TaxJar_API_Request( 'taxes', $json );
+			    $response = $request->send_request();
 			}
 
 			if ( is_wp_error( $response ) ) {

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -793,9 +793,10 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 
 		public function smartcalcs_request( $json ) {
 			$response = apply_filters( 'taxjar_smartcalcs_request', false, $json );
-			if ( ! $response ) {
 
+			if ( ! $response ) {
 			    $request = new TaxJar_API_Request( 'taxes', $json );
+				$this->_log( 'Requesting: ' . $request->get_full_url() . ' - ' . $json );
 			    $response = $request->send_request();
 			}
 

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -108,15 +108,8 @@ class WC_Taxjar_Nexus {
 	}
 
 	public function get_nexus_from_api() {
-		$url = $this->integration->uri . 'nexus/regions';
-
-		$response = wp_remote_get( $url, array(
-			'headers' => array(
-				'Authorization' => 'Token token="' . $this->integration->post_or_setting( 'api_token' ) . '"',
-				'Content-Type' => 'application/json',
-			),
-			'user-agent' => $this->integration->ua,
-		) );
+		$request = new TaxJar_API_Request( 'nexus/regions', null, 'get' );
+		$response = $request->send_request();
 
 		if ( ! is_wp_error( $response ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300 ) {
 			$this->integration->_log( ':::: Nexus addresses updated ::::' );

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -78,6 +78,7 @@ final class WC_Taxjar {
 			include_once 'includes/class-taxjar-customer-record.php';
 			include_once 'includes/class-wc-taxjar-queue-list.php';
 			include_once 'includes/class-wc-taxjar-api-calculation.php';
+			include_once 'includes/class-taxjar-api-request.php';
 
 			// Register the integration.
 			add_action( 'woocommerce_integrations_init', array( $this, 'add_integration' ), 20 );

--- a/tests/specs/test-class-taxjar-nexus.php
+++ b/tests/specs/test-class-taxjar-nexus.php
@@ -4,7 +4,7 @@ class TJ_WC_Class_Nexus extends WP_UnitTestCase {
 	function setUp() {
 		TaxJar_Woocommerce_Helper::prepare_woocommerce();
 
-		$this->tj = new WC_Taxjar_Integration();
+		$this->tj = TaxJar();
 		$this->tj_nexus = new WC_Taxjar_Nexus( $this->tj );
 		$this->cache_key = 'tj_nexus';
 

--- a/tests/specs/test-filters.php
+++ b/tests/specs/test-filters.php
@@ -8,7 +8,7 @@ class TJ_WC_Filters extends WP_UnitTestCase {
 	function test_append_base_address_to_customer_taxable_address() {
 		TaxJar_Woocommerce_Helper::prepare_woocommerce();
 
-		$tj = new WC_Taxjar_Integration();
+		$tj = TaxJar();
 		WC()->session->set( 'chosen_shipping_methods', array( 'local_pickup' ) );
 
 		$address = array( 'US', 'CO', '81210', 'Denver', '1437 Bannock St' );


### PR DESCRIPTION
In order to ensure data sent to TaxJar for tax filings is as accurate as possible, the plugin needed to be updated to use a x-api-version header that has additional validation of transactions. As part of this change, the plugin was also improved by abstracting out the code used to perform requests to the TaxJar API. 

**Click-Test Versions**

- [X] Woo 5.0 RC1
- [X] Woo 4.9
- [X] Woo 4.3

**Specs Passing**

- [X] Woo 5.0 RC1
- [X] Woo 4.9
- [X] Woo 4.3
