### PR TITLE
Fix dynamic tax code issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1 (2021-11-19)
+* Change dynamic tax rate ID to 999999999 to help prevent issues with 3rd parties ingesting exported WooCommerce order data
+* Fix issue where shipping was still utilizing dynamic tax rate when the save rates setting was enabled.
+
 # 4.0.0 (2021-11-11)
 * Refactor cart tax calculation to stop calculation events from triggering twice
 * Fix issue with tax calculation on dynamically created products and variations

--- a/includes/TaxCalculation/class-tax-builder.php
+++ b/includes/TaxCalculation/class-tax-builder.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Tax_Builder {
 
-	const TAX_RATE_ID = 999999999999999;
+	const TAX_RATE_ID = 999999999;
 
 	/**
 	 * Determines whether to create a WooCommerce tax rate during tax calculation.
@@ -185,7 +185,7 @@ class Tax_Builder {
 				$woo_rate = $this->create_woocommerce_rate( $applied_rate * 100 );
 				$wc_rate  = $this->build_woocommerce_rate( $applied_rate * 100, $woo_rate['id'] );
 			} else {
-				$wc_rate = $this->build_woocommerce_rate( $applied_rate * 100 );
+				$wc_rate = [];
 			}
 		} else {
 			$wc_rate = $this->build_woocommerce_rate( $applied_rate * 100 );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 5.4
 Tested up to: 5.8.2
-Stable tag: 4.0.0
+Stable tag: 4.0.1
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 5.4.0
@@ -94,6 +94,10 @@ Our plans come with filings included, with additional filings available for purc
 3. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 4.0.1 (2021-11-19)
+* Change dynamic tax rate ID to 999999999 to help prevent issues with 3rd parties ingesting exported WooCommerce order data
+* Fix issue where shipping was still utilizing dynamic tax rate when the save rates setting was enabled.
 
 = 4.0.0 (2021-11-11)
 * Refactor cart tax calculation to stop calculation events from triggering twice

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 4.0.0
+ * Version: 4.0.1
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 5.4.0
@@ -43,7 +43,7 @@ if ( ! $woocommerce_active || version_compare( get_option( 'woocommerce_db_versi
  */
 final class WC_Taxjar {
 
-	static $version = '4.0.0';
+	static $version = '4.0.1';
 	public static $minimum_woocommerce_version = '5.4.0';
 
 	/**


### PR DESCRIPTION
When save tax rates is enabled, the plugin should create a rate when applying tax to line items, fees, shipping, etc. It should not use the dynamic rate (which should only be used when the save rates setting is disabled). However there was an issue where the dynamic rate was still being applied when shipping wasn't taxable. It was still applying and calculating the correct amount of tax but was assigning the shipping item tax the dynamic rate ID.

This has been resolved. When shipping is not taxable, no tax rate will be applied to the shipping item. This brings the plugin inline with the WooCommerce native functionality.

Additionally in some stores, integrations were unable to handle the dynamic rate ID (999999999999999). This was due to them attempting to parse the ID as a int instead of a bigint (which is what the rate ID column in the database is stored as). In order to address this we have changed the dynamic rate ID to 999999999, which should be parseable as an integer and still should not conflict with any existing rate IDs.

**Steps to Reproduce**

1. Enable TaxJar tax calculations and the save rates setting
2. Place an order on the cart with shipping that is to an area where shipping is not taxable
3. After the order is placed, check the order item meta table for items of the order. For the shipping item the entry with the meta key of taxes should be a:1:{s:5:"total";a:1:{i:999999999999999;s:1:"0";}} This is a serialize array storing that the rate with ID 999999999999999 applied $0 total tax.

**Expected Result**

After applying the PR, in step 3 the serialize data will now be a:1:{s:5:"total";a:0:{}}. This indicates that no tax rate was applied to the shipping and is the correct handling of non taxable shipping.

**Click-Test Versions**

- [X] Woo 5.9
- [X] Woo 5.4

**Specs Passing**

- [X] Woo 5.9
- [X] Woo 5.4
