### PR TITLE
Remove tax items before recalculating on subscriptions and API orders

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -1115,6 +1115,8 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 				return;
 			}
 
+			$order->remove_order_items( 'tax' );
+
 			foreach ( $order->get_items() as $item_key => $item ) {
 				$product_id    = $item->get_product_id();
 				$line_item_key = $product_id . '-' . $item_key;


### PR DESCRIPTION
This issue was brought up in #178 

**Steps to Reproduce**

1. Create a subscription
2. Manually process the renew
3. Sales tax will be displayed twice on each line item of the subscription. (The totals will be correct but the sales tax should not be displayed twice).

**Expected Result**

After applying the PR, sales tax on each line item will only display once.

**Click-Test Versions**

- [X] Woo 5.0
- [X] Woo 4.4


**Specs Passing**

- [X] Woo 5.0
- [X] Woo 4.4
