### PR TITLE
Fix Precision Point Issues When Creating Transactions in TaxJar

### DIFF
--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -177,9 +177,9 @@ class TaxJar_Order_Record extends TaxJar_Record {
 			'from_state' => $from_state,
 			'from_city' => $from_city,
 			'from_street' => $from_street,
-			'amount' => $amount,
-			'shipping' => $this->object->get_shipping_total(),
-			'sales_tax' => $this->object->get_total_tax(),
+			'amount' => (string) $amount,
+			'shipping' => (string) $this->object->get_shipping_total(),
+			'sales_tax' => (string) $this->object->get_total_tax(),
 			'line_items' => $this->get_line_items(),
 		);
 
@@ -276,9 +276,9 @@ class TaxJar_Order_Record extends TaxJar_Record {
 					'product_identifier' => $product_identifier,
 					'description' => $product_name,
 					'product_tax_code' => $tax_code,
-					'unit_price' => $unit_price,
-					'discount' => $discount,
-					'sales_tax' => $item->get_total_tax(),
+					'unit_price' => (string) $unit_price,
+					'discount' => (string) $discount,
+					'sales_tax' => (string) $item->get_total_tax(),
 				);
 			}
 		}
@@ -306,8 +306,8 @@ class TaxJar_Order_Record extends TaxJar_Record {
 					'quantity' => $fee->get_quantity(),
 					'description' => $fee->get_name(),
 					'product_tax_code' => $tax_code,
-					'unit_price' => $fee_amount,
-					'sales_tax' => $fee->get_total_tax(),
+					'unit_price' => (string) $fee_amount,
+					'sales_tax' => (string) $fee->get_total_tax(),
 				);
 			}
 		}

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -97,7 +97,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		$from_zip         = $store_settings['postcode'];
 		$from_city        = $store_settings['city'];
 		$from_street      = $store_settings['street'];
-		
+
 		$amount = $this->object->get_amount() - abs( $this->object->get_total_tax() );
 
 		$ship_to_address = $this->get_ship_to_address( $order );
@@ -111,9 +111,9 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 			'from_state' => $from_state,
 			'from_city' => $from_city,
 			'from_street' => $from_street,
-			'amount' => $amount,
-			'shipping' => $this->object->get_shipping_total(),
-			'sales_tax' => $this->object->get_total_tax(),
+			'amount' => (string) $amount,
+			'shipping' => (string) $this->object->get_shipping_total(),
+			'sales_tax' => (string) $this->object->get_total_tax(),
 			'line_items' => $this->get_line_items(),
 		);
 
@@ -221,9 +221,9 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 					'product_identifier' => $product_identifier,
 					'description' => $product_name,
 					'product_tax_code' => $tax_code,
-					'unit_price' => $unit_price,
-					'discount' => $discount,
-					'sales_tax' => $item->get_total_tax(),
+					'unit_price' => (string) $unit_price,
+					'discount' => (string) $discount,
+					'sales_tax' => (string) $item->get_total_tax(),
 				);
 			}
 		}
@@ -250,8 +250,8 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 					'quantity' => $fee->get_quantity(),
 					'description' => $fee->get_name(),
 					'product_tax_code' => $tax_code,
-					'unit_price' => $fee_amount,
-					'sales_tax' => $fee->get_total_tax(),
+					'unit_price' => (string) $fee_amount,
+					'sales_tax' => (string) $fee->get_total_tax(),
 				);
 			}
 		}


### PR DESCRIPTION
For some PHP configurations using json_encode on float values may caused them to be altered from their original state. For example 472.185 would become 472.18500000000006 after it has been encoded. This may create a scenario when the numbers are parsed in TaxJar that the math between the line item amounts and the total amounts do not add up correctly.

To resolve the issue all the floats are being cast as strings before performing the request to TaxJar.

**Click-Test Versions**

- [X] Woo 5.9
- [X] Woo 5.4

**Specs Passing**

- [X] Woo 5.9
- [X] Woo 5.4
