### PR TITLE
Filter Invalid PTCs

### DIFF
--- a/includes/class-taxjar-tax-calculation.php
+++ b/includes/class-taxjar-tax-calculation.php
@@ -198,7 +198,12 @@ class TaxJar_Tax_Calculation {
 			$tax_code = end( $tax_class );
 		}
 
-		return strtoupper( $tax_code );
+		if ( ! preg_match( '/^\d{5}$|^\d+[a-zA-Z]\d+$/', $tax_code ) ) {
+			$tax_code = '';
+		}
+
+		$tax_code = strtoupper( $tax_code );
+		return apply_filters( 'taxjar_get_product_tax_code', $tax_code, $tax_class );
 	}
 
 	/**

--- a/tests/specs/test-get-tax-code.php
+++ b/tests/specs/test-get-tax-code.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TaxJar;
+
+use TaxJar_Tax_Calculation;
+use WP_UnitTestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Test_Get_Tax_Code extends WP_UnitTestCase {
+
+	/**
+	 * @dataProvider tax_class_provider
+	 */
+	public function test_correct_ptcs_are_parsed_from_tax_class( $tax_class, $expected_tax_code ) {
+		$parsed_code = TaxJar_Tax_Calculation::get_tax_code_from_class( $tax_class );
+
+		$this->assertEquals( $expected_tax_code, $parsed_code );
+	}
+
+	public function tax_class_provider() {
+		return [
+			[ 'test', '' ],
+			[ 'test-10001', '10001' ],
+			[ 'test-111', '' ],
+			[ '10122100A0000', '10122100A0000' ],
+			[ 'test-10122100A0000', '10122100A0000' ],
+			[ 'test-10122100a0000', '10122100A0000' ],
+			[ '', '' ],
+			[ '10001', '10001' ],
+			[ '1111', '' ],
+			[ '10122100A', '' ],
+			[ '0', '' ],
+		];
+	}
+}

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -553,7 +553,7 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$record = new TaxJar_Order_Record( $order->get_id(), true );
 		$record->load_object( $order );
 		$fee_line_items = $record->get_fee_line_items();
-		$this->assertEquals( 'RATE', $fee_line_items[ 0 ][ 'product_tax_code' ] );
+		$this->assertEquals( '', $fee_line_items[ 0 ][ 'product_tax_code' ] );
 
 		$order = $this->create_test_order( 1 );
 		$fee = new WC_Order_Item_Fee();
@@ -1408,7 +1408,7 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 
 		$noncomplete_order = $this->create_test_order( 1 );
 		$noncomplete_order_refund = $this->create_test_refund( $noncomplete_order->get_id() );
-		
+
 		$synced_order = $this->create_test_order( 1 );
 		$synced_order->update_status( 'completed' );
 		$synced_order_refund = $this->create_test_refund( $synced_order->get_id() );


### PR DESCRIPTION
The TaxJar plugin parses PTCs (Product Tax Codes) from a given products tax class. These tax classes are natively functionality to WooCommerce which means that many invalid codes are sent to TaxJar when creating transactions. While this doesn't prevent the transaction from being created, it can create confusion for customers and potential confusion for filings.

This PR adds additional filtering to PTC parsing and ensures that only PTCs that are in a valid format are sent to TaxJar.

**Click-Test Versions**

- [X] Woo 5.9
- [X] Woo 5.4

**Specs Passing**

- [X] Woo 5.9
- [X] Woo 5.4
