### PR TITLE
Calculation Logging Performance Changes

### DIFF
--- a/includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php
+++ b/includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php
@@ -40,6 +40,8 @@ class Cart_Tax_Calculation_Result_Data_Store implements Tax_Calculation_Result_D
 	 * @param Tax_Calculation_Result $calculation_result Result of tax calculation.
 	 */
 	public function update( Tax_Calculation_Result $calculation_result ) {
+		$calculation_result->set_raw_request('');
+		$calculation_result->set_raw_response('');
 		$this->cart->tax_calculation_results = $calculation_result->to_json();
 	}
 

--- a/includes/TaxCalculation/class-order-tax-calculation-result-data-store.php
+++ b/includes/TaxCalculation/class-order-tax-calculation-result-data-store.php
@@ -40,6 +40,8 @@ class Order_Tax_Calculation_Result_Data_Store implements Tax_Calculation_Result_
 	 * @param Tax_Calculation_Result $calculation_result Result of tax calculation.
 	 */
 	public function update( Tax_Calculation_Result $calculation_result ) {
+		$calculation_result->set_raw_request('');
+		$calculation_result->set_raw_response('');
 		$this->order->update_meta_data( '_taxjar_tax_result', $calculation_result->to_json() );
 	}
 

--- a/includes/admin/class-order-meta-box.php
+++ b/includes/admin/class-order-meta-box.php
@@ -50,13 +50,9 @@ class Order_Meta_Box {
 			$result                                     = Tax_Calculation_Result::from_json_string( $raw_calculation_result );
 			$metadata['calculation_status']             = self::get_calculation_status( $result );
 			$metadata['calculation_status_description'] = self::get_calculation_status_description( $result );
-			$metadata['request_json']                   = self::get_request_json( $result );
-			$metadata['response_json']                  = self::get_response_json( $result );
 		} else {
 			$metadata['calculation_status']             = 'unknown';
 			$metadata['calculation_status_description'] = 'No TaxJar calculation data is present on the order. This may indicate that TaxJar was not enabled when this order was placed, that tax calculation has not yet occurred (if creating the order manually through admin) or that the tax was calculated prior to TaxJar version 4.1.0 which introduced this status feature.';
-			$metadata['request_json']                   = '';
-			$metadata['response_json']                  = '';
 		}
 
 		return $metadata;
@@ -90,46 +86,6 @@ class Order_Meta_Box {
 		} else {
 			return 'TaxJar did not or was unable to perform a tax calculation on this order.<br>Reason: ' . $result->get_error_message();
 		}
-	}
-
-	/**
-	 * Get the calculation request JSON string.
-	 *
-	 * @param Tax_Calculation_Result $result Tax calculation result.
-	 *
-	 * @return false|string
-	 */
-	private static function get_request_json( Tax_Calculation_Result $result ) {
-		$request_json = '';
-
-		if ( ! empty( $result->get_raw_request() ) ) {
-			$request_json = wp_json_encode( json_decode( $result->get_raw_request() ), JSON_PRETTY_PRINT );
-		}
-
-		return $request_json;
-	}
-
-	/**
-	 * Get the calculation response JSON string.
-	 *
-	 * @param Tax_Calculation_Result $result Tax calculation result.
-	 *
-	 * @return false|string
-	 */
-	private static function get_response_json( Tax_Calculation_Result $result ) {
-		$response_json = '';
-
-		if ( ! empty( $result->get_raw_response() ) ) {
-			$response = json_decode( $result->get_raw_response() );
-
-			if ( ! empty( $response->body ) ) {
-				$response->body = json_decode( $response->body );
-			}
-
-			$response_json = wp_json_encode( $response, JSON_PRETTY_PRINT );
-		}
-
-		return $response_json;
 	}
 
 	/**

--- a/includes/admin/views/html-order-meta-box.php
+++ b/includes/admin/views/html-order-meta-box.php
@@ -34,11 +34,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 					'target' => 'sync_status_order_data',
 					'class'  => '',
 				),
-				'advanced'           => array(
-					'label'  => __( 'Advanced', 'taxjar' ),
-					'target' => 'advanced_order_data',
-					'class'  => '',
-				),
 			)
 		);
 
@@ -116,24 +111,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php } ?>
 
 		<?php do_action( 'taxjar_sync_status_order_data_panel', $order->get_id(), $order ); ?>
-	</div>
-	<div id="advanced_order_data" class="panel woocommerce_options_panel">
-		<div class="accordion-container">
-			<div class="accordion-section request-json">
-				<h3 class="accordion-section-title">Calculation Request JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php echo esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
-				<div class="accordion-section-content">
-					<pre><?php echo esc_html( $metadata['request_json'] ); ?></pre>
-				</div>
-			</div>
-			<div class="accordion-section response-json">
-				<h3 class="accordion-section-title">Calculation Response JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php echo esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
-				<div class="accordion-section-content">
-					<pre><?php echo esc_html( $metadata['response_json'] ); ?></pre>
-				</div>
-			</div>
-			<?php do_action( 'taxjar_advanced_order_data_panel_accordion', $order->get_id(), $order ); ?>
-		</div>
-		<?php do_action( 'taxjar_advanced_order_data_panel', $order->get_id(), $order ); ?>
 	</div>
 	<?php do_action( 'taxjar_order_data_panels', $order->get_id(), $order ); ?>
 	<div class="clear"></div>

--- a/includes/js/wc-taxjar-order.js
+++ b/includes/js/wc-taxjar-order.js
@@ -34,42 +34,4 @@ jQuery( document ).ready( function() {
 			}
 		} );
 	}( jQuery, TaxJarOrder || {} ) );
-
-	var taxjar_order_calculation_meta = {
-		init: function() {
-			jQuery( '#advanced_order_data .request-json .copy-button' )
-				.on( 'click', this.copy_request_json )
-				.on( 'aftercopy', this.copy_success );
-
-			jQuery( '#advanced_order_data .response-json .copy-button' )
-				.on( 'click', this.copy_response_json )
-				.on( 'aftercopy', this.copy_success );
-		},
-
-		copy_request_json: function( e ) {
-			wcClearClipboard();
-			wcSetClipboard( jQuery('#advanced_order_data .request-json .accordion-section-content pre').text(), jQuery( this ) );
-			e.preventDefault();
-			e.stopPropagation();
-		},
-
-		copy_response_json: function( e ) {
-			wcClearClipboard();
-			wcSetClipboard( jQuery('#advanced_order_data .response-json .accordion-section-content pre').text(), jQuery( this ) );
-			e.preventDefault();
-			e.stopPropagation();
-		},
-
-		copy_success: function() {
-			jQuery( this ).tipTip({
-				'attribute':  'data-tip',
-				'activation': 'focus',
-				'fadeIn':     50,
-				'fadeOut':    50,
-				'delay':      0
-			}).focus().focus();
-		}
-	};
-
-	taxjar_order_calculation_meta.init();
 });


### PR DESCRIPTION
Previously in the logging feature branch we were storing the entire request and response JSON strings. It was determined that this approach may not scale well as these strings can be quite large and would be stored in the postmeta table for any order created. The storing and display of those values has now been removed.

**Click-Test Versions**

- [X] Woo 6.1
- [X] Woo 5.6

**Specs Passing**

- [X] Woo 6.1
- [X] Woo 5.6
