### PR TITLE
Add support for customer sync with REST API and Import Suite

### DIFF
--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -82,7 +82,7 @@ abstract class TaxJar_Record {
 		global $wpdb;
 		$insert = array(
 			'record_id'          => $this->get_record_id(),
-			'record_type'        => $this->get_record_type(),
+			'record_type'        => static::get_record_type(),
 			'status'             => $this->get_status(),
 			'batch_id'           => $this->get_batch_id(),
 			'created_datetime'   => $this->get_created_datetime(),
@@ -123,7 +123,7 @@ abstract class TaxJar_Record {
 		$data = array(
 			'record_id' => $this->get_record_id(),
 			'status' => $this->get_status(),
-			'record_type' => $this->get_record_type(),
+			'record_type' => static::get_record_type(),
 			'force_push' => $this->get_force_push()
 		);
 
@@ -171,8 +171,8 @@ abstract class TaxJar_Record {
 	public function sync() {
 		try {
 			$this->clear_error();
-			$this->log( 'Attempting to sync ' . $this->get_record_type() . ' # ' . $this->get_record_id() . ' (Queue # ' . $this->get_queue_id() . ')' );
-			if ( ! apply_filters( 'taxjar_should_sync_' . $this->get_record_type(), $this->should_sync() ) ) {
+			$this->log( 'Attempting to sync ' . static::get_record_type() . ' # ' . $this->get_record_id() . ' (Queue # ' . $this->get_queue_id() . ')' );
+			if ( ! apply_filters( 'taxjar_should_sync_' . static::get_record_type(), $this->should_sync() ) ) {
 				if ( $this->get_error() ) {
 					$this->sync_failure( $this->get_error()[ 'message' ] );
 				} else {
@@ -272,7 +272,7 @@ abstract class TaxJar_Record {
 	}
 
 	public function log( $message ) {
-		if ( $this->get_record_type() == 'customer' ) {
+		if ( static::get_record_type() == 'customer' ) {
 			$this->taxjar_integration->customer_sync->_log( $message );
 		} else {
 			$this->taxjar_integration->transaction_sync->_log( $message );
@@ -345,7 +345,7 @@ abstract class TaxJar_Record {
 	abstract function get_from_taxjar();
 
 	public function get_provider() {
-		return apply_filters( 'taxjar_get_' . $this->get_record_type() . '_provider', 'woo', $this->object, $this );
+		return apply_filters( 'taxjar_get_' . static::get_record_type() . '_provider', 'woo', $this->object, $this );
 	}
 
 	/**
@@ -358,7 +358,8 @@ abstract class TaxJar_Record {
 		global $wpdb;
 
 		$table_name = self::get_queue_table_name();
-		$query = "SELECT queue_id FROM {$table_name} WHERE record_id = {$record_id} AND status IN ( 'new', 'awaiting' )";
+		$record_type = static::get_record_type();
+		$query = "SELECT queue_id FROM {$table_name} WHERE record_id = {$record_id} AND record_type = '{$record_type}' AND status IN ( 'new', 'awaiting' )";
 		$results = $wpdb->get_results( $query,  ARRAY_A );
 
 		if ( empty( $results ) || ! is_array( $results ) ) {
@@ -471,7 +472,7 @@ abstract class TaxJar_Record {
 		return $this->record_id;
 	}
 
-	abstract function get_record_type();
+	abstract static function get_record_type();
 
 	public function set_status( $status ) {
 		$this->status = $status;

--- a/includes/class-taxjar-customer-record.php
+++ b/includes/class-taxjar-customer-record.php
@@ -31,7 +31,7 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	/**
 	 * @return string - customer record type
 	 */
-	public function get_record_type() {
+	public static function get_record_type() {
 		return 'customer';
 	}
 
@@ -153,7 +153,7 @@ class TaxJar_Customer_Record extends TaxJar_Record {
 	public function get_data_from_object() {
 		$customer_data = array();
 
-		$customer_data['customer_id']    = $this->get_customer_id();
+		$customer_data['customer_id']    = strval( $this->get_customer_id() );
 		$customer_data['name']           = $this->get_customer_name();
 		$customer_data['exemption_type'] = $this->get_exemption_type();
 		$customer_data['exempt_regions'] = $this->get_exempt_regions();

--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -24,7 +24,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 		parent::load_object();
 	}
 
-	public function get_record_type() {
+	public static function get_record_type() {
 		return 'order';
 	}
 

--- a/includes/class-taxjar-refund-record.php
+++ b/includes/class-taxjar-refund-record.php
@@ -317,7 +317,7 @@ class TaxJar_Refund_Record extends TaxJar_Record {
 		return $response;
 	}
 
-	public function get_record_type() {
+	public static function get_record_type() {
 		return 'refund';
 	}
 

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -192,7 +192,7 @@ class WC_Taxjar_Transaction_Sync {
 			$previous_sync_datetime = $record->object->get_meta( '_taxjar_last_sync', true );
 			$result = $record->sync();
 
-			if ( $result && $record->get_record_type() == 'order' ) {
+			if ( $result && $record::get_record_type() == 'order' ) {
 				if ( empty( $previous_sync_datetime ) ) {
 					$record->object->add_order_note( __( 'Order synced to TaxJar', 'taxjar' ) );
 				}
@@ -651,11 +651,11 @@ class WC_Taxjar_Transaction_Sync {
 
 		$posts = $wpdb->get_results(
 			"
-			SELECT p.id 
-			FROM {$wpdb->posts} AS p 
-			WHERE p.post_type = 'shop_order_refund' 
-			AND p.post_status = 'wc-completed' 
-			AND p.post_parent IN ( {$order_ids_string} ) 
+			SELECT p.id
+			FROM {$wpdb->posts} AS p
+			WHERE p.post_type = 'shop_order_refund'
+			AND p.post_status = 'wc-completed'
+			AND p.post_parent IN ( {$order_ids_string} )
 			ORDER BY p.post_date ASC
 			", ARRAY_N
 		);


### PR DESCRIPTION
This PR adds support for syncing customers to TaxJar in some common scenarios that weren't previously handled. This includes syncing a customer to TaxJar when the customer is created or updated through the WooCommerce REST API and when a customer is created or updated through the WooCommerce Customer/Order/Coupon CSV Import Suite.

**Click-Test Versions**

- [X] Woo 6.1
- [X] Woo 5.6

**Specs Passing**

- [X] Woo 6.1
- [X] Woo 5.6
