### PR TITLE
Add compatibility module for WooCommerce Gift Cards plugin

### DIFF
--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -168,13 +168,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 		$from_street      = $store_settings['street'];
 
 		$amount = $this->object->get_total() - wc_round_tax_total( $this->object->get_total_tax() );
-
-		// gift card use with Smart Coupons plugin cause discrepancy between total and sum of line items
-		if ( class_exists( 'WC_SC_Order_Fields' ) ) {
-			$smart_coupons_order_fields = WC_SC_Order_Fields::get_instance();
-			$total_credit_used = $smart_coupons_order_fields->get_total_credit_used_in_order( $this->object );
-			$amount += $total_credit_used;
-		}
+		$amount = apply_filters( 'taxjar_order_total_amount', $amount, $this->object );
 
 		$ship_to_address = $this->get_ship_to_address();
 		$order_data = array(

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -40,6 +40,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 			$this->download_orders    = new WC_Taxjar_Download_Orders( $this );
 			$this->transaction_sync   = new WC_Taxjar_Transaction_Sync( $this );
 			$this->customer_sync      = new WC_Taxjar_Customer_Sync( $this );
+			$this->module_loader      = new \TaxJar\Module_Loader();
 
 			// Load the settings.
 			TaxJar_Settings::init();

--- a/includes/compatibility/abstract-class-module.php
+++ b/includes/compatibility/abstract-class-module.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Abstract class for compatibility modules.
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+/**
+ * Abstract class Module
+ */
+abstract class Module {
+
+	/**
+	 * Determine if the compatibility module should be loaded.
+	 *
+	 * @return bool
+	 */
+	abstract public function should_load(): bool;
+
+	/**
+	 * Load the compatibility module.
+	 *
+	 * @return mixed
+	 */
+	abstract public function load();
+}

--- a/includes/compatibility/class-module-loader.php
+++ b/includes/compatibility/class-module-loader.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Loads compatibility modules
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+/**
+ * Class Module_Loader
+ */
+class Module_Loader {
+
+	/**
+	 * List of compatibility modules to load
+	 *
+	 * @var string[]
+	 */
+	private $extensions = array(
+		'\TaxJar\WooCommerce_Gift_Cards',
+		'\TaxJar\WooCommerce_Smart_Coupons',
+	);
+
+	/**
+	 * Add necessary actions
+	 */
+	public function __construct() {
+		add_action( 'wp_loaded', array( $this, 'load_modules' ) );
+	}
+
+	/**
+	 * Load compatibility modules
+	 */
+	public function load_modules() {
+		foreach ( $this->extensions as $extension_class ) {
+			$extension = new $extension_class();
+
+			if ( $extension->should_load() ) {
+				$extension->load();
+			}
+		}
+	}
+}

--- a/includes/compatibility/modules/class-woocommerce-gift-cards.php
+++ b/includes/compatibility/modules/class-woocommerce-gift-cards.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Compatibility module for WooCommerce Gift Cards plugin
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+/**
+ * Class WooCommerce_Gift_Cards
+ */
+class WooCommerce_Gift_Cards extends Module {
+
+	/**
+	 * Determine if the module should be loaded
+	 *
+	 * @return bool
+	 */
+	public function should_load(): bool {
+		return class_exists( 'WC_Gift_Cards' );
+	}
+
+	/**
+	 * Load module
+	 *
+	 * @return void
+	 */
+	public function load() {
+		add_filter( 'taxjar_order_total_amount', array( $this, 'add_gift_card_usage_to_total' ), 10, 2 );
+	}
+
+	/**
+	 * Add gift card amount used to order total
+	 *
+	 * @param int|float $total_amount Order total.
+	 * @param \WC_Order $order Order.
+	 *
+	 * @return mixed
+	 */
+	public function add_gift_card_usage_to_total( $total_amount, $order ) {
+		$giftcards_total = WC_GC()->order->get_gift_cards( $order );
+		if ( $giftcards_total['total'] > 0 ) {
+			$total_amount = $total_amount + $giftcards_total['total'];
+		}
+
+		return $total_amount;
+	}
+}

--- a/includes/compatibility/modules/class-woocommerce-smart-coupons.php
+++ b/includes/compatibility/modules/class-woocommerce-smart-coupons.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Compatibility module for WooCommerce Smart Coupons plugin
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+/**
+ * Class WooCommerce_Smart_Coupons
+ */
+class WooCommerce_Smart_Coupons extends Module {
+
+	/**
+	 * Determine if the module should be loaded
+	 *
+	 * @return bool
+	 */
+	public function should_load(): bool {
+		return class_exists( 'WC_SC_Order_Fields' );
+	}
+
+	/**
+	 * Load module
+	 *
+	 * @return void
+	 */
+	public function load() {
+		add_filter( 'taxjar_order_total_amount', array( $this, 'add_gift_card_credits_to_total' ), 10, 2 );
+	}
+
+	/**
+	 * Add credit used to order total
+	 *
+	 * @param int|float $total_amount Order total.
+	 * @param \WC_Order $order Order.
+	 *
+	 * @return mixed
+	 */
+	public function add_gift_card_credits_to_total( $total_amount, $order ) {
+		$smart_coupons_order_fields = \WC_SC_Order_Fields::get_instance();
+		$total_credit_used          = $smart_coupons_order_fields->get_total_credit_used_in_order( $order );
+		$total_amount              += $total_credit_used;
+
+		return $total_amount;
+	}
+}

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -121,6 +121,11 @@ final class WC_Taxjar {
 			include_once 'includes/admin/class-admin-meta-boxes.php';
 			include_once 'includes/admin/class-order-meta-box.php';
 
+			include_once 'includes/compatibility/abstract-class-module.php';
+			include_once 'includes/compatibility/class-module-loader.php';
+			include_once 'includes/compatibility/modules/class-woocommerce-gift-cards.php';
+			include_once 'includes/compatibility/modules/class-woocommerce-smart-coupons.php';
+
 			// Register the integration.
 			add_action( 'woocommerce_integrations_init', array( $this, 'add_integration' ), 20 );
 


### PR DESCRIPTION
This PR adds a new abstraction layer for compatibility modules. This makes it easier to maintain support for other plugins. Additionally a module was added for the WooCommerce Gift Cards plugin to resolve a conflict.

**Steps to Reproduce**

1. Create an order and use a gift card for a portion of the payment.
2. Complete the order and attempt to sync it to TaxJar
3. The order will fail to sync and the logs will indicate that the amount did not match the line items.

**Expected Result**

After applying the PR, the order will successfully sync.

**Click-Test Versions**

- [X] Woo 6.1
- [X] Woo 5.6

**Specs Passing**

- [X] Woo 6.1
- [X] Woo 5.6
