### PR TITLE
Support WooCommerce Cart and Checkout Blocks

### DIFF
--- a/includes/TaxCalculation/class-block-flag.php
+++ b/includes/TaxCalculation/class-block-flag.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Block Flag
+ *
+ * Used to determine if currently executing a request to the Woo REST API that requires tax calculation.
+ *
+ * @package TaxJar\WooCommerce\TaxCalculation
+ */
+
+namespace TaxJar\WooCommerce\TaxCalculation;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Block_Flag
+ */
+class Block_Flag {
+
+	/**
+	 * Stores whether request that requires calculation is being executed.
+	 *
+	 * @var bool
+	 */
+	private static $doing_calculation_request;
+
+	/**
+	 * Add filters.
+	 */
+	public static function init_hooks() {
+		add_filter( 'rest_dispatch_request', 'TaxJar\WooCommerce\TaxCalculation\Block_Flag::maybe_set_block_flag', 10, 3 );
+	}
+
+	/**
+	 * Set the flag if performing API request that requires calculation.
+	 *
+	 * @param mixed           $dispatch_result Dispatch result.
+	 * @param WP_REST_Request $request         Request used to generate the response.
+	 * @param string          $route           Route of the request.
+	 *
+	 * @return mixed
+	 */
+	public static function maybe_set_block_flag( $dispatch_result, $request, $route ) {
+		if ( self::is_doing_request_that_requires_calculation( $route ) ) {
+			self::doing_request_that_requires_calculation();
+		} else {
+			self::clear_flag();
+		}
+
+		return $dispatch_result;
+	}
+
+	/**
+	 * Check if currently executing a request that requires calculation.
+	 *
+	 * @param string $route Request route.
+	 *
+	 * @return bool
+	 */
+	private static function is_doing_request_that_requires_calculation( $route ) {
+		foreach ( self::get_routes_that_require_calculation() as $calculation_route ) {
+			if ( strpos( $route, $calculation_route ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the routes the require tax calculation.
+	 *
+	 * @return array
+	 */
+	private static function get_routes_that_require_calculation() {
+		return array(
+			'/wc/store/cart',
+			'/wc/store/checkout',
+		);
+	}
+
+	/**
+	 * Set the flag.
+	 */
+	public static function doing_request_that_requires_calculation() {
+		self::$doing_calculation_request = true;
+	}
+
+	/**
+	 * Check if flag is set.
+	 *
+	 * @return bool
+	 */
+	public static function was_block_initialized() {
+		return true === self::$doing_calculation_request;
+	}
+
+	/**
+	 * Clear the flag.
+	 */
+	public static function clear_flag() {
+		self::$doing_calculation_request = false;
+	}
+
+}

--- a/includes/class-taxjar-tax-calculation.php
+++ b/includes/class-taxjar-tax-calculation.php
@@ -203,8 +203,7 @@ class TaxJar_Tax_Calculation {
 	 */
 	public function should_calculate_cart_tax( $wc_cart_object ) {
 		$should_calculate = true;
-
-		// If outside of cart and checkout page or within mini-cart, skip calculations
+		
 		if ( ! $this->should_calculate_on_page() ) {
 			$should_calculate = false;
 		}

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -104,6 +104,7 @@ final class WC_Taxjar {
 			include_once 'includes/TaxCalculation/class-tax-calculator.php';
 			include_once 'includes/TaxCalculation/class-order-tax-calculation-validator.php';
 			include_once 'includes/TaxCalculation/class-tax-calculator-builder.php';
+			include_once 'includes/TaxCalculation/class-block-flag.php';
 
 			// Register the integration.
 			add_action( 'woocommerce_integrations_init', array( $this, 'add_integration' ), 20 );

--- a/tests/specs/tax-calculation/test-block-flag.php
+++ b/tests/specs/tax-calculation/test-block-flag.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace TaxJar;
+
+use PHPUnit\Framework\TestCase;
+use TaxJar\WooCommerce\TaxCalculation\Block_Flag;
+
+class Test_Block_Flag extends TestCase {
+
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		Block_Flag::clear_flag();
+		parent::tearDown();
+	}
+
+	public function test_cart_route() {
+		$this->assertFalse( Block_Flag::was_block_initialized() );
+		apply_filters( 'rest_dispatch_request', null, null, '/wc/store/cart', null );
+		$this->assertTrue( Block_Flag::was_block_initialized() );
+	}
+
+	public function test_checkout_route() {
+		$this->assertFalse( Block_Flag::was_block_initialized() );
+		apply_filters( 'rest_dispatch_request', null, null, '/wc/store/checkout', null );
+		$this->assertTrue( Block_Flag::was_block_initialized() );
+	}
+
+	public function test_incorrect_route() {
+		apply_filters( 'rest_dispatch_request', null, null, '/wc/store/invalid', null );
+		$this->assertFalse( Block_Flag::was_block_initialized() );
+	}
+
+	public function test_flag_reset() {
+		apply_filters( 'rest_dispatch_request', null, null, '/wc/store/checkout', null );
+		apply_filters( 'rest_dispatch_request', null, null, '/wc/store/invalid', null );
+		$this->assertFalse( Block_Flag::was_block_initialized() );
+	}
+}


### PR DESCRIPTION
This PR enables our plugin to calculate tax when using the WooCommerce cart and checkout blocks.

**Steps to Reproduce**

1. Activate WooCommerce blocks plugin.
2. Add the cart/checkout block to a page.
3. Add a product to the cart and navigate to the page.
4. Tax will not be calculated.

**Expected Result**

After applying the PR, tax will be calculated in the cart and checkout blocks.

**Click-Test Versions**

- [X] Woo 5.3
- [X] Woo 4.8

**Specs Passing**

- [X] Woo 5.3
- [X] Woo 4.8
