### PR TITLE
Calculation/Transaction Sync Status Meta Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.1.0 (2022-01-19)
+* Add order meta box to give details of calculation and sync statuses
+* Remove usage of deprecated function is_ajax
+* WooCommerce tested up to 6.1
+* Update minimum WordPress version to 5.6
+
 # 4.0.1 (2021-11-19)
 * Change dynamic tax rate ID to 999999999 to help prevent issues with 3rd parties ingesting exported WooCommerce order data
 * Fix issue where shipping was still utilizing dynamic tax rate when the save rates setting was enabled.

--- a/includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php
+++ b/includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Cart Tax Calculation Result Data Store
+ *
+ * Persists tax calculation result to cart.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Cart_Tax_Calculation_Result_Data_Store
+ */
+class Cart_Tax_Calculation_Result_Data_Store implements Tax_Calculation_Result_Data_Store {
+
+	/**
+	 * Cart to persist result on
+	 *
+	 * @var \WC_Cart
+	 */
+	private $cart;
+
+	/**
+	 * Cart_Tax_Calculation_Result_Data_Store Constructor
+	 *
+	 * @param \WC_Cart $cart Cart to persist results on.
+	 */
+	public function __construct( \WC_Cart $cart ) {
+		$this->cart = $cart;
+	}
+
+	/**
+	 * Persist results on the cart
+	 *
+	 * @param Tax_Calculation_Result $calculation_result Result of tax calculation.
+	 */
+	public function update( Tax_Calculation_Result $calculation_result ) {
+		$this->cart->tax_calculation_results = $calculation_result->to_json();
+	}
+
+}

--- a/includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php
+++ b/includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php
@@ -40,6 +40,8 @@ class Cart_Tax_Calculation_Result_Data_Store implements Tax_Calculation_Result_D
 	 * @param Tax_Calculation_Result $calculation_result Result of tax calculation.
 	 */
 	public function update( Tax_Calculation_Result $calculation_result ) {
+		$calculation_result->set_raw_request('');
+		$calculation_result->set_raw_response('');
 		$this->cart->tax_calculation_results = $calculation_result->to_json();
 	}
 

--- a/includes/TaxCalculation/class-order-tax-calculation-result-data-store.php
+++ b/includes/TaxCalculation/class-order-tax-calculation-result-data-store.php
@@ -40,6 +40,8 @@ class Order_Tax_Calculation_Result_Data_Store implements Tax_Calculation_Result_
 	 * @param Tax_Calculation_Result $calculation_result Result of tax calculation.
 	 */
 	public function update( Tax_Calculation_Result $calculation_result ) {
+		$calculation_result->set_raw_request('');
+		$calculation_result->set_raw_response('');
 		$this->order->update_meta_data( '_taxjar_tax_result', $calculation_result->to_json() );
 	}
 

--- a/includes/TaxCalculation/class-order-tax-calculation-result-data-store.php
+++ b/includes/TaxCalculation/class-order-tax-calculation-result-data-store.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Order Tax Calculation Result Data Store
+ *
+ * Persists tax calculation result to order.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Order_Tax_Calculation_Result_Data_Store
+ */
+class Order_Tax_Calculation_Result_Data_Store implements Tax_Calculation_Result_Data_Store {
+
+	/**
+	 * Order to persist result on
+	 *
+	 * @var \WC_Order
+	 */
+	private $order;
+
+	/**
+	 * Order_Tax_Calculation_Result_Data_Store Constructor
+	 *
+	 * @param \WC_Order $order Order to persist results on.
+	 */
+	public function __construct( \WC_Order $order ) {
+		$this->order = $order;
+	}
+
+	/**
+	 * Persist results on the order
+	 *
+	 * @param Tax_Calculation_Result $calculation_result Result of tax calculation.
+	 */
+	public function update( Tax_Calculation_Result $calculation_result ) {
+		$this->order->update_meta_data( '_taxjar_tax_result', $calculation_result->to_json() );
+	}
+
+}

--- a/includes/TaxCalculation/class-tax-calculator-builder.php
+++ b/includes/TaxCalculation/class-tax-calculator-builder.php
@@ -8,6 +8,7 @@
 namespace TaxJar;
 
 use WC_Cart;
+use WC_Order;
 use WC_Taxjar_Nexus;
 use TaxJar_Settings;
 
@@ -101,6 +102,7 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $order );
 		$this->set_order_validator( $order );
 		$this->set_context( 'api_order' );
+		$this->set_order_tax_result_data_store( $order );
 	}
 
 	/**
@@ -114,6 +116,7 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $order );
 		$this->set_order_validator( $order );
 		$this->set_context( 'order' );
+		$this->set_order_tax_result_data_store( $order );
 	}
 
 	/**
@@ -270,6 +273,7 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $order );
 		$this->set_order_validator( $order );
 		$this->set_context( 'admin_order' );
+		$this->set_order_tax_result_data_store( $order );
 	}
 
 	/**
@@ -294,6 +298,7 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $subscription );
 		$this->set_order_validator( $subscription );
 		$this->set_context( 'subscription_order' );
+		$this->set_order_tax_result_data_store( $subscription );
 		return $this->calculator;
 	}
 
@@ -310,7 +315,18 @@ class Tax_Calculator_Builder {
 		$this->set_order_applicator( $renewal );
 		$this->set_order_validator( $renewal );
 		$this->set_context( 'renewal_order' );
+		$this->set_order_tax_result_data_store( $renewal );
 		return $this->calculator;
+	}
+
+	/**
+	 * Set the tax result data store when building an order calculator.
+	 *
+	 * @param WC_Order $order Order whose tax is being calculated.
+	 */
+	private function set_order_tax_result_data_store( WC_Order $order ) {
+		$result_data_store = new Order_Tax_Calculation_Result_Data_Store( $order );
+		$this->calculator->set_result_data_store( $result_data_store );
 	}
 
 	/**
@@ -326,7 +342,18 @@ class Tax_Calculator_Builder {
 		$this->set_cart_tax_applicator( $cart );
 		$this->set_cart_validator( $cart );
 		$this->set_context( 'cart' );
+		$this->set_cart_tax_result_data_store( $cart );
 		return $this->calculator;
+	}
+
+	/**
+	 * Set the tax result data store when building a cart calculator.
+	 *
+	 * @param WC_Cart $cart Cart whose tax is being calculated.
+	 */
+	private function set_cart_tax_result_data_store( WC_Cart $cart ) {
+		$result_data_store = new Cart_Tax_Calculation_Result_Data_Store( $cart );
+		$this->calculator->set_result_data_store( $result_data_store );
 	}
 
 	/**

--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -289,12 +289,13 @@ abstract class TaxJar_Record {
 		$this->save();
 	}
 
-	public function add_object_sync_metadata() {
+	public function update_object_sync_success_meta_data() {
 		$data = $this->get_data();
 		$data_hash = hash( 'md5', serialize( $data ) );
 		$sync_datetime =  $this->get_processed_datetime();
 		$this->object->update_meta_data( '_taxjar_last_sync', $sync_datetime );
 		$this->object->update_meta_data( '_taxjar_hash', $data_hash );
+		$this->object->delete_meta_data( '_taxjar_sync_last_error' );
 		$this->object->save();
 	}
 
@@ -329,6 +330,13 @@ abstract class TaxJar_Record {
 		}
 
 		$this->save();
+	}
+
+	public function update_object_sync_failure_meta_data( $error_message ) {
+		if ( $this->object ) {
+			$this->object->update_meta_data( '_taxjar_sync_last_error', $error_message );
+			$this->object->save();
+		}
 	}
 
 	abstract function create_in_taxjar();

--- a/includes/admin/class-admin-meta-boxes.php
+++ b/includes/admin/class-admin-meta-boxes.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Admin Meta Boxes
+ *
+ * Adds meta box to order type posts.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Admin_Meta_Boxes
+ */
+class Admin_Meta_Boxes {
+
+	/**
+	 * Admin_Meta_Boxes Constructor.
+	 */
+	public function __construct() {
+		add_action( 'add_meta_boxes', array( $this, 'add_order_meta_box' ), 30 );
+	}
+
+	/**
+	 * Add meta box to order post types.
+	 */
+	public function add_order_meta_box() {
+		foreach ( wc_get_order_types( 'order-meta-boxes' ) as $type ) {
+			add_meta_box(
+				'taxjar',
+				__( 'TaxJar', 'taxjar' ),
+				'\TaxJar\Order_Meta_Box::output',
+				$type,
+				'normal',
+				'low'
+			);
+		}
+	}
+}

--- a/includes/admin/class-order-meta-box.php
+++ b/includes/admin/class-order-meta-box.php
@@ -9,6 +9,9 @@
 
 namespace TaxJar;
 
+use TaxJar_Order_Record;
+use TaxJar_Refund_Record;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -26,7 +29,7 @@ class Order_Meta_Box {
 	public static function output( $post ) {
 		$order_id = $post->ID;
 		$order    = wc_get_order( $order_id );
-		$metadata = self::get_taxjar_order_metadata( $order );
+		$metadata = self::get_order_tax_calculation_metadata( $order );
 		wp_enqueue_script( 'accordion' );
 
 		include_once dirname( __FILE__ ) . '/views/html-order-meta-box.php';
@@ -39,10 +42,9 @@ class Order_Meta_Box {
 	 *
 	 * @return array
 	 */
-	private static function get_taxjar_order_metadata( \WC_Order $order ): array {
-		$metadata                = array();
-		$raw_calculation_result  = $order->get_meta( '_taxjar_tax_result' );
-		$metadata['sync_status'] = self::get_last_sync_status( $order );
+	private static function get_order_tax_calculation_metadata( \WC_Order $order ): array {
+		$metadata               = array();
+		$raw_calculation_result = $order->get_meta( '_taxjar_tax_result' );
 
 		if ( ! empty( $raw_calculation_result ) ) {
 			$result                                     = Tax_Calculation_Result::from_json_string( $raw_calculation_result );
@@ -137,18 +139,137 @@ class Order_Meta_Box {
 	 *
 	 * @return string
 	 */
-	private static function get_last_sync_status( \WC_Order $order ): string {
-		if ( is_a( $order, 'WC_Subscription' ) ) {
-			return 'Subscriptions are not synced to TaxJar. Each order created from the subscription must be individually synced.';
-		}
-
+	public static function get_order_sync_accordion_content( \WC_Order $order ): string {
 		$last_sync_timestamp = $order->get_meta( '_taxjar_last_sync' );
-		if ( ! empty( $last_sync_timestamp ) ) {
+		$last_error          = $order->get_meta( '_taxjar_sync_last_error' );
+
+		if ( empty( $last_sync_timestamp ) ) {
+			if ( empty( $last_error ) ) {
+				$queue_id = TaxJar_Order_Record::find_active_in_queue( $order->get_id() );
+
+				if ( $queue_id ) {
+					return 'Order is currently in the sync queue. ' . self::get_sync_queue_link( $order );
+				}
+
+				$record = new TaxJar_Order_Record( $order->get_id(), true );
+				$record->load_object( $order );
+				$can_sync = $record->should_sync();
+
+				if ( $can_sync ) {
+					return 'Order is ready to sync to TaxJar but has not yet been added to the sync queue.';
+				} else {
+					return 'Order cannot sync to TaxJar. ' . $record->get_error()['message'];
+				}
+			} else {
+				return 'Order failed to sync to TaxJar. ' . $last_error;
+			}
+		} else {
 			$sync_date = wp_date( wc_date_format(), wc_string_to_timestamp( $last_sync_timestamp ) );
 			$sync_time = wp_date( wc_time_format(), wc_string_to_timestamp( $last_sync_timestamp ) );
-			return 'Last Synced on: ' . $sync_date . ' ' . $sync_time;
-		} else {
-			return 'Order has not been synced to TaxJar.';
+			return 'Order successfully synced to TaxJar.<br>Last Synced on: ' . $sync_date . ' ' . $sync_time;
 		}
+	}
+
+	/**
+	 * Get accordion content for a refund.
+	 *
+	 * @param \WC_Order_Refund $refund Refund.
+	 *
+	 * @return string
+	 */
+	public static function get_refund_sync_accordion_content( \WC_Order_Refund $refund ): string {
+		$last_sync_timestamp = $refund->get_meta( '_taxjar_last_sync' );
+		$last_error          = $refund->get_meta( '_taxjar_sync_last_error' );
+
+		if ( empty( $last_sync_timestamp ) ) {
+			if ( empty( $last_error ) ) {
+				$queue_id = TaxJar_Refund_Record::find_active_in_queue( $refund->get_id() );
+
+				if ( $queue_id ) {
+					return 'Refund is currently in the sync queue. ' . self::get_sync_queue_link( $refund );
+				}
+
+				$record = new TaxJar_Refund_Record( $refund->get_id(), true );
+				$record->load_object();
+				$can_sync = $record->should_sync();
+
+				if ( $can_sync ) {
+					return 'Refund is ready to sync to TaxJar but has not yet been added to the sync queue.';
+				} else {
+					return 'Refund cannot sync to TaxJar. ' . $record->get_error()['message'];
+				}
+			} else {
+				return 'Refund failed to sync to TaxJar. ' . $last_error;
+			}
+		} else {
+			$sync_date = wp_date( wc_date_format(), wc_string_to_timestamp( $last_sync_timestamp ) );
+			$sync_time = wp_date( wc_time_format(), wc_string_to_timestamp( $last_sync_timestamp ) );
+			return 'Refund successfully synced to TaxJar.<br>Last Synced on: ' . $sync_date . ' ' . $sync_time;
+		}
+	}
+
+	/**
+	 * Get the link to the sync queue search for a particular order.
+	 *
+	 * @param \WC_Abstract_Order $order Order or Refund to get sync queue link for.
+	 *
+	 * @return string
+	 */
+	private static function get_sync_queue_link( \WC_Abstract_Order $order ): string {
+		$link = add_query_arg(
+			array(
+				'page'    => 'wc-settings',
+				'tab'     => 'taxjar-integration',
+				'section' => 'sync_queue',
+				's'       => $order->get_id(),
+				'paged'   => 1,
+			),
+			admin_url( 'admin.php' )
+		);
+
+		return '<a href="' . esc_url( $link ) . '" >View Progress</a>';
+	}
+
+	/**
+	 * Get the sync status of an order or refund.
+	 *
+	 * @param \WC_Abstract_Order $order Order or Refund.
+	 *
+	 * @return string
+	 */
+	public static function get_sync_status( \WC_Abstract_Order $order ): string {
+		$last_sync_timestamp = $order->get_meta( '_taxjar_last_sync' );
+		$last_error          = $order->get_meta( '_taxjar_sync_last_error' );
+
+		if ( empty( $last_sync_timestamp ) ) {
+			if ( empty( $last_error ) ) {
+				return 'not-synced';
+			} else {
+				return 'failed';
+			}
+		} else {
+			return 'synced';
+		}
+	}
+
+	/**
+	 * Get the text description of an order or refund sync status.
+	 *
+	 * @param string $status Sync status of order or refund.
+	 * @param string $type Type, either order or refund.
+	 *
+	 * @return string
+	 */
+	public static function get_sync_status_tip( string $status, string $type ): string {
+		$tips = array(
+			'order-synced'      => __( 'Order successfully synced to TaxJar.', 'taxjar' ),
+			'order-not-synced'  => __( 'Order has not been synced to TaxJar.', 'taxjar' ),
+			'order-failed'      => __( 'Order failed to sync to TaxJar.', 'taxjar' ),
+			'refund-synced'     => __( 'Refund successfully synced to TaxJar.', 'taxjar' ),
+			'refund-not-synced' => __( 'Refund has not been synced to TaxJar.', 'taxjar' ),
+			'refund-failed'     => __( 'Refund failed to sync to TaxJar.', 'taxjar' ),
+		);
+
+		return $tips[ $type . '-' . $status ];
 	}
 }

--- a/includes/admin/class-order-meta-box.php
+++ b/includes/admin/class-order-meta-box.php
@@ -50,13 +50,9 @@ class Order_Meta_Box {
 			$result                                     = Tax_Calculation_Result::from_json_string( $raw_calculation_result );
 			$metadata['calculation_status']             = self::get_calculation_status( $result );
 			$metadata['calculation_status_description'] = self::get_calculation_status_description( $result );
-			$metadata['request_json']                   = self::get_request_json( $result );
-			$metadata['response_json']                  = self::get_response_json( $result );
 		} else {
 			$metadata['calculation_status']             = 'unknown';
 			$metadata['calculation_status_description'] = 'No TaxJar calculation data is present on the order. This may indicate that TaxJar was not enabled when this order was placed, that tax calculation has not yet occurred (if creating the order manually through admin) or that the tax was calculated prior to TaxJar version 4.1.0 which introduced this status feature.';
-			$metadata['request_json']                   = '';
-			$metadata['response_json']                  = '';
 		}
 
 		return $metadata;
@@ -90,46 +86,6 @@ class Order_Meta_Box {
 		} else {
 			return 'TaxJar did not or was unable to perform a tax calculation on this order.<br>Reason: ' . $result->get_error_message();
 		}
-	}
-
-	/**
-	 * Get the calculation request JSON string.
-	 *
-	 * @param Tax_Calculation_Result $result Tax calculation result.
-	 *
-	 * @return false|string
-	 */
-	private static function get_request_json( Tax_Calculation_Result $result ) {
-		$request_json = '';
-
-		if ( ! empty( $result->get_raw_request() ) ) {
-			$request_json = wp_json_encode( json_decode( $result->get_raw_request() ), JSON_PRETTY_PRINT );
-		}
-
-		return $request_json;
-	}
-
-	/**
-	 * Get the calculation response JSON string.
-	 *
-	 * @param Tax_Calculation_Result $result Tax calculation result.
-	 *
-	 * @return false|string
-	 */
-	private static function get_response_json( Tax_Calculation_Result $result ) {
-		$response_json = '';
-
-		if ( ! empty( $result->get_raw_response() ) ) {
-			$response = json_decode( $result->get_raw_response() );
-
-			if ( ! empty( $response->body ) ) {
-				$response->body = json_decode( $response->body );
-			}
-
-			$response_json = wp_json_encode( $response, JSON_PRETTY_PRINT );
-		}
-
-		return $response_json;
 	}
 
 	/**

--- a/includes/admin/class-order-meta-box.php
+++ b/includes/admin/class-order-meta-box.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Order Meta Box
+ *
+ * Outputs the contents of the meta box containing TaxJar calculation and sync metadata.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Order_Meta_Box
+ */
+class Order_Meta_Box {
+
+	/**
+	 * Output meta box contents.
+	 *
+	 * @param mixed $post WP Post.
+	 */
+	public static function output( $post ) {
+		$order_id = $post->ID;
+		$order    = wc_get_order( $order_id );
+		$metadata = self::get_taxjar_order_metadata( $order );
+		wp_enqueue_script( 'accordion' );
+
+		include_once dirname( __FILE__ ) . '/views/html-order-meta-box.php';
+	}
+
+	/**
+	 * Get the metadata to display in the meta box.
+	 *
+	 * @param \WC_Order $order Order object.
+	 *
+	 * @return array
+	 */
+	private static function get_taxjar_order_metadata( \WC_Order $order ): array {
+		$metadata                = array();
+		$raw_calculation_result  = $order->get_meta( '_taxjar_tax_result' );
+		$metadata['sync_status'] = self::get_last_sync_status( $order );
+
+		if ( ! empty( $raw_calculation_result ) ) {
+			$result                                     = Tax_Calculation_Result::from_json_string( $raw_calculation_result );
+			$metadata['calculation_status']             = self::get_calculation_status( $result );
+			$metadata['calculation_status_description'] = self::get_calculation_status_description( $result );
+			$metadata['request_json']                   = self::get_request_json( $result );
+			$metadata['response_json']                  = self::get_response_json( $result );
+		} else {
+			$metadata['calculation_status']             = 'unknown';
+			$metadata['calculation_status_description'] = 'No TaxJar calculation data is present on the order. This may indicate that TaxJar was not enabled when this order was placed, that tax calculation has not yet occurred (if creating the order manually through admin) or that the tax was calculated prior to TaxJar version 4.1.0 which introduced this status feature.';
+			$metadata['request_json']                   = '';
+			$metadata['response_json']                  = '';
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Get the calculation status of the result.
+	 *
+	 * @param Tax_Calculation_Result $result Tax calculation result.
+	 *
+	 * @return string
+	 */
+	private static function get_calculation_status( Tax_Calculation_Result $result ): string {
+		if ( $result->get_success() ) {
+			return 'success';
+		} else {
+			return 'fail';
+		}
+	}
+
+	/**
+	 * Get the calculation status description.
+	 *
+	 * @param Tax_Calculation_Result $result Tax calculation result.
+	 *
+	 * @return string
+	 */
+	private static function get_calculation_status_description( Tax_Calculation_Result $result ): string {
+		if ( $result->get_success() ) {
+			return 'Tax was calculated in realtime through the TaxJar API.';
+		} else {
+			return 'TaxJar did not or was unable to perform a tax calculation on this order.<br>Reason: ' . $result->get_error_message();
+		}
+	}
+
+	/**
+	 * Get the calculation request JSON string.
+	 *
+	 * @param Tax_Calculation_Result $result Tax calculation result.
+	 *
+	 * @return false|string
+	 */
+	private static function get_request_json( Tax_Calculation_Result $result ) {
+		$request_json = '';
+
+		if ( ! empty( $result->get_raw_request() ) ) {
+			$request_json = wp_json_encode( json_decode( $result->get_raw_request() ), JSON_PRETTY_PRINT );
+		}
+
+		return $request_json;
+	}
+
+	/**
+	 * Get the calculation response JSON string.
+	 *
+	 * @param Tax_Calculation_Result $result Tax calculation result.
+	 *
+	 * @return false|string
+	 */
+	private static function get_response_json( Tax_Calculation_Result $result ) {
+		$response_json = '';
+
+		if ( ! empty( $result->get_raw_response() ) ) {
+			$response = json_decode( $result->get_raw_response() );
+
+			if ( ! empty( $response->body ) ) {
+				$response->body = json_decode( $response->body );
+			}
+
+			$response_json = wp_json_encode( $response, JSON_PRETTY_PRINT );
+		}
+
+		return $response_json;
+	}
+
+	/**
+	 * Get the sync status of the order.
+	 *
+	 * @param \WC_Order $order Order object.
+	 *
+	 * @return string
+	 */
+	private static function get_last_sync_status( \WC_Order $order ): string {
+		if ( is_a( $order, 'WC_Subscription' ) ) {
+			return 'Subscriptions are not synced to TaxJar. Each order created from the subscription must be individually synced.';
+		}
+
+		$last_sync_timestamp = $order->get_meta( '_taxjar_last_sync' );
+		if ( ! empty( $last_sync_timestamp ) ) {
+			$sync_date = wp_date( wc_date_format(), wc_string_to_timestamp( $last_sync_timestamp ) );
+			$sync_time = wp_date( wc_time_format(), wc_string_to_timestamp( $last_sync_timestamp ) );
+			return 'Last Synced on: ' . $sync_date . ' ' . $sync_time;
+		} else {
+			return 'Order has not been synced to TaxJar.';
+		}
+	}
+}

--- a/includes/admin/views/html-order-meta-box.php
+++ b/includes/admin/views/html-order-meta-box.php
@@ -59,19 +59,74 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php do_action( 'taxjar_calculation_status_order_data_panel', $order->get_id(), $order ); ?>
 	</div>
 	<div id="sync_status_order_data" class="panel woocommerce_options_panel">
-		<p><?php echo esc_html( $metadata['sync_status'] ); ?></p>
+		<?php if ( is_a( $order, 'WC_Subscription' ) ) { ?>
+		<p><?php echo esc_html( __( 'Subscriptions are not synced to TaxJar. Each order created from the subscription will be individually synced.', 'taxjar' ) ); ?></p>
+			<?php
+		} else {
+			$refunds           = $order->get_refunds();
+			$order_sync_status = Order_Meta_Box::get_sync_status( $order );
+			?>
+
+		<div class="accordion-container">
+			<div class="accordion-section order-section">
+				<h3 class="accordion-section-title">
+					Order #<?php echo esc_html( $order->get_id() ); ?>
+					<span class="sync-status tips <?php echo esc_attr( $order_sync_status ); ?>" data-tip="<?php echo esc_attr( Order_Meta_Box::get_sync_status_tip( $order_sync_status, 'order' ) ); ?>"></span>
+				</h3>
+				<div class="accordion-section-content">
+					<p>
+					<?php
+					echo wp_kses(
+						Order_Meta_Box::get_order_sync_accordion_content( $order ),
+						array(
+							'br' => array(),
+							'a'  => array( 'href' => array() ),
+						)
+					);
+					?>
+						</p>
+				</div>
+			</div>
+			<?php
+			foreach ( $refunds as $refund ) {
+				$refund_sync_status = Order_Meta_Box::get_sync_status( $refund );
+				?>
+				<div class="accordion-section refund-section">
+					<h3 class="accordion-section-title">
+						Refund #<?php echo esc_html( $refund->get_id() ); ?>
+						<span class="sync-status tips <?php echo esc_attr( $refund_sync_status ); ?>" data-tip="<?php echo esc_attr( Order_Meta_Box::get_sync_status_tip( $refund_sync_status, 'refund' ) ); ?>"></span>
+					</h3>
+					<div class="accordion-section-content">
+						<p>
+						<?php
+						echo wp_kses(
+							Order_Meta_Box::get_refund_sync_accordion_content( $refund ),
+							array(
+								'br' => array(),
+								'a'  => array( 'href' => array() ),
+							)
+						);
+						?>
+							</p>
+					</div>
+				</div>
+			<?php } ?>
+		</div>
+
+		<?php } ?>
+
 		<?php do_action( 'taxjar_sync_status_order_data_panel', $order->get_id(), $order ); ?>
 	</div>
 	<div id="advanced_order_data" class="panel woocommerce_options_panel">
 		<div class="accordion-container">
 			<div class="accordion-section request-json">
-				<h3 class="accordion-section-title">Calculation Request JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
+				<h3 class="accordion-section-title">Calculation Request JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php echo esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
 				<div class="accordion-section-content">
 					<pre><?php echo esc_html( $metadata['request_json'] ); ?></pre>
 				</div>
 			</div>
 			<div class="accordion-section response-json">
-				<h3 class="accordion-section-title">Calculation Response JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
+				<h3 class="accordion-section-title">Calculation Response JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php echo esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
 				<div class="accordion-section-content">
 					<pre><?php echo esc_html( $metadata['response_json'] ); ?></pre>
 				</div>

--- a/includes/admin/views/html-order-meta-box.php
+++ b/includes/admin/views/html-order-meta-box.php
@@ -34,11 +34,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 					'target' => 'sync_status_order_data',
 					'class'  => '',
 				),
-				'advanced'           => array(
-					'label'  => __( 'Advanced', 'taxjar' ),
-					'target' => 'advanced_order_data',
-					'class'  => '',
-				),
 			)
 		);
 
@@ -116,24 +111,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php } ?>
 
 		<?php do_action( 'taxjar_sync_status_order_data_panel', $order->get_id(), $order ); ?>
-	</div>
-	<div id="advanced_order_data" class="panel woocommerce_options_panel">
-		<div class="accordion-container">
-			<div class="accordion-section request-json">
-				<h3 class="accordion-section-title">Calculation Request JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php echo esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
-				<div class="accordion-section-content">
-					<pre><?php echo esc_html( $metadata['request_json'] ); ?></pre>
-				</div>
-			</div>
-			<div class="accordion-section response-json">
-				<h3 class="accordion-section-title">Calculation Response JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php echo esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
-				<div class="accordion-section-content">
-					<pre><?php echo esc_html( $metadata['response_json'] ); ?></pre>
-				</div>
-			</div>
-			<?php do_action( 'taxjar_advanced_order_data_panel_accordion', $order->get_id(), $order ); ?>
-		</div>
-		<?php do_action( 'taxjar_advanced_order_data_panel', $order->get_id(), $order ); ?>
 	</div>
 	<?php do_action( 'taxjar_order_data_panels', $order->get_id(), $order ); ?>
 	<div class="clear"></div>

--- a/includes/admin/views/html-order-meta-box.php
+++ b/includes/admin/views/html-order-meta-box.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Display the TaxJar calculation and sync data on a subscription or order.
+ *
+ * @var array $metadata Array of the TaxJar order metadata.
+ * @var \WC_Order $order Order object.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+?>
+
+<div id="taxjar_order_data" class="panel-wrap">
+	<div class="wc-tabs-back"></div>
+	<ul class="taxjar_order_data_tabs wc-tabs" style="display:none;">
+
+		<?php
+		$order_tabs = apply_filters(
+			'taxjar_order_data_tabs',
+			array(
+				'calculation_status' => array(
+					'label'  => __( 'Calculation Status', 'taxjar' ),
+					'target' => 'calculation_status_order_data',
+					'class'  => '',
+				),
+				'sync_status'        => array(
+					'label'  => __( 'Sync Status', 'taxjar' ),
+					'target' => 'sync_status_order_data',
+					'class'  => '',
+				),
+				'advanced'           => array(
+					'label'  => __( 'Advanced', 'taxjar' ),
+					'target' => 'advanced_order_data',
+					'class'  => '',
+				),
+			)
+		);
+
+		foreach ( $order_tabs as $key => $order_tab ) :
+			?>
+			<li class="<?php echo esc_html( $key ); ?>_options <?php echo esc_html( $key ); ?>_tab <?php echo esc_html( implode( ' ', (array) $order_tab['class'] ) ); ?>">
+				<a href="#<?php echo esc_html( $order_tab['target'] ); ?>">
+					<span><?php echo esc_html( $order_tab['label'] ); ?></span>
+				</a>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+	<div id="calculation_status_order_data" class="panel woocommerce_options_panel">
+		<p class="form-field">
+			<label >Calculation Status: <span class="calculation-status-icon <?php echo esc_html( $metadata['calculation_status'] ); ?>"></span></label>
+			<span class="description"><?php echo wp_kses( $metadata['calculation_status_description'], array( 'br' => array() ) ); ?></span>
+		</p>
+		<?php do_action( 'taxjar_calculation_status_order_data_panel', $order->get_id(), $order ); ?>
+	</div>
+	<div id="sync_status_order_data" class="panel woocommerce_options_panel">
+		<p><?php echo esc_html( $metadata['sync_status'] ); ?></p>
+		<?php do_action( 'taxjar_sync_status_order_data_panel', $order->get_id(), $order ); ?>
+	</div>
+	<div id="advanced_order_data" class="panel woocommerce_options_panel">
+		<div class="accordion-container">
+			<div class="accordion-section request-json">
+				<h3 class="accordion-section-title">Calculation Request JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
+				<div class="accordion-section-content">
+					<pre><?php echo esc_html( $metadata['request_json'] ); ?></pre>
+				</div>
+			</div>
+			<div class="accordion-section response-json">
+				<h3 class="accordion-section-title">Calculation Response JSON <span class="copy-button dashicons dashicons-clipboard" data-tip="<?php esc_attr_e( 'Copied!', 'taxjar' ); ?>"></span></h3>
+				<div class="accordion-section-content">
+					<pre><?php echo esc_html( $metadata['response_json'] ); ?></pre>
+				</div>
+			</div>
+			<?php do_action( 'taxjar_advanced_order_data_panel_accordion', $order->get_id(), $order ); ?>
+		</div>
+		<?php do_action( 'taxjar_advanced_order_data_panel', $order->get_id(), $order ); ?>
+	</div>
+	<?php do_action( 'taxjar_order_data_panels', $order->get_id(), $order ); ?>
+	<div class="clear"></div>
+</div>

--- a/includes/class-taxjar-customer-record.php
+++ b/includes/class-taxjar-customer-record.php
@@ -79,7 +79,12 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	 */
 	public function sync_success() {
 		parent::sync_success();
-		$this->add_object_sync_metadata();
+		$this->update_object_sync_success_meta_data();
+	}
+
+	public function sync_failure( $error_message ) {
+		parent::sync_failure( $error_message );
+		$this->update_object_sync_failure_meta_data( $error_message );
 	}
 
 	/**

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -23,47 +23,47 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 	public function should_sync() {
 		$data = $this->get_data();
 		if ( empty( $data ) ) {
-			$this->add_error( __( 'Refund failed validation - refund object not loaded to record before syncing.', 'wc-taxjar' ) );
+			$this->add_error( __( 'Refund object not loaded to record before syncing.', 'wc-taxjar' ) );
 			return false;
 		}
 
 		if ( WC_Taxjar_Transaction_Sync::should_validate_order_completed_date() ) {
 			if ( empty( $this->order_completed_date ) ) {
-				$this->add_error( __( 'Refund failed validation - parent order has no completed date.', 'wc-taxjar' ) );
+				$this->add_error( __( 'Parent order does not have a completed date. Only refunds of orders that have been completed can sync to TaxJar.', 'wc-taxjar' ) );
 				return false;
 			}
 		}
 
 		$valid_order_statuses = apply_filters( 'taxjar_valid_order_statuses_for_sync', array( 'completed', 'refunded' ) );
 		if ( empty( $this->order_status ) || ! in_array( $this->order_status, $valid_order_statuses ) ) {
-			$this->add_error( __( 'Refund failed validation - parent order does not have valid status.', 'wc-taxjar' ) );
+			$this->add_error( __( 'Parent order has an invalid status. Only refunds of orders with the following statuses can sync to TaxJar: ', 'wc-taxjar' ) . implode( ", ", $valid_order_statuses ) );
 			return false;
 		}
 
 		if ( ! $this->get_force_push() ) {
 			if ( hash( 'md5', serialize( $this->get_data() ) ) === $this->get_object_hash() ) {
-				$this->add_error( __( 'Refund failed validation - not updated since last sync.', 'wc-taxjar' ) );
+				$this->add_error( __( 'Refund data is not different from previous sync, re-syncing the transaction is not necessary.', 'wc-taxjar' ) );
 				return false;
 			}
 		}
 
 		if ( ! in_array( $data[ 'to_country' ], TaxJar_Record::allowed_countries() ) ) {
-			$this->add_error( __( 'Refund failed validation, ship to country did not pass validation', 'wc-taxjar' ) );
+			$this->add_error( __( 'Parent order ship to country is not supported for reporting and filing. Only orders shipped to the following countries will sync to TaxJar: ', 'wc-taxjar' ) . implode( ", ", TaxJar_Record::allowed_countries()) );
 			return false;
 		}
 
 		if ( ! in_array( $this->object->get_currency(), TaxJar_Record::allowed_currencies() ) ) {
-			$this->add_error( __( 'Refund failed validation, currency did not pass validation.', 'wc-taxjar' ) );
+			$this->add_error( __( 'Refund currency is not supported. Only refunds with the following currencies will sync to TaxJar: ', 'wc-taxjar' ) . implode( ", ", TaxJar_Record::allowed_currencies() ) );
 			return false;
 		}
 
 		if ( ! $this->has_valid_ship_from_address() ) {
-			$this->add_error( __( 'Refund failed validation - missing required ship from field on parent order', 'wc-taxjar' ) );
+			$this->add_error( __( 'Parent order is missing required ship from field.', 'wc-taxjar' ) );
 			return false;
 		}
 
 		if ( empty( $data[ 'to_country' ] ) || empty( $data[ 'to_state' ] ) || empty( $data[ 'to_zip' ] ) || empty( $data[ 'to_city' ] ) ) {
-			$this->add_error( __( 'Refund failed validation - missing required ship to field on parent order.', 'wc-taxjar' ) );
+			$this->add_error( __( 'Parent order is missing required ship to field', 'wc-taxjar' ) );
 			return false;
 		}
 
@@ -72,7 +72,12 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 
 	public function sync_success() {
 		parent::sync_success();
-		$this->add_object_sync_metadata();
+		$this->update_object_sync_success_meta_data();
+	}
+
+	public function sync_failure( $error_message ) {
+		parent::sync_failure( $error_message );
+		$this->update_object_sync_failure_meta_data( $error_message );
 	}
 
 	public function get_data_from_object() {
@@ -97,7 +102,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		$from_zip         = $store_settings['postcode'];
 		$from_city        = $store_settings['city'];
 		$from_street      = $store_settings['street'];
-		
+
 		$amount = $this->object->get_amount() - abs( $this->object->get_total_tax() );
 
 		$ship_to_address = $this->get_ship_to_address( $order );

--- a/includes/class-taxjar-tax-calculation.php
+++ b/includes/class-taxjar-tax-calculation.php
@@ -38,6 +38,18 @@ class TaxJar_Tax_Calculation {
 		add_filter( 'wcs_new_order_created', array( $this, 'calculate_renewal_order_totals' ), 10, 3 );
 
 		add_action( 'woocommerce_order_after_calculate_totals', array( $this, 'maybe_calculate_order_taxes' ), 10, 2 );
+		add_action( 'woocommerce_checkout_create_order', array( $this, 'persist_cart_calculation_results_to_order'), 10, 1 );
+		add_action( 'woocommerce_checkout_create_subscription', array( $this, 'persist_recurring_cart_calculation_results_to_subscription'), 10, 4 );
+	}
+
+	public function persist_cart_calculation_results_to_order( $order ) {
+		$calculation_results = WC()->cart->tax_calculation_results;
+		$order->update_meta_data( '_taxjar_tax_result', $calculation_results );
+	}
+
+	public function persist_recurring_cart_calculation_results_to_subscription(  $subscription, $posted_data, $order, $recurring_cart ) {
+		$calculation_results = $recurring_cart->tax_calculation_results;
+		$subscription->update_meta_data( '_taxjar_tax_result', $calculation_results );
 	}
 
 	public function maybe_calculate_order_taxes( $and_taxes, $order ) {

--- a/includes/class-taxjar-tax-calculation.php
+++ b/includes/class-taxjar-tax-calculation.php
@@ -144,7 +144,7 @@ class TaxJar_Tax_Calculation {
 	 * @return bool
 	 */
 	private function is_mini_cart() {
-		return is_cart() && is_ajax();
+		return is_cart() && wp_doing_ajax();
 	}
 
 	/**

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 			TaxJar_Settings::init();
 			$this->tax_calculations = new TaxJar_Tax_Calculation();
 
-			if ( $this->on_settings_page() ) {
+			if ( is_admin() ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_assets' ) );
 			}
 
@@ -53,6 +53,8 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 				// Scripts / Stylesheets
 				add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_new_order_assets' ) );
 			}
+
+			new \TaxJar\Admin_Meta_Boxes();
 		}
 
 		/**
@@ -215,15 +217,6 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		private function is_order_post_type( $post_type ) {
 			$allowed_post_types = array( 'shop_order', 'shop_subscription' );
 			return in_array( $post_type, $allowed_post_types, true );
-		}
-
-		/**
-		 * Checks if currently on the TaxJar settings page
-		 *
-		 * @return boolean
-		 */
-		public function on_settings_page() {
-			return ( isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'taxjar-integration' === $_GET['tab'] );
 		}
 
 		/**

--- a/includes/css/admin.css
+++ b/includes/css/admin.css
@@ -1,17 +1,3 @@
-/* Remove Calculate Taxes button */
-#poststuff #woocommerce-order-totals .buttons .calc_line_taxes {
-	display: none !important;
-}
-
-/* Remove Add Tax Row Button */
-.add_total_row {
-	display: none !important;
-}
-
-.add-order-tax {
-	display: none !important;
-}
-
 .widefat .column-taxjar_actions a.button {
 	display: block;
 	text-indent: -9999px;
@@ -90,4 +76,144 @@ div.taxjar-connected p {
 
 .woocommerce table.form-table th label[for="woocommerce_taxjar-integration_settings[api_token]"] {
 	display: none;
+}
+
+#taxjar_order_data.panel-wrap {
+	overflow: hidden;
+}
+
+#taxjar_order_data ul.wc-tabs {
+	margin: 0;
+	width: 20%;
+	float: left;
+	line-height: 1em;
+	padding: 0 0 10px;
+	position: relative;
+	background-color: #fafafa;
+	border-right: 1px solid #eee;
+	box-sizing: border-box;
+}
+
+#taxjar_order_data ul.wc-tabs li {
+	margin: 0;
+	padding: 0;
+	display: block;
+	position: relative;
+}
+
+#taxjar_order_data ul.wc-tabs li a {
+	margin: 0;
+	padding: 10px;
+	display: block;
+	box-shadow: none;
+	text-decoration: none;
+	line-height: 20px!important;
+	border-bottom: 1px solid #eee;
+}
+
+#taxjar_order_data ul.wc-tabs li.active a {
+	color: #555;
+	position: relative;
+	background-color: #eee;
+}
+
+#taxjar_order_data ul.wc-tabs li a::before {
+	font-family: Dashicons;
+	speak: never;
+	font-weight: 400;
+	font-variant: normal;
+	text-transform: none;
+	line-height: 1;
+	-webkit-font-smoothing: antialiased;
+	content: "";
+	text-decoration: none;
+}
+
+#taxjar_order_data .wc-metaboxes-wrapper, #taxjar_order_data .woocommerce_options_panel {
+	float: left;
+	width: 80%;
+}
+
+#taxjar.postbox .inside {
+	margin: 0;
+	padding: 0;
+}
+
+#taxjar_order_data ul.wc-tabs li.calculation_status_tab a::before, #taxjar_order_data ul.wc-tabs li.sync_status_tab a::before {
+	content: "\f226";
+}
+
+#taxjar_order_data ul.wc-tabs li.advanced_tab a::before {
+	content: "\f111";
+}
+
+#taxjar_order_data ul.wc-tabs li a span {
+	margin-left: 0.618em;
+	margin-right: 0.618em;
+}
+
+#taxjar_order_data ul.wc-tabs::after {
+	content: "";
+	display: block;
+	width: 100%;
+	height: 9999em;
+	position: absolute;
+	bottom: -9999em;
+	left: 0;
+	background-color: #fafafa;
+	border-right: 1px solid #eee;
+}
+
+#calculation_status_order_data label span.calculation-status-icon::before {
+	font-family: Dashicons;
+	speak: never;
+	font-weight: 400;
+	font-variant: normal;
+	text-transform: none;
+	line-height: 1;
+	-webkit-font-smoothing: antialiased;
+	content: "";
+	text-decoration: none;
+}
+
+#calculation_status_order_data label span.calculation-status-icon.success::before {
+	content: "\f159";
+	color: #5b841b;
+	background-color: #5b841b;
+	border-radius: 50%;
+}
+
+#calculation_status_order_data label span.calculation-status-icon.fail::before {
+	content: "\f153";
+	color: #d63638;
+}
+
+#calculation_status_order_data label span.calculation-status-icon.unknown::before {
+	content: "\f348";
+	color: #dba617;
+}
+
+#advanced_order_data pre {
+	margin: 0 0 9px;
+	font-size: 12px;
+	padding: 5px 9px;
+	line-height: 24px;
+	max-width: 95%;
+}
+
+#calculation_status_order_data .description {
+	font-style: italic;
+	margin: 0px;
+}
+
+#advanced_order_data .accordion-section-title {
+	font-size: 12px;
+}
+
+#advanced_order_data span.copy-button.dashicons.dashicons-clipboard {
+	float: right;
+	margin-right: 20px;
+	font-size: 14px;
+	vertical-align: middle;
+	margin-top: 2px;
 }

--- a/includes/css/admin.css
+++ b/includes/css/admin.css
@@ -217,3 +217,38 @@ div.taxjar-connected p {
 	vertical-align: middle;
 	margin-top: 2px;
 }
+
+#sync_status_order_data span.sync-status::before {
+	font-family: Dashicons;
+	speak: never;
+	font-weight: 400;
+	font-variant: normal;
+	text-transform: none;
+	line-height: 1;
+	-webkit-font-smoothing: antialiased;
+	content: "";
+	text-decoration: none;
+	margin-left: 15px;
+	vertical-align: middle;
+}
+
+#sync_status_order_data span.sync-status.synced::before {
+	content: "\f159";
+	color: #5b841b;
+	background-color: #5b841b;
+	border-radius: 50%;
+}
+
+#sync_status_order_data span.sync-status.not-synced::before {
+	content: "\f159";
+	color: #dcdcde;
+	background-color: #dcdcde;
+	border-radius: 50%;
+}
+
+#sync_status_order_data span.sync-status.failed::before {
+	content: "\f159";
+	color: #d63638;
+	background-color: #d63638;
+	border-radius: 50%;
+}

--- a/includes/interfaces/class-tax-calculation-result-data-store.php
+++ b/includes/interfaces/class-tax-calculation-result-data-store.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Tax Calculation Result Data Store Interface
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+interface Tax_Calculation_Result_Data_Store {
+
+	/**
+	 * Persists calculation result on object.
+	 *
+	 * @param Tax_Calculation_Result $calculation_result Calculation result.
+	 *
+	 * @return void
+	 */
+	public function update( Tax_Calculation_Result $calculation_result );
+
+}

--- a/includes/js/wc-taxjar-order.js
+++ b/includes/js/wc-taxjar-order.js
@@ -34,4 +34,42 @@ jQuery( document ).ready( function() {
 			}
 		} );
 	}( jQuery, TaxJarOrder || {} ) );
+
+	var taxjar_order_calculation_meta = {
+		init: function() {
+			jQuery( '#advanced_order_data .request-json .copy-button' )
+				.on( 'click', this.copy_request_json )
+				.on( 'aftercopy', this.copy_success );
+
+			jQuery( '#advanced_order_data .response-json .copy-button' )
+				.on( 'click', this.copy_response_json )
+				.on( 'aftercopy', this.copy_success );
+		},
+
+		copy_request_json: function( e ) {
+			wcClearClipboard();
+			wcSetClipboard( jQuery('#advanced_order_data .request-json .accordion-section-content pre').text(), jQuery( this ) );
+			e.preventDefault();
+			e.stopPropagation();
+		},
+
+		copy_response_json: function( e ) {
+			wcClearClipboard();
+			wcSetClipboard( jQuery('#advanced_order_data .response-json .accordion-section-content pre').text(), jQuery( this ) );
+			e.preventDefault();
+			e.stopPropagation();
+		},
+
+		copy_success: function() {
+			jQuery( this ).tipTip({
+				'attribute':  'data-tip',
+				'activation': 'focus',
+				'fadeIn':     50,
+				'fadeOut':    50,
+				'delay':      0
+			}).focus().focus();
+		}
+	};
+
+	taxjar_order_calculation_meta.init();
 });

--- a/includes/js/wc-taxjar-order.js
+++ b/includes/js/wc-taxjar-order.js
@@ -34,42 +34,4 @@ jQuery( document ).ready( function() {
 			}
 		} );
 	}( jQuery, TaxJarOrder || {} ) );
-
-	var taxjar_order_calculation_meta = {
-		init: function() {
-			jQuery( '#advanced_order_data .request-json .copy-button' )
-				.on( 'click', this.copy_request_json )
-				.on( 'aftercopy', this.copy_success );
-
-			jQuery( '#advanced_order_data .response-json .copy-button' )
-				.on( 'click', this.copy_response_json )
-				.on( 'aftercopy', this.copy_success );
-		},
-
-		copy_request_json: function( e ) {
-			wcClearClipboard();
-			wcSetClipboard( jQuery('#advanced_order_data .request-json .accordion-section-content pre').text(), jQuery( this ) );
-			e.preventDefault();
-			e.stopPropagation();
-		},
-
-		copy_response_json: function( e ) {
-			wcClearClipboard();
-			wcSetClipboard( jQuery('#advanced_order_data .response-json .accordion-section-content pre').text(), jQuery( this ) );
-			e.preventDefault();
-			e.stopPropagation();
-		},
-
-		copy_success: function() {
-			jQuery( this ).tipTip({
-				'attribute':  'data-tip',
-				'activation': 'focus',
-				'fadeIn':     50,
-				'fadeOut':    50,
-				'delay':      0
-			}).focus().focus();
-		}
-	};
-
-	taxjar_order_calculation_meta.init();
 });

--- a/readme.txt
+++ b/readme.txt
@@ -2,12 +2,12 @@
 Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 5.4
-Tested up to: 5.8.2
-Stable tag: 4.0.1
+Tested up to: 5.8.3
+Stable tag: 4.1.0
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
-WC requires at least: 5.4.0
-WC tested up to: 5.9.0
+WC requires at least: 5.6.0
+WC tested up to: 6.1.0
 
 Trusted by more than 20,000 businesses, TaxJar’s award-winning solution makes it easy to automate sales tax reporting and filing, and determine economic nexus with a single click.
 
@@ -94,6 +94,12 @@ Our plans come with filings included, with additional filings available for purc
 3. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 4.1.0 (2022-01-19)
+* Add order meta box to give details of calculation and sync statuses
+* Remove usage of deprecated function is_ajax
+* WooCommerce tested up to 6.1
+* Update minimum WordPress version to 5.6
 
 = 4.0.1 (2021-11-19)
 * Change dynamic tax rate ID to 999999999 to help prevent issues with 3rd parties ingesting exported WooCommerce order data

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -68,6 +68,7 @@ final class WC_Taxjar {
 			include_once 'includes/interfaces/class-tax-client-interface.php';
 			include_once 'includes/interfaces/class-tax-applicator-interface.php';
 			include_once 'includes/interfaces/class-tax-calculation-validator-interface.php';
+			include_once 'includes/interfaces/class-tax-calculation-result-data-store.php';
 
 			// Include our integration class and WP_User for wp_delete_user()
 			include_once ABSPATH . 'wp-admin/includes/user.php';
@@ -114,6 +115,8 @@ final class WC_Taxjar {
 			include_once 'includes/TaxCalculation/class-tax-calculation-result.php';
 			include_once 'includes/TaxCalculation/class-cart-calculation-logger.php';
 			include_once 'includes/TaxCalculation/class-tax-builder.php';
+			include_once 'includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php';
+			include_once 'includes/TaxCalculation/class-order-tax-calculation-result-data-store.php';
 
 			// Register the integration.
 			add_action( 'woocommerce_integrations_init', array( $this, 'add_integration' ), 20 );

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -118,6 +118,9 @@ final class WC_Taxjar {
 			include_once 'includes/TaxCalculation/class-cart-tax-calculation-result-data-store.php';
 			include_once 'includes/TaxCalculation/class-order-tax-calculation-result-data-store.php';
 
+			include_once 'includes/admin/class-admin-meta-boxes.php';
+			include_once 'includes/admin/class-order-meta-box.php';
+
 			// Register the integration.
 			add_action( 'woocommerce_integrations_init', array( $this, 'add_integration' ), 20 );
 

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,11 +3,11 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 4.0.1
+ * Version: 4.1.0
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
- * WC requires at least: 5.4.0
- * WC tested up to: 5.9.0
+ * WC requires at least: 5.6.0
+ * WC tested up to: 6.1.0
  * Requires PHP: 7.0
  *
  * Copyright: © 2014-2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc.
@@ -43,8 +43,8 @@ if ( ! $woocommerce_active || version_compare( get_option( 'woocommerce_db_versi
  */
 final class WC_Taxjar {
 
-	static $version = '4.0.1';
-	public static $minimum_woocommerce_version = '5.4.0';
+	static $version = '4.1.0';
+	public static $minimum_woocommerce_version = '5.6.0';
 
 	/**
 	 * Construct the plugin.

--- a/tests/specs/tax-calculation/test-cart-tax-result-data-store.php
+++ b/tests/specs/tax-calculation/test-cart-tax-result-data-store.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TaxJar;
+
+use WP_UnitTestCase;
+
+class Test_Cart_Tax_Result_Data_Store extends WP_UnitTestCase {
+
+	public function tearDown() {
+		WC()->cart->empty_cart();
+		unset( WC()->cart->tax_calculation_results );
+		parent::tearDown();
+	}
+
+	function test_result_is_stored_on_cart() {
+		$test_json = 'test';
+		$cart = WC()->cart;
+		$result_stub = $this->createMock( Tax_Calculation_Result::class );
+		$result_stub->method( 'to_json' )->willReturn( $test_json );
+		$cart_result_data_store = new Cart_Tax_Calculation_Result_Data_Store( $cart );
+
+		$cart_result_data_store->update( $result_stub );
+
+		$this->assertEquals( $test_json, $cart->tax_calculation_results );
+	}
+}

--- a/tests/specs/tax-calculation/test-order-tax-calculator.php
+++ b/tests/specs/tax-calculation/test-order-tax-calculator.php
@@ -17,6 +17,7 @@ class Test_Order_Tax_Calculator extends WP_UnitTestCase {
 	private $mock_tax_details;
 	private $mock_order;
 	private $mock_validator;
+	private $mock_tax_result_data_store;
 
 	public function setUp() {
 		$this->mock_request_body = $this->createMock( Tax_Request_Body::class );
@@ -33,6 +34,7 @@ class Test_Order_Tax_Calculator extends WP_UnitTestCase {
 		$this->mock_logger     = $this->createMock( Tax_Calculation_Logger::class );
 		$this->mock_cache      = $this->createMock( Cache_Interface::class );
 		$this->mock_applicator = $this->createMock( Tax_Applicator_Interface::class );
+		$this->mock_tax_result_data_store = $this->createMock( Order_Tax_Calculation_Result_Data_Store::class );
 		$this->mock_order      = $this->createMock( WC_Order::class );
 
 		$this->mock_validator = $this->createMock( Tax_Calculation_Validator_Interface::class );
@@ -63,6 +65,7 @@ class Test_Order_Tax_Calculator extends WP_UnitTestCase {
 		$calculator->set_applicator( $this->mock_applicator );
 		$calculator->set_validator( $this->mock_validator );
 		$calculator->set_context( 'test' );
+		$calculator->set_result_data_store( $this->mock_tax_result_data_store );
 		return $calculator;
 	}
 }

--- a/tests/specs/tax-calculation/test-order-tax-result-data-store.php
+++ b/tests/specs/tax-calculation/test-order-tax-result-data-store.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TaxJar;
+
+use WP_UnitTestCase;
+
+class Test_Order_Tax_Result_Data_Store extends WP_UnitTestCase {
+
+	function test_result_is_stored_on_cart() {
+		$test_json = 'test';
+		$order = new \WC_Order();
+		$result_stub = $this->createMock( Tax_Calculation_Result::class );
+		$result_stub->method( 'to_json' )->willReturn( $test_json );
+		$cart_result_data_store = new Order_Tax_Calculation_Result_Data_Store( $order );
+
+		$cart_result_data_store->update( $result_stub );
+
+		$this->assertEquals( $test_json, $order->get_meta( '_taxjar_tax_result' ) );
+	}
+}

--- a/tests/specs/test-transaction-sync.php
+++ b/tests/specs/test-transaction-sync.php
@@ -280,6 +280,7 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 		$record->sync_failure( "Last Error" );
 
 		$updated_record = new TaxJar_Order_Record( $order->get_id() );
+		$updated_record->load_object();
 		$updated_record->set_queue_id( $record->get_queue_id() );
 		$updated_record->read();
 
@@ -1408,7 +1409,7 @@ class TJ_WC_Test_Sync extends WP_UnitTestCase {
 
 		$noncomplete_order = $this->create_test_order( 1 );
 		$noncomplete_order_refund = $this->create_test_refund( $noncomplete_order->get_id() );
-		
+
 		$synced_order = $this->create_test_order( 1 );
 		$synced_order->update_status( 'completed' );
 		$synced_order_refund = $this->create_test_refund( $synced_order->get_id() );


### PR DESCRIPTION
This PR adds a feature that displays the calculation and transaction sync statuses, any associated errors, etc. in a meta box on the admin order view.

It also includes a minor fix to remove the usage of the deprecated is_ajax function and the versioning bump to version 4.1.0.

**Click-Test Versions**

- [X] Woo 6.1
- [X] Woo 5.6

**Specs Passing**

- [X] Woo 6.1
- [X] Woo 5.6
