### PR TITLE
Add cart tax request body builder and tests

### DIFF
--- a/includes/TaxCalculation/class-cart-tax-request-body-builder.php
+++ b/includes/TaxCalculation/class-cart-tax-request-body-builder.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * TaxJar Cart Tax Request Body Builder
+ *
+ * Builds tax request body from WC_Cart.
+ *
+ * @package TaxJar\TaxCalculation
+ */
+
+namespace TaxJar;
+
+use TaxJar_Settings;
+use TaxJar_Tax_Calculation;
+use WC_Cart;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Order_Tax_Request_Body_Builder
+ */
+class Cart_Tax_Request_Body_Builder extends Tax_Request_Body_Builder {
+
+	/**
+	 * Cart object use to get details for tax request body.
+	 *
+	 * @var WC_Cart
+	 */
+	protected $cart;
+
+	/**
+	 * Cart_Tax_Request_Body_Builder constructor.
+	 *
+	 * @param WC_Cart $cart cart to get tax request body details from.
+	 */
+	public function __construct( WC_Cart $cart ) {
+		$this->cart = $cart;
+		parent::__construct();
+	}
+
+	/**
+	 * Get ship to address from cart and set on tax request body.
+	 * Method based on WC_Customer::get_taxable_address but can't use it directly due to lack of street field
+	 */
+	protected function get_ship_to_address() {
+		$tax_based_on = get_option( 'woocommerce_tax_based_on' );
+
+		if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && count( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+			$tax_based_on = 'base';
+		}
+
+		if ( 'base' === $tax_based_on ) {
+			$store_settings = TaxJar_Settings::get_store_settings();
+			$country        = $store_settings['country'];
+			$state          = $store_settings['state'];
+			$postcode       = $store_settings['postcode'];
+			$city           = $store_settings['city'];
+			$street         = $store_settings['street'];
+		} elseif ( 'billing' === $tax_based_on ) {
+			$country  = WC()->customer->get_billing_country();
+			$state    = WC()->customer->get_billing_state();
+			$postcode = WC()->customer->get_billing_postcode();
+			$city     = WC()->customer->get_billing_city();
+			$street   = WC()->customer->get_billing_address();
+		} else {
+			$country  = WC()->customer->get_shipping_country();
+			$state    = WC()->customer->get_shipping_state();
+			$postcode = WC()->customer->get_shipping_postcode();
+			$city     = WC()->customer->get_shipping_city();
+			$street   = WC()->customer->get_shipping_address();
+		}
+
+		$taxable_address = apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city, $street ) );
+		$this->tax_request_body->set_to_country( $taxable_address[0] );
+		$this->tax_request_body->set_to_state( $taxable_address[1] );
+		$this->tax_request_body->set_to_zip( $taxable_address[2] );
+		$this->tax_request_body->set_to_city( $taxable_address[3] );
+		$this->tax_request_body->set_to_street( $taxable_address[4] );
+	}
+
+	/**
+	 * Get shipping amount and adds it to request body.
+	 */
+	protected function get_shipping_amount() {
+		$this->tax_request_body->set_shipping_amount( $this->cart->get_shipping_total() );
+	}
+
+	/**
+	 * Get customer ID and add it to request body.
+	 */
+	protected function get_customer_id() {
+		$customer_id = apply_filters( 'taxjar_get_customer_id', WC()->customer->get_id(), WC()->customer );
+		$this->tax_request_body->set_customer_id( $customer_id );
+	}
+
+	/**
+	 * Get exemption type and add it to request body.
+	 */
+	protected function get_exemption_type() {
+		$exemption_type = apply_filters( 'taxjar_cart_exemption_type', '', $this->cart );
+		$this->tax_request_body->set_exemption_type( $exemption_type );
+	}
+
+	/**
+	 * Get product line items and add them to request body.
+	 */
+	protected function get_product_line_items() {
+		foreach ( $this->cart->get_cart() as $item_key => $item ) {
+			$request_line_item = array(
+				'id'               => $item['data']->get_id() . '-' . $item_key,
+				'quantity'         => $item['quantity'],
+				'product_tax_code' => $this->get_line_item_tax_code( $item['data'] ),
+				'unit_price'       => $this->get_line_item_unit_price( $item ),
+				'discount'         => $this->get_line_item_discount_amount( $item ),
+			);
+
+			$this->tax_request_body->add_line_item( $request_line_item );
+		}
+	}
+
+	/**
+	 * Get product tax code for line item
+	 *
+	 * @param WC_Product $product Product in cart.
+	 *
+	 * @return string
+	 */
+	private function get_line_item_tax_code( $product ): string {
+		if ( ! $product->is_taxable() || 'zero-rate' === sanitize_title( $product->get_tax_class() ) ) {
+			return '99999';
+		}
+
+		return TaxJar_Tax_Calculation::get_tax_code_from_class( $product->get_tax_class() );
+	}
+
+	/**
+	 * Get line item unit price
+	 *
+	 * @param array $item Item in cart.
+	 *
+	 * @return float|string
+	 */
+	private function get_line_item_unit_price( $item ) {
+		return wc_format_decimal( $item['line_subtotal'] / $item['quantity'] );
+	}
+
+	/**
+	 * Get line item discount amount
+	 *
+	 * @param array $item Item in cart.
+	 *
+	 * @return float|string
+	 */
+	private function get_line_item_discount_amount( $item ) {
+		return wc_format_decimal( $item['line_subtotal'] - $item['line_total'] );
+	}
+
+	/**
+	 * Get fee line items and add them to request body.
+	 */
+	protected function get_fee_line_items() {
+		foreach ( $this->cart->get_fees() as $fee_key => $fee ) {
+			$request_line_item = array(
+				'id'               => $fee->id,
+				'quantity'         => 1,
+				'product_tax_code' => $this->get_fee_item_tax_code( $fee ),
+				'unit_price'       => $fee->total,
+				'discount'         => 0,
+			);
+
+			$this->tax_request_body->add_line_item( $request_line_item );
+		}
+	}
+
+	/**
+	 * Get product tax code from fee
+	 *
+	 * @param object $fee Fee in cart.
+	 *
+	 * @return string
+	 */
+	private function get_fee_item_tax_code( $fee ): string {
+		if ( ! $fee->taxable || 'zero-rate' === sanitize_title( $fee->tax_class ) ) {
+			return '99999';
+		}
+
+		return TaxJar_Tax_Calculation::get_tax_code_from_class( $fee->tax_class );
+	}
+}
+

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -105,6 +105,7 @@ final class WC_Taxjar {
 			include_once 'includes/TaxCalculation/class-order-tax-calculation-validator.php';
 			include_once 'includes/TaxCalculation/class-tax-calculator-builder.php';
 			include_once 'includes/TaxCalculation/class-block-flag.php';
+			include_once 'includes/TaxCalculation/class-cart-tax-request-body-builder.php';
 
 			// Register the integration.
 			add_action( 'woocommerce_integrations_init', array( $this, 'add_integration' ), 20 );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -91,6 +91,7 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		require_once $this->tests_dir . '/framework/class-taxjar-api-order-helper.php';
 		require_once $this->tests_dir . '/framework/class-tj-wc-rest-unit-test-case.php';
 		require_once $this->tests_dir . '/framework/class-taxjar-test-order-factory.php';
+		require_once $this->tests_dir . '/framework/cart-builder.php';
 	}
 
 	public function setup() {

--- a/tests/framework/cart-builder.php
+++ b/tests/framework/cart-builder.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace TaxJar\Tests\Framework;
+
+use WC_Cart;
+use WC_Customer;
+
+class Cart_Builder {
+
+	private $cart;
+
+	private $shipping_address = [
+		'street' => '123 main st',
+		'city' => 'Payson',
+		'state' => 'UT',
+		'zip' => '84651',
+		'country' => 'US'
+	];
+
+	private $billing_address = [
+		'street' => '123 state st',
+		'city' => 'Denver',
+		'state' => 'CO',
+		'zip' => '80014',
+		'country' => 'US'
+	];
+
+	private $shipping_total = '10';
+
+	private $customer_id;
+
+	private $products = [];
+
+	private $coupons = [];
+
+	private $fees = [];
+
+	public static function a_cart(): Cart_Builder {
+		return new static();
+	}
+
+	public function __construct() {
+		$this->cart = WC()->cart;
+		$this->cart->empty_cart();
+		WC()->customer = new WC_Customer();
+	}
+
+	public function with_shipping_address( array $address ): Cart_Builder {
+		$this->shipping_address = $address;
+		return $this;
+	}
+
+	public function with_billing_address( array $address ): Cart_Builder {
+		$this->billing_address = $address;
+		return $this;
+	}
+
+	public function with_shipping_total(string $total): Cart_Builder {
+		$this->shipping_total = $total;
+		return $this;
+	}
+
+	public function with_customer_id( int $customer_id ): Cart_Builder {
+		$this->customer_id = $customer_id;
+		return $this;
+	}
+
+	public function with_product( $product_id, $quantity ): Cart_Builder {
+		$this->products[] = [
+			'product_id' => $product_id,
+			'quantity' => $quantity
+		];
+		return $this;
+	}
+
+	public function with_coupon( string $coupon_code ): Cart_Builder {
+		$this->coupons[] = $coupon_code;
+		return $this;
+	}
+
+	public function with_fee( array $fee ): Cart_Builder {
+		$this->fees[] = $fee;
+		return $this;
+	}
+
+	public function build(): WC_Cart {
+		$this->set_shipping_address();
+		$this->set_billing_address();
+		$this->set_shipping_total();
+		$this->set_customer_id();
+		$this->add_products();
+		$this->add_coupons();
+		$this->add_fees();
+		return $this->cart;
+	}
+
+	private function set_shipping_address() {
+		WC()->customer->set_shipping_address( $this->shipping_address['street'] );
+		WC()->customer->set_shipping_city( $this->shipping_address['city'] );
+		WC()->customer->set_shipping_state( $this->shipping_address['state'] );
+		WC()->customer->set_shipping_postcode( $this->shipping_address['zip'] );
+		WC()->customer->set_shipping_country( $this->shipping_address['country'] );
+	}
+
+	private function set_billing_address() {
+		WC()->customer->set_billing_address( $this->billing_address['street'] );
+		WC()->customer->set_billing_city( $this->billing_address['city'] );
+		WC()->customer->set_billing_state( $this->billing_address['state'] );
+		WC()->customer->set_billing_postcode( $this->billing_address['zip'] );
+		WC()->customer->set_billing_country( $this->billing_address['country'] );
+	}
+
+	private function set_shipping_total() {
+		$this->cart->set_shipping_total( $this->shipping_total );
+	}
+
+	private function set_customer_id() {
+		if ( $this->customer_id ) {
+			WC()->customer->set_id( $this->customer_id );
+		}
+	}
+
+	private function add_products() {
+		foreach( $this->products as $item ) {
+			$this->cart->add_to_cart( $item['product_id'], $item['quantity'] );
+		}
+	}
+
+	private function add_coupons() {
+		foreach( $this->coupons as $coupon ) {
+			$this->cart->apply_coupon( $coupon );
+		}
+	}
+
+	private function add_fees() {
+		foreach( $this->fees as $fee ) {
+			$this->cart->add_fee( $fee['name'], $fee['amount'], $fee['taxable'], $fee['tax_class'] );
+		}
+	}
+}

--- a/tests/specs/tax-calculation/test-cart-tax-request-body-builder.php
+++ b/tests/specs/tax-calculation/test-cart-tax-request-body-builder.php
@@ -1,0 +1,395 @@
+<?php
+
+namespace TaxJar\Tests;
+
+use Exception;
+use TaxJar\Cart_Tax_Request_Body_Builder;
+use TaxJar\Tests\Framework\Cart_Builder;
+use TaxJar_Coupon_Helper;
+use TaxJar_Product_Helper;
+use WC_Cart_Totals;
+use WC_Tax;
+use WP_UnitTestCase;
+
+class Test_Cart_Tax_Request_Body_Builder extends WP_UnitTestCase {
+
+	private $test_exemption_type;
+
+	public function tearDown() {
+		update_option( 'woocommerce_tax_based_on', 'shipping' );
+		remove_filter( 'taxjar_cart_exemption_type', array( $this, 'add_test_exemption_type' ) );
+	}
+
+	/**
+	 * @dataProvider provide_tax_basis_address
+	 */
+	public function test_correct_to_address_by_tax_basis( string $tax_basis, array $expected_address ) {
+		update_option( 'woocommerce_tax_based_on', $tax_basis );
+		$cart = Cart_Builder::a_cart()->build();
+		$cart_tax_request_body_builder = new Cart_Tax_Request_Body_Builder( $cart );
+
+		$tax_request_body = $cart_tax_request_body_builder->create();
+
+		$this->assertEquals( $expected_address['street'], $tax_request_body->get_to_street() );
+		$this->assertEquals( $expected_address['city'], $tax_request_body->get_to_city() );
+		$this->assertEquals( $expected_address['state'], $tax_request_body->get_to_state() );
+		$this->assertEquals( $expected_address['zip'], $tax_request_body->get_to_zip() );
+		$this->assertEquals( $expected_address['country'], $tax_request_body->get_to_country() );
+	}
+
+	public function provide_tax_basis_address(): array {
+		return [
+			'shipping tax basis' => [
+				'shipping',
+				[
+					'street' => '123 main st',
+					'city' => 'Payson',
+					'state' => 'UT',
+					'zip' => '84651',
+					'country' => 'US'
+				]
+			],
+			'billing tax basis' => [
+				'billing',
+				[
+					'street' => '123 state st',
+					'city' => 'Denver',
+					'state' => 'CO',
+					'zip' => '80014',
+					'country' => 'US'
+				]
+			],
+			'base tax basis' => [
+				'base',
+				[
+					'street' => '6060 S Quebec St',
+					'city' => 'Greenwood Village',
+					'state' => 'CO',
+					'zip' => '80111',
+					'country' => 'US'
+				]
+			],
+		];
+	}
+
+	public function test_shipping_amount() {
+		$cart = Cart_Builder::a_cart()->with_shipping_total( '20' )->build();
+		$cart_tax_request_body_builder = new Cart_Tax_Request_Body_Builder( $cart );
+
+		$tax_request_body = $cart_tax_request_body_builder->create();
+
+		$this->assertEquals( '20', $tax_request_body->get_shipping_amount() );
+	}
+
+	/**
+	 * @dataProvider provide_customer_id
+	 * @param $customer_id
+	 */
+	public function test_customer_id( $customer_id ) {
+		$cart = Cart_Builder::a_cart()->with_customer_id( $customer_id )->build();
+		$cart_tax_request_body_builder = new Cart_Tax_Request_Body_Builder( $cart );
+
+		$tax_request_body = $cart_tax_request_body_builder->create();
+
+		$this->assertEquals( $customer_id, $tax_request_body->get_customer_id() );
+	}
+
+	public function provide_customer_id(): array {
+		return [
+			'guest checkout' => [0],
+			'logged in user' => [5]
+		];
+	}
+
+	/**
+	 * @dataProvider provide_exemption_type
+	 * @param $exemption_type
+	 */
+	public function test_exemption_type( $exemption_type ) {
+		$this->set_test_exemption_type( $exemption_type );
+		$cart = Cart_Builder::a_cart()->build();
+		$cart_tax_request_body_builder = new Cart_Tax_Request_Body_Builder( $cart );
+
+		$tax_request_body = $cart_tax_request_body_builder->create();
+
+		$this->assertEquals( $exemption_type, $tax_request_body->get_exemption_type() );
+	}
+
+	private function set_test_exemption_type( $exemption_type ) {
+		if ( $exemption_type ) {
+			$this->test_exemption_type = $exemption_type;
+			add_filter( 'taxjar_cart_exemption_type', array( $this, 'add_test_exemption_type' ) );
+		}
+	}
+
+	public function provide_exemption_type(): array {
+		return [
+			'no filter applied' => [''],
+			'exemption type filter applied' => ['test_type']
+		];
+	}
+
+	public function add_test_exemption_type( $exemption_type ) {
+		return $this->test_exemption_type;
+	}
+
+	/**
+	 * @dataProvider provide_cart_data
+	 *
+	 * @param array $products
+	 * @param array $coupons
+	 */
+	public function test_line_item( array $products, array $coupons = []) {
+		$cart = Cart_Builder::a_cart();
+		foreach( $products as $product ) {
+			$cart = $cart->with_product( $product['product']->get_id(), $product['quantity'] );
+		}
+		foreach( $coupons as $coupon ) {
+			$cart->with_coupon( $coupon->get_code() );
+		}
+		$cart = $cart->build();
+		$cart_tax_request_body_builder = new Cart_Tax_Request_Body_Builder( $cart );
+
+		$tax_request_body = $cart_tax_request_body_builder->create();
+
+		foreach( $products as $product ) {
+			$item = $this->get_item_from_tax_request_body( $tax_request_body, $product['product']->get_id() );
+			$this->assertEquals( $product['quantity'], $item['quantity'] );
+			$this->assertEquals( $product['expected_values']['product_tax_code'], $item['product_tax_code'] );
+			$this->assertEquals( $product['expected_values']['unit_price'], $item['unit_price'] );
+			$this->assertEquals( $product['expected_values']['discount'], $item['discount'] );
+		}
+	}
+
+	private function get_item_from_tax_request_body( $tax_request_body, $product_id ) {
+		foreach( $tax_request_body->get_line_items() as $item ) {
+			if ( strpos( $item['id'], $product_id . '-' ) !== false ) {
+				return $item;
+			}
+		}
+	}
+
+	public function provide_cart_data(): array {
+		WC_Tax::create_tax_class( 'clothing-rate-20010' );
+		return [
+			'a single simple product' => [
+				[
+					[
+						'product' => TaxJar_Product_Helper::create_product(),
+						'quantity' => 1,
+						'expected_values' => [
+							'product_tax_code' => '',
+							'unit_price' => 10,
+							'discount' => 0
+						]
+					],
+				],
+			],
+			'a simple product with quantity of 2' => [
+				[
+					[
+						'product' => TaxJar_Product_Helper::create_product(),
+						'quantity' => 2,
+						'expected_values' => [
+							'product_tax_code' => '',
+							'unit_price' => 10,
+							'discount' => 0
+						]
+					],
+				],
+			],
+			'a simple product with discount' => [
+				[
+					[
+						'product' => TaxJar_Product_Helper::create_product(),
+						'quantity' => 2,
+						'expected_values' => [
+							'product_tax_code' => '',
+							'unit_price' => 10,
+							'discount' => 10
+						]
+					]
+				],
+				[
+					TaxJar_Coupon_Helper::create_coupon()
+				]
+			],
+			'a simple product with non taxable status' => [
+				[
+					[
+						'product' => TaxJar_Product_Helper::create_product(
+							'simple',
+							[ 'tax_status' => 'none']
+						),
+						'quantity' => 1,
+						'expected_values' => [
+							'product_tax_code' => '99999',
+							'unit_price' => 10,
+							'discount' => 0
+						]
+					],
+				],
+			],
+			'a simple product with tax class' => [
+				[
+					[
+						'product' => TaxJar_Product_Helper::create_product(
+							'simple',
+							[ 'tax_class' => 'clothing-rate-20010']
+						),
+						'quantity' => 1,
+						'expected_values' => [
+							'product_tax_code' => '20010',
+							'unit_price' => 10,
+							'discount' => 0
+						]
+					],
+				],
+			],
+			'a subscription product' => [
+				[
+					[
+						'product' => TaxJar_Product_Helper::create_product(
+							'subscription',
+							[ 'trial_length' => 0 ]
+						),
+						'quantity' => 1,
+						'expected_values' => [
+							'product_tax_code' => '',
+							'unit_price' => 19.99,
+							'discount' => 0
+						]
+					],
+				],
+			],
+			'a subscription product with free trial' => [
+				[
+					[
+						'product' => TaxJar_Product_Helper::create_product( 'subscription' ),
+						'quantity' => 1,
+						'expected_values' => [
+							'product_tax_code' => '',
+							'unit_price' => 0,
+							'discount' => 0
+						]
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provide_cart_data_with_fees
+	 *
+	 * @param array $fees
+	 * @param array $coupons
+	 *
+	 * @throws Exception
+	 */
+	public function test_fee_item( array $fees, array $coupons = []) {
+		$cart_builder = Cart_Builder::a_cart();
+		$cart_builder->with_product( TaxJar_Product_Helper::create_product()->get_id(), 1 );
+		foreach( $fees as $fee ) {
+			$cart_builder->with_fee( $fee );
+		}
+		foreach( $coupons as $coupon ) {
+			$cart_builder->with_coupon( $coupon->get_code() );
+		}
+		$cart = $cart_builder->build();
+		$totals = new WC_Cart_Totals( $cart );
+		$cart_tax_request_body_builder = new Cart_Tax_Request_Body_Builder( $cart );
+
+		$tax_request_body = $cart_tax_request_body_builder->create();
+
+		foreach( $fees as $fee ) {
+			$item = $this->get_fee_item_from_tax_request_body( $tax_request_body, $fee );
+
+			$this->assertEquals( $fee['expected_values']['quantity'], $item['quantity'] );
+			$this->assertEquals( $fee['expected_values']['product_tax_code'], $item['product_tax_code'] );
+			$this->assertEquals( $fee['expected_values']['unit_price'], $item['unit_price'] );
+			$this->assertEquals( $fee['expected_values']['discount'], $item['discount'] );
+		}
+	}
+
+	public function provide_cart_data_with_fees(): array {
+		WC_Tax::create_tax_class( 'clothing-rate-20010' );
+		return [
+			'a taxable fee' => [
+				[
+					[
+						'name' => 'test-fee',
+						'amount' => 10,
+						'taxable' => true,
+						'tax_class' => '',
+						'expected_values' => [
+							'quantity' => 1,
+							'product_tax_code' => '',
+							'unit_price' => 10,
+							'discount' => 0
+						]
+					]
+				]
+			],
+			'a non taxable fee ' => [
+				[
+					[
+						'name' => 'test-fee',
+						'amount' => 10,
+						'taxable' => false,
+						'tax_class' => '',
+						'expected_values' => [
+							'quantity' => 1,
+							'product_tax_code' => '99999',
+							'unit_price' => 10,
+							'discount' => 0
+						]
+					]
+				]
+			],
+			'a fee with ptc ' => [
+				[
+					[
+						'name' => 'test-fee',
+						'amount' => 10,
+						'taxable' => true,
+						'tax_class' => 'clothing-rate-20010',
+						'expected_values' => [
+							'quantity' => 1,
+							'product_tax_code' => '20010',
+							'unit_price' => 10,
+							'discount' => 0
+						]
+					]
+				]
+			],
+			'a fee with coupon applied' => [
+				[
+					[
+						'name' => 'test-fee',
+						'amount' => 10,
+						'taxable' => true,
+						'tax_class' => '',
+						'expected_values' => [
+							'quantity' => 1,
+							'product_tax_code' => '',
+							'unit_price' => 10,
+							'discount' => 0
+						]
+					]
+				],
+				[
+					TaxJar_Coupon_Helper::create_coupon()
+				]
+			]
+		];
+	}
+
+	private function get_fee_item_from_tax_request_body( $tax_request_body, $fee ) {
+		foreach( $tax_request_body->get_line_items() as $item ) {
+			if ( $item['id'] === $fee['name'] ) {
+				return $item;
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
The cart tax calculation portion of the plugin is built in such a way that it often creates conflicts with other plugins, and makes troubleshooting and maintenance difficult. This PR is the first step in resolving this issue. All the changes and fixes regarding the cart calculation process will be merged into and released with a feature branch.

**Specs Passing**

- [X] Woo 5.6
- [X] Woo 5.1
