### PR TITLE
Set the baseurl in the constructor, and make it filterable

### DIFF
--- a/includes/class-taxjar-api-request.php
+++ b/includes/class-taxjar-api-request.php
@@ -17,7 +17,7 @@ class TaxJar_API_Request {
 	private $content_type;
 
 	public static $x_api_version = '2020-08-07';
-	public static $base_url = 'https://api.taxjar.com/v2/';
+	public static $base_url;
 
 	/**
 	 * TaxJar_API_Request constructor.
@@ -28,6 +28,8 @@ class TaxJar_API_Request {
 	 * @param string $content_type - content type header for request
 	 */
 	public function __construct( $endpoint, $body = null, $type = 'post', $content_type = 'application/json' ) {
+		self::$base_url = apply_filters( 'taxjar_set_base_url', 'https://api.taxjar.com/v2/' );
+
 		$this->set_api_token( TaxJar()->settings['api_token'] );
 		$this->set_user_agent( self::create_ua_header() );
 		$this->set_request_type( $type );


### PR DESCRIPTION
_Describe the problem ([reference the issue](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) if applicable) and what the PR accomplishes._

https://github.com/taxjar/taxjar-woocommerce-plugin/issues/184

In this PR, I make the baseUrl filterable, so that the baseurl can be changed to https://api.sandbox.taxjar.com.

**Steps to Reproduce**

1. Do this
2. And that
3. Finally this

**Expected Result**

After applying the PR, this should happen.

**Click-Test Versions**

- [ ] Woo 4.0
- [ ] Woo 3.9
- [ ] Woo 3.8
- [ ] Woo 3.7
- [ ] Woo 3.6
- [ ] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0

**Specs Passing**

- [ ] Woo 4.0
- [ ] Woo 3.9
- [ ] Woo 3.8
- [ ] Woo 3.7
- [ ] Woo 3.6
- [ ] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
