### PR TITLE
Fix error when no line items are present in tax details

### DIFF
--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -56,10 +56,6 @@ class WC_Taxjar_Nexus {
 
 		$nexus_areas = $this->get_or_update_cached_nexus();
 
-		if ( count( $nexus_areas ) == 0 ) {
-			$has_nexus = true;
-		}
-
 		array_push(
 			$nexus_areas,
 			(object) array(


### PR DESCRIPTION
This PR resolves the issues found in https://github.com/taxjar/taxjar-woocommerce-plugin/issues/193 and https://github.com/taxjar/taxjar-woocommerce-plugin/issues/192

When a customer set up their TaxJar account and did not configure any nexus states, the API response for nexus regions would return an empty list. When the nexus list was empty there was logic in our plugin that would determine that we should calculate tax for all orders. 

When the api response was returned for these orders, it would indicate that no nexus was found and would not include the "breakdown" field in the response. This scenario was not handled by the plugin and would lead to a fatal PHP error being thrown when attempting to apply the tax response to an order.

**Steps to Reproduce**

1. Create/use a TaxJar account with no nexus states configured.
2. In the WooCommerce admin dashboard (with the above TaxJar account connected) manually create an order.
3. For the shipping and billing address use an address that is not in the state configured in the WooCommerce store settings. If the store setting state it used, it will be sent as the from state on the API request and the TaxJar API will appropriately mark it as having nexus. This will prevent the issue from being replicated.
4. Add a product to the order and click the "Recalculate Totals" button.
5. The AJAX request triggered by the button will not finish, and a fatal PHP error will be present in the logs.

**Expected Result**

After applying the PR, the recalculate totals call with finish as expect and no tax will be applied to the order since it does not have nexus.

**Click-Test Versions**

- [X] Woo 5.5
- [X] Woo 5.0

**Specs Passing**

- [X] Woo 5.5
- [X] Woo 5.0
