### PR TITLE
Improves stored tax rate precision

### DIFF
--- a/includes/TaxCalculation/class-cart-tax-applicator.php
+++ b/includes/TaxCalculation/class-cart-tax-applicator.php
@@ -78,7 +78,17 @@ class Cart_Tax_Applicator extends Tax_Applicator {
 
 		foreach ( $this->cart->get_cart() as $item_key => $item ) {
 			$total_taxes           = $this->apply_line_total_tax( $item_key, $item );
-			$applied_rate          = empty( $item['line_total'] ) ? 0.0 : reset( $total_taxes ) / wc_add_number_precision( $item['line_total'] );
+			$tax_detail_key		   = $item['product_id'] . '-' . $item_key;
+			$tax_detail_line_item  = $this->tax_details->get_line_item($tax_detail_key);
+
+			if ( empty( $item['line_total'] ) ) {
+				$applied_rate = 0.0;
+			} elseif ( $tax_detail_line_item ) {
+				$applied_rate = $tax_detail_line_item->get_tax_rate();
+			} else {
+				$applied_rate = reset( $total_taxes ) / wc_add_number_precision( $item['line_total'] );
+			}
+
 			$subtotal_taxes        = $this->apply_line_subtotal_tax( $item_key, $item, $applied_rate );
 			$merged_subtotal_taxes = $this->merge_tax_arrays( $merged_subtotal_taxes, $subtotal_taxes );
 			$merged_total_taxes    = $this->merge_tax_arrays( $merged_total_taxes, $total_taxes );

--- a/includes/TaxCalculation/class-order-tax-applicator.php
+++ b/includes/TaxCalculation/class-order-tax-applicator.php
@@ -87,7 +87,17 @@ class Order_Tax_Applicator extends Tax_Applicator {
 		$tax_class      = $item->get_tax_class();
 		$total_taxes    = wc_remove_number_precision_deep( $this->tax_builder->get_line_tax( $line_item_key, $tax_class ) );
 		$total_tax      = array_sum( $total_taxes );
-		$applied_rate   = empty( $item->get_total() ) ? 0.0 : $total_tax / $item->get_total();
+
+		$tax_detail_line_item = $this->tax_details->get_line_item($line_item_key);
+
+		if ( empty( $item['line_total'] ) ) {
+			$applied_rate = 0.0;
+		} elseif ( $tax_detail_line_item ) {
+			$applied_rate = $tax_detail_line_item->get_tax_rate();
+		} else {
+			$applied_rate = $total_tax / wc_add_number_precision( $item['line_total'] );
+		}
+
 		$subtotal_taxes = $this->tax_builder->build_line_tax_from_rate( $applied_rate, $item->get_subtotal(), $tax_class );
 		$taxes          = array(
 			'total'    => $total_taxes,


### PR DESCRIPTION
Closes #221  

During tax calculation, the TaxJar plugin correctly stores the location's rate from the TaxJar API, but then overwrites the stored rate when calculating cart and order line subtotals with a "reconstructed" `$applied_rate` that is reverse-engineered from the line total. Rounding line item tax amounts in previous steps can lead to a loss of float precision when reconstructing the tax rate.

This PR adds an additional check for the existence of line item tax directly on the tax detail object before attempting to reconstruct an applied rate from item totals.

**Click-Test Versions**

- [X] Woo 5.9

**Specs Passing**

- [ ] Woo 5.9