### PR TITLE
INT 2039 Subscription Support

### DIFF
--- a/includes/TaxCalculation/class-cart-tax-applicator.php
+++ b/includes/TaxCalculation/class-cart-tax-applicator.php
@@ -100,7 +100,7 @@ class Cart_Tax_Applicator extends Tax_Applicator {
 	 * @return array
 	 */
 	private function apply_line_subtotal_tax( $item_key, $item, $applied_rate ): array {
-		$item_subtotal  = wc_add_number_precision( $item['data']->get_price() * $item['quantity'], false );
+		$item_subtotal  = wc_add_number_precision( $item['line_subtotal'], false );
 		$tax_class      = $item['data']->get_tax_class();
 		$subtotal_taxes = $this->tax_builder->build_line_tax_from_rate( $applied_rate, $item_subtotal, $tax_class );
 		$subtotal_tax   = array_sum( array_map( array( $this, 'round_line_tax' ), $subtotal_taxes ) );

--- a/includes/TaxCalculation/class-tax-builder.php
+++ b/includes/TaxCalculation/class-tax-builder.php
@@ -11,7 +11,6 @@ namespace TaxJar;
 
 use Exception;
 use TaxJar_Settings;
-
 use WC_Tax;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -92,6 +92,7 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		require_once $this->tests_dir . '/framework/class-tj-wc-rest-unit-test-case.php';
 		require_once $this->tests_dir . '/framework/class-taxjar-test-order-factory.php';
 		require_once $this->tests_dir . '/framework/cart-builder.php';
+		require_once $this->tests_dir . '/framework/abstract-cart-integration-test.php';
 	}
 
 	public function setup() {

--- a/tests/framework/abstract-cart-integration-test.php
+++ b/tests/framework/abstract-cart-integration-test.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace TaxJar;
+
+use Automattic\Jetpack\Constants;
+use TaxJar\Tests\Framework\Cart_Builder;
+use TaxJar_Coupon_Helper;
+use TaxJar_Product_Helper;
+use TaxJar_Shipping_Helper;
+use WP_UnitTestCase;
+
+abstract class Cart_Integration_Test extends WP_UnitTestCase {
+
+	protected $cart_builder;
+
+	public function setUp() {
+		Constants::set_constant( 'WOOCOMMERCE_CART', true );
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		Constants::clear_single_constant( 'WOOCOMMERCE_CART' );
+		parent::tearDown();
+	}
+
+	protected function create_cart_builder_from_provider_data( $data ) {
+		TaxJar_Shipping_Helper::create_simple_flat_rate( 10 );
+		$this->cart_builder = Cart_Builder::a_cart();
+		$this->add_items_to_cart_builder( $data['items'] );
+		$this->add_coupons_to_cart_builder( $data['coupons'] );
+		$this->add_fees_to_cart_builder( $data['fees'] );
+	}
+
+	protected function add_items_to_cart_builder( $items ) {
+		foreach( $items as $item ) {
+			$product = TaxJar_Product_Helper::create_product( $item['type'], $item['options'] );
+			$this->cart_builder = $this->cart_builder->with_product( $product->get_id(), $item['quantity'] );
+		}
+	}
+
+	protected function add_coupons_to_cart_builder( $coupons ) {
+		foreach( $coupons as $coupon ) {
+			$this->cart_builder = $this->cart_builder->with_coupon( TaxJar_Coupon_Helper::create_coupon( $coupon )->get_code() );
+		}
+	}
+
+	protected function add_fees_to_cart_builder( $fees ) {
+		foreach( $fees as $fee ) {
+			$this->cart_builder = $this->cart_builder->with_fee( $fee['data'] );
+		}
+	}
+
+	protected function assert_cart_has_correct_tax( $cart, $data  ) {
+		$index = 0;
+		foreach( $cart->get_cart() as $cart_item ) {
+			$this->assert_line_item_has_correct_tax( $data['items'][ $index ]['expected_tax'], $cart_item );
+			$index++;
+		}
+
+		foreach( $cart->get_fees() as $fee_key => $fee ) {
+			$this->assert_fee_item_has_correct_tax( $data['fees'][ $fee_key ]['expected_tax'], $fee );
+		}
+
+		$this->assert_cart_has_correct_tax_totals( $cart, $data['expected_cart_totals'] );
+	}
+
+	protected function assert_cart_has_correct_tax_totals( $cart, $expected_totals ) {
+		$this->assertEquals( $expected_totals['tax_subtotal'], $cart->get_subtotal_tax() );
+		$this->assertEquals( $expected_totals['cart_contents_tax'], $cart->get_cart_contents_tax() );
+
+		if ( isset( $cart->get_cart_contents_taxes()[0] ) ) {
+			$this->assertEquals( $expected_totals['cart_contents_tax'], $cart->get_cart_contents_taxes()[0] );
+		}
+
+		$this->assertEquals( $expected_totals['shipping_tax'], $cart->get_shipping_tax() );
+		$shipping_taxes = $cart->get_shipping_taxes();
+		$this->assertEquals( $expected_totals['shipping_tax'], reset( $shipping_taxes ) );
+		$this->assertEquals( $expected_totals['fee_tax'], $cart->get_fee_tax() );
+
+		if ( isset( $cart->get_fee_taxes()[0] ) ) {
+			$fee_taxes = $cart->get_fee_taxes();
+			$this->assertEquals( $expected_totals['fee_tax'], reset( $fee_taxes ) );
+		}
+
+		$this->assertEquals( $expected_totals['total_tax'], $cart->get_total_tax() );
+		$this->assertEquals( $expected_totals['cart_total'], $cart->get_total( 'amount' ) );
+	}
+
+	protected function assert_line_item_has_correct_tax( $given_item_data, $cart_item ) {
+		$this->assertEquals( $given_item_data['tax_subtotal'], $cart_item['line_subtotal_tax'] );
+		$this->assertEquals( $given_item_data['tax_subtotal'], reset( $cart_item['line_tax_data']['subtotal'] ) );
+		$this->assertEquals( $given_item_data['tax_total'], $cart_item['line_tax'] );
+		$this->assertEquals( $given_item_data['tax_total'], reset( $cart_item['line_tax_data']['total'] ) );
+	}
+
+	protected function assert_fee_item_has_correct_tax( $expected_tax, $fee_item ) {
+		$this->assertEquals( $expected_tax, $fee_item->tax );
+		$this->assertEquals( $expected_tax, reset($fee_item->tax_data ) );
+	}
+}

--- a/tests/framework/order-builder.php
+++ b/tests/framework/order-builder.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace TaxJar\Tests\Framework;
+
+use TaxJar_Product_Helper;
+use WC_Order_Item_Fee;
+use WC_Order_Item_Product;
+use WC_Order_Item_Shipping;
+use WC_Shipping_Rate;
+
+class Order_Builder {
+
+	const SIMPLE_PRODUCT = [
+		'type'         => 'simple',
+		'price'        => 100,
+		'quantity'     => 1,
+		'name'         => 'Dummy Product',
+		'sku'          => 'SIMPLE1',
+		'manage_stock' => false,
+		'tax_status'   => 'taxable',
+		'downloadable' => false,
+		'virtual'      => false,
+		'stock_status' => 'instock',
+		'weight'       => '1.1',
+		'tax_class'    => '',
+		'tax_total'    => array( 0 ),
+		'tax_subtotal' => array( 0 ),
+	];
+
+	private $order;
+	private $customer_id = 1;
+	private $products = [];
+	private $fees = [];
+	private $shipping;
+
+	private $shipping_address = [
+		'first_name' => 'Fname',
+		'last_name'  => 'Lname',
+		'address_1'  => 'Shipping Address',
+		'address_2'  => '',
+		'city'       => 'Greenwood Village',
+		'state'      => 'CO',
+		'postcode'   => '80111',
+		'country'    => 'US',
+	];
+
+	private $billing_address = [
+		'first_name' => 'Fname',
+		'last_name'  => 'Lname',
+		'address_1'  => 'Billing Address',
+		'address_2'  => '',
+		'city'       => 'Greenwood Village',
+		'state'      => 'CO',
+		'postcode'   => '80111',
+		'country'    => 'US',
+		'email'      => 'admin@example.org',
+		'phone'      => '111-111-1111',
+	];
+
+	private $totals = [
+		'shipping_total' => 0,
+		'discount_total' => 0,
+		'discount_tax'   => 0,
+		'cart_tax'       => 0,
+		'shipping_tax'   => 0,
+		'total'          => 0,
+	];
+
+	public static function an_order(): Order_Builder {
+		return new static();
+	}
+
+	public function __construct() {
+		$this->order = wc_create_order();
+	}
+
+	public function build(): WC_Order {
+		$this->set_customer_id();
+		$this->set_shipping_address();
+		$this->set_billing_address();
+		$this->add_products();
+		$this->add_fees();
+		$this->add_shipping();
+		$this->set_payment_method();
+		$this->set_totals();
+		$this->order->save();
+		return $this->order;
+	}
+
+	private function set_customer_id() {
+		$this->order->set_customer_id( $this->customer_id );
+	}
+
+	private function set_shipping_address() {
+		$this->order->set_shipping_first_name( $this->shipping_address['first_name'] );
+		$this->order->set_shipping_last_name( $this->shipping_address['last_name'] );
+		$this->order->set_shipping_address_1( $this->shipping_address['address_1'] );
+		$this->order->set_shipping_address_2( $this->shipping_address['address_2'] );
+		$this->order->set_shipping_city( $this->shipping_address['city'] );
+		$this->order->set_shipping_state( $this->shipping_address['state'] );
+		$this->order->set_shipping_postcode( $this->shipping_address['postcode'] );
+		$this->order->set_shipping_country( $this->shipping_address['country'] );
+	}
+
+	private function set_billing_address() {
+		$this->order->set_billing_first_name( $this->billing_address['first_name'] );
+		$this->order->set_billing_last_name(  $this->billing_address['last_name'] );
+		$this->order->set_billing_address_1(  $this->billing_address['address_1'] );
+		$this->order->set_billing_address_2(  $this->billing_address['address_2'] );
+		$this->order->set_billing_city(  $this->billing_address['city'] );
+		$this->order->set_billing_state(  $this->billing_address['state'] );
+		$this->order->set_billing_postcode(  $this->billing_address['postcode'] );
+		$this->order->set_billing_country(  $this->billing_address['country'] );
+		$this->order->set_billing_email(  $this->billing_address['email'] );
+		$this->order->set_billing_phone(  $this->billing_address['phone'] );
+	}
+
+	private function add_products() {
+		foreach( $this->products as $product_details ) {
+			$product = TaxJar_Product_Helper::create_product( $product_details['type'], $product_details );
+			$item    = new WC_Order_Item_Product();
+			$item->set_props(
+				array(
+					'product'  => $product,
+					'quantity' => $product_details['quantity'],
+					'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => $product_details['quantity'] ) ),
+					'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => $product_details['quantity'] ) ),
+				)
+			);
+			$item->set_taxes(
+				array(
+					'total'    => $product_details['tax_total'],
+					'subtotal' => $product_details['tax_subtotal'],
+				)
+			);
+			$item->set_order_id( $this->order->get_id() );
+			$item->save();
+			$this->order->add_item( $item );
+		}
+	}
+
+	public function add_fees() {
+		foreach( $this->fees as $fee_details ) {
+			$fee = new WC_Order_Item_Fee();
+			$fee->set_name( $fee_details['name'] );
+			$fee->set_amount( $fee_details['amount'] );
+			$fee->set_tax_class( $fee_details['tax_class'] );
+			$fee->set_tax_status( $fee_details['tax_status'] );
+			$fee->set_total( $fee_details['amount'] );
+			$this->order->add_item( $fee );
+		}
+	}
+
+	private function add_shipping() {
+		$rate = new WC_Shipping_Rate(
+			$this->shipping['id'],
+			$this->shipping['label'],
+			$this->shipping['cost'],
+			$this->shipping['taxes'],
+			$this->shipping['method_id']
+		);
+
+		$item = new WC_Order_Item_Shipping();
+		$item->set_props(
+			array(
+				'method_title' => $rate->label,
+				'method_id'    => $rate->id,
+				'total'        => wc_format_decimal( $rate->cost ),
+				'taxes'        => $rate->taxes,
+			)
+		);
+
+		foreach ( $rate->get_meta_data() as $key => $value ) {
+			$item->add_meta_data( $key, $value, true );
+		}
+
+		$item->save();
+		$this->order->add_item( $item );
+	}
+
+	private function set_payment_method() {
+		$payment_gateways = WC()->payment_gateways->payment_gateways();
+		$this->order->set_payment_method( $payment_gateways['bacs'] );
+	}
+
+	public function set_totals() {
+		$this->order->set_shipping_total( $this->totals['shipping_total'] );
+		$this->order->set_discount_total( $this->totals['discount_total'] );
+		$this->order->set_discount_tax( $this->totals['discount_tax'] );
+		$this->order->set_cart_tax( $this->totals['cart_tax'] );
+		$this->order->set_shipping_tax( $this->totals['shipping_tax'] );
+		$this->order->set_total( $this->totals['total'] );
+	}
+
+	public function with_customer_id( $customer_id ) {
+		$this->customer_id = $customer_id;
+	}
+
+	public function with_shipping_address( $shipping_address ) {
+		$this->shipping_address = $shipping_address;
+	}
+
+	public function with_billing_address( $billing_address ) {
+		$this->billing_address = $billing_address;
+	}
+
+	public function with_product( $product ) {
+		$this->products[] = $product;
+	}
+
+	public function with_shipping( $shipping ) {
+		$this->shipping = $shipping;
+	}
+
+	public function with_totals( $totals ) {
+		$this->totals = $totals;
+	}
+
+	public function with_fee( $fee ) {
+		$this->fees[] = $fee;
+	}
+}

--- a/tests/integration/test-subscription-cart-tax-calculation.php
+++ b/tests/integration/test-subscription-cart-tax-calculation.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Subscription_Cart_Tax_Calculation extends Cart_Integration_Test {
+
+	/**
+	 * @dataProvider get_subscription_cart_test_data
+	 */
+	public function test_subscription_cart_tax_calculation( $data ) {
+		$this->create_cart_builder_from_provider_data( $data );
+		$cart = $this->cart_builder->build();
+
+		$cart->calculate_totals();
+
+		$this->assert_cart_has_correct_tax( $cart, $data );
+
+		foreach ( $cart->recurring_carts as $recurring_cart ) {
+			$this->assert_cart_has_correct_recurring_tax( $recurring_cart, $data );
+		}
+	}
+
+	public function get_subscription_cart_test_data() {
+		return [
+			'a cart with a simple subscription' => [
+				'cart_data' => [
+					'expected_cart_totals' => [
+						'tax_subtotal' => .73,
+						'cart_contents_tax' => .73,
+						'shipping_tax' => 0.0,
+						'fee_tax' => 0.0,
+						'total_tax' => .73,
+						'cart_total' => 20.73,
+					],
+					'expected_recurring_cart_totals' => [
+						'tax_subtotal' => .73,
+						'cart_contents_tax' => .73,
+						'shipping_tax' => 0.0,
+						'fee_tax' => 0.0,
+						'total_tax' => .73,
+						'cart_total' => 20.73,
+					],
+					'items' => [
+						[
+							'type' => 'subscription',
+							'options' => [
+								'price' => 10,
+								'sign_up_fee' => 0,
+								'trial_length' => 0,
+							],
+							'quantity' => 1,
+							'expected_tax' => [
+								'tax_subtotal' => .73,
+								'tax_total' => .73,
+							],
+							'recurring_expected_tax' => [
+								'tax_subtotal' => .73,
+								'tax_total' => .73,
+							],
+						]
+					],
+					'coupons' => [],
+					'fees' => []
+				]
+			],
+			'a cart with a subscription with sign up fee' => [
+				'cart_data' => [
+					'expected_cart_totals' => [
+						'tax_subtotal' => 1.45,
+						'cart_contents_tax' => 1.45,
+						'shipping_tax' => 0.0,
+						'fee_tax' => 0.0,
+						'total_tax' => 1.45,
+						'cart_total' => 31.45,
+					],
+					'expected_recurring_cart_totals' => [
+						'tax_subtotal' => .73,
+						'cart_contents_tax' => .73,
+						'shipping_tax' => 0.0,
+						'fee_tax' => 0.0,
+						'total_tax' => .73,
+						'cart_total' => 20.73,
+					],
+					'items' => [
+						[
+							'type' => 'subscription',
+							'options' => [
+								'price' => 10,
+								'sign_up_fee' => 10.00,
+								'trial_length' => 0,
+							],
+							'quantity' => 1,
+							'expected_tax' => [
+								'tax_subtotal' => 1.45,
+								'tax_total' => 1.45,
+							],
+							'recurring_expected_tax' => [
+								'tax_subtotal' => .73,
+								'tax_total' => .73,
+							],
+						]
+					],
+					'coupons' => [],
+					'fees' => []
+				]
+			],
+			'a cart with a subscription with a free trial' => [
+				'cart_data' => [
+					'expected_cart_totals' => [
+						'tax_subtotal' => 0.0,
+						'cart_contents_tax' => 0.0,
+						'shipping_tax' => 0.0,
+						'fee_tax' => 0.0,
+						'total_tax' => 0.0,
+						'cart_total' => 0.0,
+					],
+					'expected_recurring_cart_totals' => [
+						'tax_subtotal' => .73,
+						'cart_contents_tax' => .73,
+						'shipping_tax' => 0.0,
+						'fee_tax' => 0.0,
+						'total_tax' => .73,
+						'cart_total' => 20.73,
+					],
+					'items' => [
+						[
+							'type' => 'subscription',
+							'options' => [
+								'price' => 10,
+								'sign_up_fee' => 0.0,
+								'trial_length' => 1,
+							],
+							'quantity' => 1,
+							'expected_tax' => [
+								'tax_subtotal' => 0.0,
+								'tax_total' => 0.0,
+							],
+							'recurring_expected_tax' => [
+								'tax_subtotal' => .73,
+								'tax_total' => .73,
+							],
+						]
+					],
+					'coupons' => [],
+					'fees' => []
+				]
+			],
+			'a cart with a subscription with a free trial and sign up fee' => [
+				'cart_data' => [
+					'expected_cart_totals' => [
+						'tax_subtotal' => 0.73,
+						'cart_contents_tax' => 0.73,
+						'shipping_tax' => 0.0,
+						'fee_tax' => 0.0,
+						'total_tax' => 0.73,
+						'cart_total' => 10.73,
+					],
+					'expected_recurring_cart_totals' => [
+						'tax_subtotal' => 0.73,
+						'cart_contents_tax' => 0.73,
+						'shipping_tax' => 0.0,
+						'fee_tax' => 0.0,
+						'total_tax' => 0.73,
+						'cart_total' => 20.73,
+					],
+					'items' => [
+						[
+							'type' => 'subscription',
+							'options' => [
+								'price' => 10,
+								'sign_up_fee' => 10.0,
+								'trial_length' => 1,
+							],
+							'quantity' => 1,
+							'expected_tax' => [
+								'tax_subtotal' => 0.73,
+								'tax_total' => 0.73,
+							],
+							'recurring_expected_tax' => [
+								'tax_subtotal' => 0.73,
+								'tax_total' => 0.73,
+							],
+						]
+					],
+					'coupons' => [],
+					'fees' => []
+				]
+			],
+		];
+	}
+
+	private function assert_cart_has_correct_recurring_tax( $cart, $data  ) {
+		$index = 0;
+		foreach( $cart->get_cart() as $cart_item ) {
+			$this->assert_line_item_has_correct_tax( $data['items'][ $index ]['recurring_expected_tax'], $cart_item );
+			$index++;
+		}
+
+		foreach( $cart->get_fees() as $fee_key => $fee ) {
+			$this->assert_fee_item_has_correct_tax( $data['fees'][ $fee_key ]['recurring_expected_tax'], $fee );
+		}
+
+		$this->assert_cart_has_correct_tax_totals( $cart, $data['expected_recurring_cart_totals'] );
+	}
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -10,6 +10,7 @@
   <testsuites>
     <testsuite name="taxjar">
       <directory prefix="test-" suffix=".php">./specs/</directory>
+      <directory prefix="test-" suffix=".php">./integration/</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/specs/test-subscriptions.php
+++ b/tests/specs/test-subscriptions.php
@@ -444,8 +444,6 @@ class TJ_WC_Test_Subscriptions extends WP_HTTP_TestCase {
 			WC()->cart->cart_contents[ $cart_item_key ]['line_subtotal'] = 19.99;
 		}
 
-		WC_Subscriptions_Cart::set_calculation_type( 'recurring_total' );
-
 		foreach ( WC()->cart->recurring_carts as $recurring_cart ) {
 			$this->assertEquals( $recurring_cart->tax_total, 0, '', 0.01 );
 			$this->assertEquals( $recurring_cart->get_taxes_total(), 0, '', 0.01 );


### PR DESCRIPTION
This PR adds integration tests confirming the compatibility of the new cart calculation functionality with WooCommerce Subscriptions. It also fixes a minor issue where a subscription product was not having tax calculated on the correct price.

