### PR TITLE
Save Calculation Results to Cart and Order

### DIFF
--- a/includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php
+++ b/includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Cart Tax Calculation Result Data Store
+ *
+ * Persists tax calculation result to cart.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Cart_Tax_Calculation_Result_Data_Store
+ */
+class Cart_Tax_Calculation_Result_Data_Store implements Tax_Calculation_Result_Data_Store {
+
+	/**
+	 * Cart to persist result on
+	 *
+	 * @var \WC_Cart
+	 */
+	private $cart;
+
+	/**
+	 * Cart_Tax_Calculation_Result_Data_Store Constructor
+	 *
+	 * @param \WC_Cart $cart Cart to persist results on.
+	 */
+	public function __construct( \WC_Cart $cart ) {
+		$this->cart = $cart;
+	}
+
+	/**
+	 * Persist results on the cart
+	 *
+	 * @param Tax_Calculation_Result $calculation_result Result of tax calculation.
+	 */
+	public function update( Tax_Calculation_Result $calculation_result ) {
+		$this->cart->tax_calculation_results = $calculation_result->to_json();
+	}
+
+}

--- a/includes/TaxCalculation/class-order-tax-calculation-result-data-store.php
+++ b/includes/TaxCalculation/class-order-tax-calculation-result-data-store.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Order Tax Calculation Result Data Store
+ *
+ * Persists tax calculation result to order.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Order_Tax_Calculation_Result_Data_Store
+ */
+class Order_Tax_Calculation_Result_Data_Store implements Tax_Calculation_Result_Data_Store {
+
+	/**
+	 * Order to persist result on
+	 *
+	 * @var \WC_Order
+	 */
+	private $order;
+
+	/**
+	 * Order_Tax_Calculation_Result_Data_Store Constructor
+	 *
+	 * @param \WC_Order $order Order to persist results on.
+	 */
+	public function __construct( \WC_Order $order ) {
+		$this->order = $order;
+	}
+
+	/**
+	 * Persist results on the order
+	 *
+	 * @param Tax_Calculation_Result $calculation_result Result of tax calculation.
+	 */
+	public function update( Tax_Calculation_Result $calculation_result ) {
+		$this->order->update_meta_data( '_taxjar_tax_result', $calculation_result->to_json() );
+	}
+
+}

--- a/includes/TaxCalculation/class-tax-calculator-builder.php
+++ b/includes/TaxCalculation/class-tax-calculator-builder.php
@@ -8,6 +8,7 @@
 namespace TaxJar;
 
 use WC_Cart;
+use WC_Order;
 use WC_Taxjar_Nexus;
 use TaxJar_Settings;
 
@@ -101,6 +102,7 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $order );
 		$this->set_order_validator( $order );
 		$this->set_context( 'api_order' );
+		$this->set_order_tax_result_data_store( $order );
 	}
 
 	/**
@@ -114,6 +116,7 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $order );
 		$this->set_order_validator( $order );
 		$this->set_context( 'order' );
+		$this->set_order_tax_result_data_store( $order );
 	}
 
 	/**
@@ -270,6 +273,7 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $order );
 		$this->set_order_validator( $order );
 		$this->set_context( 'admin_order' );
+		$this->set_order_tax_result_data_store( $order );
 	}
 
 	/**
@@ -294,6 +298,7 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $subscription );
 		$this->set_order_validator( $subscription );
 		$this->set_context( 'subscription_order' );
+		$this->set_order_tax_result_data_store( $subscription );
 		return $this->calculator;
 	}
 
@@ -310,7 +315,18 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $renewal );
 		$this->set_order_validator( $renewal );
 		$this->set_context( 'renewal_order' );
+		$this->set_order_tax_result_data_store( $renewal );
 		return $this->calculator;
+	}
+
+	/**
+	 * Set the tax result data store when building an order calculator.
+	 *
+	 * @param WC_Order $order Order whose tax is being calculated.
+	 */
+	private function set_order_tax_result_data_store( WC_Order $order ) {
+		$result_data_store = new Order_Tax_Calculation_Result_Data_Store( $order );
+		$this->calculator->set_result_data_store( $result_data_store );
 	}
 
 	/**
@@ -326,7 +342,18 @@ class Tax_Calculator_Builder {
 		$this->set_cart_tax_applicator( $cart );
 		$this->set_cart_validator( $cart );
 		$this->set_context( 'cart' );
+		$this->set_cart_tax_result_data_store( $cart );
 		return $this->calculator;
+	}
+
+	/**
+	 * Set the tax result data store when building a cart calculator.
+	 *
+	 * @param WC_Cart $cart Cart whose tax is being calculated.
+	 */
+	private function set_cart_tax_result_data_store( WC_Cart $cart ) {
+		$result_data_store = new Cart_Tax_Calculation_Result_Data_Store( $cart );
+		$this->calculator->set_result_data_store( $result_data_store );
 	}
 
 	/**

--- a/includes/class-taxjar-tax-calculation.php
+++ b/includes/class-taxjar-tax-calculation.php
@@ -39,7 +39,7 @@ class TaxJar_Tax_Calculation {
 
 		add_action( 'woocommerce_order_after_calculate_totals', array( $this, 'maybe_calculate_order_taxes' ), 10, 2 );
 		add_action( 'woocommerce_checkout_create_order', array( $this, 'persist_cart_calculation_results_to_order'), 10, 1 );
-		add_action( 'woocommerce_checkout_subscription_created', array( $this, 'persist_recurring_cart_calculation_results_to_subscription'), 10, 3 );
+		add_action( 'woocommerce_checkout_create_subscription', array( $this, 'persist_recurring_cart_calculation_results_to_subscription'), 10, 4 );
 	}
 
 	public function persist_cart_calculation_results_to_order( $order ) {
@@ -47,7 +47,7 @@ class TaxJar_Tax_Calculation {
 		$order->update_meta_data( '_taxjar_tax_result', $calculation_results );
 	}
 
-	public function persist_recurring_cart_calculation_results_to_subscription( $subscription, $order, $recurring_cart ) {
+	public function persist_recurring_cart_calculation_results_to_subscription(  $subscription, $posted_data, $order, $recurring_cart ) {
 		$calculation_results = $recurring_cart->tax_calculation_results;
 		$subscription->update_meta_data( '_taxjar_tax_result', $calculation_results );
 	}

--- a/includes/class-taxjar-tax-calculation.php
+++ b/includes/class-taxjar-tax-calculation.php
@@ -38,6 +38,18 @@ class TaxJar_Tax_Calculation {
 		add_filter( 'wcs_new_order_created', array( $this, 'calculate_renewal_order_totals' ), 10, 3 );
 
 		add_action( 'woocommerce_order_after_calculate_totals', array( $this, 'maybe_calculate_order_taxes' ), 10, 2 );
+		add_action( 'woocommerce_checkout_create_order', array( $this, 'persist_cart_calculation_results_to_order'), 10, 1 );
+		add_action( 'woocommerce_checkout_subscription_created', array( $this, 'persist_recurring_cart_calculation_results_to_subscription'), 10, 3 );
+	}
+
+	public function persist_cart_calculation_results_to_order( $order ) {
+		$calculation_results = WC()->cart->tax_calculation_results;
+		$order->update_meta_data( '_taxjar_tax_result', $calculation_results );
+	}
+
+	public function persist_recurring_cart_calculation_results_to_subscription( $subscription, $order, $recurring_cart ) {
+		$calculation_results = $recurring_cart->tax_calculation_results;
+		$subscription->update_meta_data( '_taxjar_tax_result', $calculation_results );
 	}
 
 	public function maybe_calculate_order_taxes( $and_taxes, $order ) {

--- a/includes/interfaces/class-tax-calculation-result-data-store.php
+++ b/includes/interfaces/class-tax-calculation-result-data-store.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Tax Calculation Result Data Store Interface
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+interface Tax_Calculation_Result_Data_Store {
+
+	/**
+	 * Persists calculation result on object.
+	 *
+	 * @param Tax_Calculation_Result $calculation_result Calculation result.
+	 *
+	 * @return void
+	 */
+	public function update( Tax_Calculation_Result $calculation_result );
+
+}

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -68,6 +68,7 @@ final class WC_Taxjar {
 			include_once 'includes/interfaces/class-tax-client-interface.php';
 			include_once 'includes/interfaces/class-tax-applicator-interface.php';
 			include_once 'includes/interfaces/class-tax-calculation-validator-interface.php';
+			include_once 'includes/interfaces/class-tax-calculation-result-data-store.php';
 
 			// Include our integration class and WP_User for wp_delete_user()
 			include_once ABSPATH . 'wp-admin/includes/user.php';
@@ -114,6 +115,8 @@ final class WC_Taxjar {
 			include_once 'includes/TaxCalculation/class-tax-calculation-result.php';
 			include_once 'includes/TaxCalculation/class-cart-calculation-logger.php';
 			include_once 'includes/TaxCalculation/class-tax-builder.php';
+			include_once 'includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php';
+			include_once 'includes/TaxCalculation/class-order-tax-calculation-result-data-store.php';
 
 			// Register the integration.
 			add_action( 'woocommerce_integrations_init', array( $this, 'add_integration' ), 20 );

--- a/tests/specs/tax-calculation/test-cart-tax-result-data-store.php
+++ b/tests/specs/tax-calculation/test-cart-tax-result-data-store.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TaxJar;
+
+use WP_UnitTestCase;
+
+class Test_Cart_Tax_Result_Data_Store extends WP_UnitTestCase {
+
+	public function tearDown() {
+		WC()->cart->empty_cart();
+		unset( WC()->cart->tax_calculation_results );
+		parent::tearDown();
+	}
+
+	function test_result_is_stored_on_cart() {
+		$test_json = 'test';
+		$cart = WC()->cart;
+		$result_stub = $this->createMock( Tax_Calculation_Result::class );
+		$result_stub->method( 'to_json' )->willReturn( $test_json );
+		$cart_result_data_store = new Cart_Tax_Calculation_Result_Data_Store( $cart );
+
+		$cart_result_data_store->update( $result_stub );
+
+		$this->assertEquals( $test_json, $cart->tax_calculation_results );
+	}
+}

--- a/tests/specs/tax-calculation/test-order-tax-calculator.php
+++ b/tests/specs/tax-calculation/test-order-tax-calculator.php
@@ -17,6 +17,7 @@ class Test_Order_Tax_Calculator extends WP_UnitTestCase {
 	private $mock_tax_details;
 	private $mock_order;
 	private $mock_validator;
+	private $mock_tax_result_data_store;
 
 	public function setUp() {
 		$this->mock_request_body = $this->createMock( Tax_Request_Body::class );
@@ -33,6 +34,7 @@ class Test_Order_Tax_Calculator extends WP_UnitTestCase {
 		$this->mock_logger     = $this->createMock( Tax_Calculation_Logger::class );
 		$this->mock_cache      = $this->createMock( Cache_Interface::class );
 		$this->mock_applicator = $this->createMock( Tax_Applicator_Interface::class );
+		$this->mock_tax_result_data_store = $this->createMock( Order_Tax_Calculation_Result_Data_Store::class );
 		$this->mock_order      = $this->createMock( WC_Order::class );
 
 		$this->mock_validator = $this->createMock( Tax_Calculation_Validator_Interface::class );
@@ -63,6 +65,7 @@ class Test_Order_Tax_Calculator extends WP_UnitTestCase {
 		$calculator->set_applicator( $this->mock_applicator );
 		$calculator->set_validator( $this->mock_validator );
 		$calculator->set_context( 'test' );
+		$calculator->set_result_data_store( $this->mock_tax_result_data_store );
 		return $calculator;
 	}
 }

--- a/tests/specs/tax-calculation/test-order-tax-result-data-store.php
+++ b/tests/specs/tax-calculation/test-order-tax-result-data-store.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TaxJar;
+
+use WP_UnitTestCase;
+
+class Test_Order_Tax_Result_Data_Store extends WP_UnitTestCase {
+
+	function test_result_is_stored_on_cart() {
+		$test_json = 'test';
+		$order = new \WC_Order();
+		$result_stub = $this->createMock( Tax_Calculation_Result::class );
+		$result_stub->method( 'to_json' )->willReturn( $test_json );
+		$cart_result_data_store = new Order_Tax_Calculation_Result_Data_Store( $order );
+
+		$cart_result_data_store->update( $result_stub );
+
+		$this->assertEquals( $test_json, $order->get_meta( '_taxjar_tax_result' ) );
+	}
+}


### PR DESCRIPTION
In order to allow merchants to have more visibility into if and when TaxJar calculated tax on a cart/order and why we may not have calculated tax (for instance no nexus, etc.) we want to surface the tax calculation results to the order page in WooCommerce admin. This PR represents the first step to accomplish that.

This PR stores a JSON representation of the calculation results on the cart during the checkout process (and on recurring carts as well). When an order is created from a cart or a subscription is created from a recurring cart during checkout the JSON representation is then saved to the order/subscription as meta data.

**Click-Test Versions**

- [X] Woo 5.9

**Specs Passing**

- [X] Woo 5.9

