### PR TITLE
Fixes for Test Suite

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,6 +62,7 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		update_option( 'woocommerce_status_options', array( 'uninstall_data' => 1 ) );
 		include $this->plugin_dir . 'woocommerce/uninstall.php';
 
+		do_action( 'wp_enqueue_scripts' );
 		WC_Install::install();
 
 		// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374

--- a/tests/framework/product-helper.php
+++ b/tests/framework/product-helper.php
@@ -38,12 +38,15 @@ class TaxJar_Product_Helper {
 
 	private static function create_subscription_product( $opts = array() ) {
 		$defaults = array(
-			'price' => '19.99',
-			'sku' => 'SUBSCRIPTION1',
-			'tax_class' => '',
-			'tax_status' => 'taxable',
-			'downloadable' => 'no',
-			'virtual' => 'yes',
+			'name'          => 'Dummy Product',
+			'price'         => '19.99',
+			'sku'           => 'SUBSCRIPTION1',
+			'manage_stock'  => false,
+			'tax_status'    => 'taxable',
+			'downloadable'  => false,
+			'virtual'       => false,
+			'stock_status'  => 'instock',
+			'weight'        => '1.1',
 			'interval' => 1,
 			'period' => 'month',
 			'sign_up_fee' => 0,
@@ -51,43 +54,22 @@ class TaxJar_Product_Helper {
 			'trial_period' => 'month',
 		);
 
-		$post = array(
-			'post_title' => 'Dummy Subscription',
-			'post_type' => 'product',
-			'post_status' => 'publish',
-		);
-		$post_meta = array_replace_recursive( $defaults, $opts );
-		$post_meta['regular_price'] = $post_meta['price'];
-
-		$post_id = wp_insert_post( $post );
-
-		register_taxonomy(
-			'product_type',
-			'subscription'
-		);
-
-		update_post_meta( $post_id, '_price', $post_meta['price'] );
-		update_post_meta( $post_id, '_regular_price', $post_meta['regular_price'] );
-		update_post_meta( $post_id, '_sale_price', '' );
-		update_post_meta( $post_id, '_sku', $post_meta['sku'] );
-		update_post_meta( $post_id, '_manage_stock', 'no' );
-		update_post_meta( $post_id, '_tax_class', $post_meta['tax_class'] );
-		update_post_meta( $post_id, '_tax_status', $post_meta['tax_status'] );
-		update_post_meta( $post_id, '_downloadable', $post_meta['downloadable'] );
-		update_post_meta( $post_id, '_virtual', $post_meta['virtual'] );
-		update_post_meta( $post_id, '_stock_status', 'instock' );
+		$props = array_replace_recursive( $defaults, $opts );
+		$props[ 'regular_price' ] = $props[ 'price' ];
+		$product = new WC_Product_Subscription();
+		$product->set_props( $props );
+		$product->save();
+		$product_id = $product->get_id();
 
 		// Subscription meta
-		update_post_meta( $post_id, '_subscription_price', $post_meta['price'] );
-		update_post_meta( $post_id, '_subscription_period_interval', $post_meta['interval'] );
-		update_post_meta( $post_id, '_subscription_period', $post_meta['period'] );
-		update_post_meta( $post_id, '_subscription_sign_up_fee', $post_meta['sign_up_fee'] );
-		update_post_meta( $post_id, '_subscription_trial_length', $post_meta['trial_length'] );
-		update_post_meta( $post_id, '_subscription_trial_period', $post_meta['trial_period'] );
+		update_post_meta( $product_id, '_subscription_price', $props['price'] );
+		update_post_meta( $product_id, '_subscription_period_interval', $props['interval'] );
+		update_post_meta( $product_id, '_subscription_period', $props['period'] );
+		update_post_meta( $product_id, '_subscription_sign_up_fee', $props['sign_up_fee'] );
+		update_post_meta( $product_id, '_subscription_trial_length', $props['trial_length'] );
+		update_post_meta( $product_id, '_subscription_trial_period', $props['trial_period'] );
 
-		wp_set_object_terms( $post_id, 'subscription', 'product_type' );
-
-		return new WC_Product_Subscription( $post_id );
+		return new WC_Product_Subscription( $product_id );
 	}
 
 }

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -110,11 +110,11 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		WC()->cart->calculate_totals();
 
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $item ) {
-			$this->assertEquals( $item['line_tax'],  0.36, '', 0.01 );
+			$this->assertEquals( $item['line_tax'],  0.58, '', 0.01 );
 		}
 
-		$this->assertEquals( WC()->cart->get_shipping_tax(), 0.63, '', 0.01 );
-		$this->assertEquals( WC()->cart->get_total_tax(),  0.99, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_shipping_tax(), 0.69, '', 0.01 );
+		$this->assertEquals( WC()->cart->get_total_tax(),  1.27, '', 0.01 );
 	}
 
 	function test_correct_taxes_with_exempt_shipping() {


### PR DESCRIPTION
There were multiple issues with our test specs and test framework. These included:
- A out of date spec that was failing due to changed rates.
- Subscription specs failing due to old method of creating subscription products.
- Warning messages about scripts being enqueue before the wp_enqueue_scripts action was fired.

This PR contains a rebuild of the way we create subscription products in the test framework, an update to the out of date spec and a fix to the warnings.

As the changes are only to the test suite, no click testing is necessary.

**Specs Passing**

- [X] Woo 5.1
- [X] Woo 4.6
