### PR TITLE
Minor performance optimization for transaction sync

### DIFF
--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -33,7 +33,7 @@ class WC_Taxjar_Transaction_Sync {
 		$transaction_sync_enabled = isset( $this->taxjar_integration->settings['taxjar_download'] ) && 'yes' == $this->taxjar_integration->settings['taxjar_download'];
 
 		if ( $sales_tax_enabled || $transaction_sync_enabled ) {
-			add_action( 'init', array( __CLASS__, 'schedule_process_queue' ) );
+			add_action( 'admin_init', array( __CLASS__, 'schedule_process_queue' ) );
 			add_action( self::PROCESS_QUEUE_HOOK, array( $this, 'process_queue' ) );
 		}
 


### PR DESCRIPTION
This is a minor performance improvement to the transaction sync process. Transaction sync works using action scheduler. Every twenty minutes a scheduled action is run that will process all records in the queue and create/update them in TaxJar. If more records remain than a singe job can process, the action will be scheduled to run again at the next possible time. 

In addition to the queue processor there is also a method running on the "init" hook that ensures there is always a scheduled action to process the queue. This method exists because there have been occurrences of the scheduled action getting cancelled or removed and causing no transactions to sync to TaxJar. This PR moves that method from the "init" hook to the "admin_init" hook. This should reduce the number of queries performed against the action scheduler table while still ensuring the the process queue job remains scheduled.

**Click-Test Versions**

- [X] Woo 5.4
- [X] Woo 4.9

**Specs Passing**

- [X] Woo 5.4
- [X] Woo 4.9
