### PR TITLE
Admin Order Meta Box

### DIFF
--- a/includes/admin/class-admin-meta-boxes.php
+++ b/includes/admin/class-admin-meta-boxes.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Admin Meta Boxes
+ *
+ * Adds meta box to order type posts.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Admin_Meta_Boxes
+ */
+class Admin_Meta_Boxes {
+
+	/**
+	 * Admin_Meta_Boxes Constructor.
+	 */
+	public function __construct() {
+		add_action( 'add_meta_boxes', array( $this, 'add_order_meta_box' ), 30 );
+	}
+
+	/**
+	 * Add meta box to order post types.
+	 */
+	public function add_order_meta_box() {
+		foreach ( wc_get_order_types( 'order-meta-boxes' ) as $type ) {
+			add_meta_box(
+				'taxjar',
+				__( 'TaxJar', 'taxjar' ),
+				'\TaxJar\Order_Meta_Box::output',
+				$type,
+				'normal',
+				'low'
+			);
+		}
+	}
+}

--- a/includes/admin/class-order-meta-box.php
+++ b/includes/admin/class-order-meta-box.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Order Meta Box
+ *
+ * Outputs the contents of the meta box containing TaxJar calculation and sync metadata.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Order_Meta_Box
+ */
+class Order_Meta_Box {
+
+	/**
+	 * Output meta box contents.
+	 *
+	 * @param mixed $post WP Post.
+	 */
+	public static function output( $post ) {
+		$order_id = $post->ID;
+		$order    = wc_get_order( $order_id );
+		$metadata = self::get_taxjar_order_metadata( $order );
+		wp_enqueue_script( 'accordion' );
+
+		include_once dirname( __FILE__ ) . '/views/html-order-meta-box.php';
+	}
+
+	/**
+	 * Get the metadata to display in the meta box.
+	 *
+	 * @param \WC_Order $order Order object.
+	 *
+	 * @return array
+	 */
+	private static function get_taxjar_order_metadata( \WC_Order $order ): array {
+		$metadata                = array();
+		$raw_calculation_result  = $order->get_meta( '_taxjar_tax_result' );
+		$metadata['sync_status'] = self::get_last_sync_status( $order );
+
+		if ( ! empty( $raw_calculation_result ) ) {
+			$result                                     = Tax_Calculation_Result::from_json_string( $raw_calculation_result );
+			$metadata['calculation_status']             = self::get_calculation_status( $result );
+			$metadata['calculation_status_description'] = self::get_calculation_status_description( $result );
+			$metadata['request_json']                   = self::get_request_json( $result );
+			$metadata['response_json']                  = self::get_response_json( $result );
+		} else {
+			$metadata['calculation_status']             = 'unknown';
+			$metadata['calculation_status_description'] = 'No TaxJar calculation data is present on the order. This may indicate that TaxJar was not enabled when this order was placed, that tax calculation has not yet occurred (if creating the order manually through admin) or that the tax was calculated prior to TaxJar version 4.1.0 which introduced this status feature.';
+			$metadata['request_json']                   = '';
+			$metadata['response_json']                  = '';
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Get the calculation status of the result.
+	 *
+	 * @param Tax_Calculation_Result $result Tax calculation result.
+	 *
+	 * @return string
+	 */
+	private static function get_calculation_status( Tax_Calculation_Result $result ): string {
+		if ( $result->get_success() ) {
+			return 'success';
+		} else {
+			return 'fail';
+		}
+	}
+
+	/**
+	 * Get the calculation status description.
+	 *
+	 * @param Tax_Calculation_Result $result Tax calculation result.
+	 *
+	 * @return string
+	 */
+	private static function get_calculation_status_description( Tax_Calculation_Result $result ): string {
+		if ( $result->get_success() ) {
+			return 'Tax was calculated in realtime through the TaxJar API.';
+		} else {
+			return 'TaxJar did not or was unable to perform a tax calculation on this order.<br>Reason: ' . $result->get_error_message();
+		}
+	}
+
+	/**
+	 * Get the calculation request JSON string.
+	 *
+	 * @param Tax_Calculation_Result $result Tax calculation result.
+	 *
+	 * @return false|string
+	 */
+	private static function get_request_json( Tax_Calculation_Result $result ) {
+		$request_json = '';
+
+		if ( ! empty( $result->get_raw_request() ) ) {
+			$request_json = wp_json_encode( json_decode( $result->get_raw_request() ), JSON_PRETTY_PRINT );
+		}
+
+		return $request_json;
+	}
+
+	/**
+	 * Get the calculation response JSON string.
+	 *
+	 * @param Tax_Calculation_Result $result Tax calculation result.
+	 *
+	 * @return false|string
+	 */
+	private static function get_response_json( Tax_Calculation_Result $result ) {
+		$response_json = '';
+
+		if ( ! empty( $result->get_raw_response() ) ) {
+			$response = json_decode( $result->get_raw_response() );
+
+			if ( ! empty( $response->body ) ) {
+				$response->body = json_decode( $response->body );
+			}
+
+			$response_json = wp_json_encode( $response, JSON_PRETTY_PRINT );
+		}
+
+		return $response_json;
+	}
+
+	/**
+	 * Get the sync status of the order.
+	 *
+	 * @param \WC_Order $order Order object.
+	 *
+	 * @return string
+	 */
+	private static function get_last_sync_status( \WC_Order $order ): string {
+		if ( is_a( $order, 'WC_Subscription' ) ) {
+			return 'Subscriptions are not synced to TaxJar. Each order created from the subscription must be individually synced.';
+		}
+
+		$last_sync_timestamp = $order->get_meta( '_taxjar_last_sync' );
+		if ( ! empty( $last_sync_timestamp ) ) {
+			$sync_date = wp_date( wc_date_format(), wc_string_to_timestamp( $last_sync_timestamp ) );
+			$sync_time = wp_date( wc_time_format(), wc_string_to_timestamp( $last_sync_timestamp ) );
+			return 'Last Synced on: ' . $sync_date . ' ' . $sync_time;
+		} else {
+			return 'Order has not been synced to TaxJar.';
+		}
+	}
+}

--- a/includes/admin/views/html-order-meta-box.php
+++ b/includes/admin/views/html-order-meta-box.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Display the TaxJar calculation and sync data on a subscription or order.
+ *
+ * @var array $metadata Array of the TaxJar order metadata.
+ * @var \WC_Order $order Order object.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+?>
+
+<div id="taxjar_order_data" class="panel-wrap">
+	<div class="wc-tabs-back"></div>
+	<ul class="taxjar_order_data_tabs wc-tabs" style="display:none;">
+
+		<?php
+		$order_tabs = apply_filters(
+			'taxjar_order_data_tabs',
+			array(
+				'calculation_status' => array(
+					'label'  => __( 'Calculation Status', 'taxjar' ),
+					'target' => 'calculation_status_order_data',
+					'class'  => '',
+				),
+				'sync_status'        => array(
+					'label'  => __( 'Sync Status', 'taxjar' ),
+					'target' => 'sync_status_order_data',
+					'class'  => '',
+				),
+				'advanced'           => array(
+					'label'  => __( 'Advanced', 'taxjar' ),
+					'target' => 'advanced_order_data',
+					'class'  => '',
+				),
+			)
+		);
+
+		foreach ( $order_tabs as $key => $order_tab ) :
+			?>
+			<li class="<?php echo esc_html( $key ); ?>_options <?php echo esc_html( $key ); ?>_tab <?php echo esc_html( implode( ' ', (array) $order_tab['class'] ) ); ?>">
+				<a href="#<?php echo esc_html( $order_tab['target'] ); ?>">
+					<span><?php echo esc_html( $order_tab['label'] ); ?></span>
+				</a>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+	<div id="calculation_status_order_data" class="panel woocommerce_options_panel">
+		<p class="form-field">
+			<label >Calculation Status: <span class="calculation-status-icon <?php echo esc_html( $metadata['calculation_status'] ); ?>"></span></label>
+			<span class="description"><?php echo wp_kses( $metadata['calculation_status_description'], array( 'br' => array() ) ); ?></span>
+		</p>
+		<?php do_action( 'taxjar_calculation_status_order_data_panel', $order->get_id(), $order ); ?>
+	</div>
+	<div id="sync_status_order_data" class="panel woocommerce_options_panel">
+		<p><?php echo esc_html( $metadata['sync_status'] ); ?></p>
+		<?php do_action( 'taxjar_sync_status_order_data_panel', $order->get_id(), $order ); ?>
+	</div>
+	<div id="advanced_order_data" class="panel woocommerce_options_panel">
+		<div class="accordion-container">
+			<div class="accordion-section request-json">
+				<h3 class="accordion-section-title">Calculation Request JSON <span class="copy-button dashicons dashicons-clipboard"></span></h3>
+				<div class="accordion-section-content">
+					<pre><?php echo esc_html( $metadata['request_json'] ); ?></pre>
+				</div>
+			</div>
+			<div class="accordion-section response-json">
+				<h3 class="accordion-section-title">Calculation Response JSON <span class="copy-button dashicons dashicons-clipboard"></span></h3>
+				<div class="accordion-section-content">
+					<pre><?php echo esc_html( $metadata['response_json'] ); ?></pre>
+				</div>
+			</div>
+			<?php do_action( 'taxjar_advanced_order_data_panel_accordion', $order->get_id(), $order ); ?>
+		</div>
+		<?php do_action( 'taxjar_advanced_order_data_panel', $order->get_id(), $order ); ?>
+	</div>
+	<?php do_action( 'taxjar_order_data_panels', $order->get_id(), $order ); ?>
+	<div class="clear"></div>
+</div>

--- a/includes/admin/views/html-order-meta-box.php
+++ b/includes/admin/views/html-order-meta-box.php
@@ -65,13 +65,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div id="advanced_order_data" class="panel woocommerce_options_panel">
 		<div class="accordion-container">
 			<div class="accordion-section request-json">
-				<h3 class="accordion-section-title">Calculation Request JSON <span class="copy-button dashicons dashicons-clipboard"></span></h3>
+				<h3 class="accordion-section-title">Calculation Request JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
 				<div class="accordion-section-content">
 					<pre><?php echo esc_html( $metadata['request_json'] ); ?></pre>
 				</div>
 			</div>
 			<div class="accordion-section response-json">
-				<h3 class="accordion-section-title">Calculation Response JSON <span class="copy-button dashicons dashicons-clipboard"></span></h3>
+				<h3 class="accordion-section-title">Calculation Response JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
 				<div class="accordion-section-content">
 					<pre><?php echo esc_html( $metadata['response_json'] ); ?></pre>
 				</div>

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 			TaxJar_Settings::init();
 			$this->tax_calculations = new TaxJar_Tax_Calculation();
 
-			if ( $this->on_settings_page() ) {
+			if ( is_admin() ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_assets' ) );
 			}
 
@@ -53,6 +53,8 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 				// Scripts / Stylesheets
 				add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_new_order_assets' ) );
 			}
+
+			new \TaxJar\Admin_Meta_Boxes();
 		}
 
 		/**
@@ -215,15 +217,6 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		private function is_order_post_type( $post_type ) {
 			$allowed_post_types = array( 'shop_order', 'shop_subscription' );
 			return in_array( $post_type, $allowed_post_types, true );
-		}
-
-		/**
-		 * Checks if currently on the TaxJar settings page
-		 *
-		 * @return boolean
-		 */
-		public function on_settings_page() {
-			return ( isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'taxjar-integration' === $_GET['tab'] );
 		}
 
 		/**

--- a/includes/css/admin.css
+++ b/includes/css/admin.css
@@ -1,17 +1,3 @@
-/* Remove Calculate Taxes button */
-#poststuff #woocommerce-order-totals .buttons .calc_line_taxes {
-	display: none !important;
-}
-
-/* Remove Add Tax Row Button */
-.add_total_row {
-	display: none !important;
-}
-
-.add-order-tax {
-	display: none !important;
-}
-
 .widefat .column-taxjar_actions a.button {
 	display: block;
 	text-indent: -9999px;
@@ -90,4 +76,144 @@ div.taxjar-connected p {
 
 .woocommerce table.form-table th label[for="woocommerce_taxjar-integration_settings[api_token]"] {
 	display: none;
+}
+
+#taxjar_order_data.panel-wrap {
+	overflow: hidden;
+}
+
+#taxjar_order_data ul.wc-tabs {
+	margin: 0;
+	width: 20%;
+	float: left;
+	line-height: 1em;
+	padding: 0 0 10px;
+	position: relative;
+	background-color: #fafafa;
+	border-right: 1px solid #eee;
+	box-sizing: border-box;
+}
+
+#taxjar_order_data ul.wc-tabs li {
+	margin: 0;
+	padding: 0;
+	display: block;
+	position: relative;
+}
+
+#taxjar_order_data ul.wc-tabs li a {
+	margin: 0;
+	padding: 10px;
+	display: block;
+	box-shadow: none;
+	text-decoration: none;
+	line-height: 20px!important;
+	border-bottom: 1px solid #eee;
+}
+
+#taxjar_order_data ul.wc-tabs li.active a {
+	color: #555;
+	position: relative;
+	background-color: #eee;
+}
+
+#taxjar_order_data ul.wc-tabs li a::before {
+	font-family: Dashicons;
+	speak: never;
+	font-weight: 400;
+	font-variant: normal;
+	text-transform: none;
+	line-height: 1;
+	-webkit-font-smoothing: antialiased;
+	content: "";
+	text-decoration: none;
+}
+
+#taxjar_order_data .wc-metaboxes-wrapper, #taxjar_order_data .woocommerce_options_panel {
+	float: left;
+	width: 80%;
+}
+
+#taxjar.postbox .inside {
+	margin: 0;
+	padding: 0;
+}
+
+#taxjar_order_data ul.wc-tabs li.calculation_status_tab a::before, #taxjar_order_data ul.wc-tabs li.sync_status_tab a::before {
+	content: "\f226";
+}
+
+#taxjar_order_data ul.wc-tabs li.advanced_tab a::before {
+	content: "\f111";
+}
+
+#taxjar_order_data ul.wc-tabs li a span {
+	margin-left: 0.618em;
+	margin-right: 0.618em;
+}
+
+#taxjar_order_data ul.wc-tabs::after {
+	content: "";
+	display: block;
+	width: 100%;
+	height: 9999em;
+	position: absolute;
+	bottom: -9999em;
+	left: 0;
+	background-color: #fafafa;
+	border-right: 1px solid #eee;
+}
+
+#calculation_status_order_data label span.calculation-status-icon::before {
+	font-family: Dashicons;
+	speak: never;
+	font-weight: 400;
+	font-variant: normal;
+	text-transform: none;
+	line-height: 1;
+	-webkit-font-smoothing: antialiased;
+	content: "";
+	text-decoration: none;
+}
+
+#calculation_status_order_data label span.calculation-status-icon.success::before {
+	content: "\f159";
+	color: #5b841b;
+	background-color: #5b841b;
+	border-radius: 50%;
+}
+
+#calculation_status_order_data label span.calculation-status-icon.fail::before {
+	content: "\f153";
+	color: #d63638;
+}
+
+#calculation_status_order_data label span.calculation-status-icon.unknown::before {
+	content: "\f348";
+	color: #dba617;
+}
+
+#advanced_order_data pre {
+	margin: 0 0 9px;
+	font-size: 12px;
+	padding: 5px 9px;
+	line-height: 24px;
+	max-width: 95%;
+}
+
+#calculation_status_order_data .description {
+	font-style: italic;
+	margin: 0px;
+}
+
+#advanced_order_data .accordion-section-title {
+	font-size: 12px;
+}
+
+#advanced_order_data span.copy-button.dashicons.dashicons-clipboard {
+	float: right;
+	margin-right: 20px;
+	font-size: 14px;
+	vertical-align: middle;
+	margin-top: 2px;
 }

--- a/includes/js/wc-taxjar-order.js
+++ b/includes/js/wc-taxjar-order.js
@@ -61,7 +61,13 @@ jQuery( document ).ready( function() {
 		},
 
 		copy_success: function() {
-			alert('Copied to clipboard.');
+			jQuery( this ).tipTip({
+				'attribute':  'data-tip',
+				'activation': 'focus',
+				'fadeIn':     50,
+				'fadeOut':    50,
+				'delay':      0
+			}).focus().focus();
 		}
 	};
 

--- a/includes/js/wc-taxjar-order.js
+++ b/includes/js/wc-taxjar-order.js
@@ -34,4 +34,36 @@ jQuery( document ).ready( function() {
 			}
 		} );
 	}( jQuery, TaxJarOrder || {} ) );
+
+	var taxjar_order_calculation_meta = {
+		init: function() {
+			jQuery( '#advanced_order_data .request-json .copy-button' )
+				.on( 'click', this.copy_request_json )
+				.on( 'aftercopy', this.copy_success );
+
+			jQuery( '#advanced_order_data .response-json .copy-button' )
+				.on( 'click', this.copy_response_json )
+				.on( 'aftercopy', this.copy_success );
+		},
+
+		copy_request_json: function( e ) {
+			wcClearClipboard();
+			wcSetClipboard( jQuery('#advanced_order_data .request-json .accordion-section-content pre').text(), jQuery( this ) );
+			e.preventDefault();
+			e.stopPropagation();
+		},
+
+		copy_response_json: function( e ) {
+			wcClearClipboard();
+			wcSetClipboard( jQuery('#advanced_order_data .response-json .accordion-section-content pre').text(), jQuery( this ) );
+			e.preventDefault();
+			e.stopPropagation();
+		},
+
+		copy_success: function() {
+			alert('Copied to clipboard.');
+		}
+	};
+
+	taxjar_order_calculation_meta.init();
 });

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -118,6 +118,9 @@ final class WC_Taxjar {
 			include_once 'includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php';
 			include_once 'includes/TaxCalculation/class-order-tax-calculation-result-data-store.php';
 
+			include_once 'includes/admin/class-admin-meta-boxes.php';
+			include_once 'includes/admin/class-order-meta-box.php';
+
 			// Register the integration.
 			add_action( 'woocommerce_integrations_init', array( $this, 'add_integration' ), 20 );
 


### PR DESCRIPTION
This PR introduces a meta box on orders in the admin dashboard. This meta box surfaces data from the TaxJar calculation and sync processes. This includes:

- The calculation status of the order. Whether or not TaxJar calculated tax on the order in realtime, and if not the reason why.
- The sync status of the order. If the order has been synced to TaxJar and the last sync time.
- Additional meta data. This includes the JSON request and response from the calculation process.

![image](https://user-images.githubusercontent.com/11321890/144490283-fe9f53de-3425-4147-9736-8a79f5fb1e64.png)

![image](https://user-images.githubusercontent.com/11321890/144490310-2663c49d-137f-4fc5-8f34-5162579fb659.png)

![image](https://user-images.githubusercontent.com/11321890/144490336-7e2eff27-621c-4e0e-a271-602a8bd625f8.png)

**Click-Test Versions**

- [X] Woo 5.9
- [X] Woo 5.4


**Specs Passing**

- [X] Woo 5.9
- [X] Woo 5.4
