### PR TITLE
Prevent calculated tax rates from being saved to database

### DIFF
--- a/includes/TaxCalculation/class-cart-tax-applicator.php
+++ b/includes/TaxCalculation/class-cart-tax-applicator.php
@@ -102,7 +102,7 @@ class Cart_Tax_Applicator extends Tax_Applicator {
 	private function apply_line_subtotal_tax( $item_key, $item, $applied_rate ): array {
 		$item_subtotal  = wc_add_number_precision( $item['line_subtotal'], false );
 		$tax_class      = $item['data']->get_tax_class();
-		$subtotal_taxes = $this->tax_builder->build_line_tax_from_rate( $applied_rate, $item_subtotal, $tax_class );
+		$subtotal_taxes = $this->tax_builder->build_line_tax_from_rate( $applied_rate, $item_subtotal, $tax_class, true );
 		$subtotal_tax   = array_sum( array_map( array( $this, 'round_line_tax' ), $subtotal_taxes ) );
 		$this->cart->cart_contents[ $item_key ]['line_tax_data']['subtotal'] = wc_remove_number_precision_deep( $subtotal_taxes );
 		$this->cart->cart_contents[ $item_key ]['line_subtotal_tax']         = wc_remove_number_precision( $subtotal_tax );

--- a/includes/TaxCalculation/class-order-tax-applicator.php
+++ b/includes/TaxCalculation/class-order-tax-applicator.php
@@ -88,7 +88,7 @@ class Order_Tax_Applicator extends Tax_Applicator {
 		$total_taxes    = wc_remove_number_precision_deep( $this->tax_builder->get_line_tax( $line_item_key, $tax_class ) );
 		$total_tax      = array_sum( $total_taxes );
 		$applied_rate   = empty( $item->get_total() ) ? 0.0 : $total_tax / $item->get_total();
-		$subtotal_taxes = $this->tax_builder->build_line_tax_from_rate( $applied_rate, $item->get_subtotal(), $tax_class );
+		$subtotal_taxes = $this->tax_builder->build_line_tax_from_rate( $applied_rate, $item->get_subtotal(), $tax_class, true );
 		$taxes          = array(
 			'total'    => $total_taxes,
 			'subtotal' => $subtotal_taxes,

--- a/includes/TaxCalculation/class-tax-builder.php
+++ b/includes/TaxCalculation/class-tax-builder.php
@@ -137,11 +137,12 @@ class Tax_Builder {
 	 * @param float  $applied_rate Tax rate to apply.
 	 * @param float  $taxable_amount Taxable amount.
 	 * @param string $tax_class Tax class.
+	 * @param bool   $prevent_save Prevent saving rate to WooCommerce
 	 *
 	 * @return array
 	 */
-	public function build_line_tax_from_rate( $applied_rate, $taxable_amount, $tax_class = '' ): array {
-		if ( $this->save_rates_enabled ) {
+	public function build_line_tax_from_rate( $applied_rate, $taxable_amount, $tax_class = '', $prevent_save = false ): array {
+		if ( $this->save_rates_enabled && $prevent_save !== true ) {
 			$woo_rate = $this->create_woocommerce_rate( $applied_rate * 100, $tax_class );
 			$wc_rate  = $this->build_woocommerce_rate( $applied_rate * 100, $woo_rate['id'] );
 		} else {


### PR DESCRIPTION
Closes #221 

This PR adds an optional parameter to Tax_Builder::build_line_tax_from_rate to prevent saving some tax rates to WooCommerce. This will prevent saving any tax rates that are calculated based on taxes applied to line items which are used as variables of other calculations.  Another solution to this would be to expose the private method `build_woocommerce_rate` but I wanted to get your feedback on this. I have ran this patch both in my staging environment and production now for a few days and everything has been going smooth.

## Here are some photos of the production data after the application of the patch.

![taxjar-api-rate](https://user-images.githubusercontent.com/3008677/158840355-6e741b8c-f3ac-4ad5-b33b-fa0b4fa60bcc.png)
**This is the tax rate for this orders ZIP code from the [taxjar sales tax calculator](https://www.taxjar.com/sales-tax-calculator).** 


![rates-saved-db-rate_percent-taxjar](https://user-images.githubusercontent.com/3008677/158841401-692e6de8-9e83-4801-81c1-a5a43dafb1b5.png)
**This is the tax rate saved to the order item which is the rate percent my customer uses to send to an upstream provider as explained in #221. It now matches the correct value from taxjar sales tax calculation.**




![rates-saved-db-woocommerce](https://user-images.githubusercontent.com/3008677/158840806-69426bf0-c039-4a68-b6c1-ee7fc22928c8.png)
**Here are various rates that have been calculated over the course of a few days for taxable orders. All of which are now matching the taxjar sales tax calculator values.**

**Click-Test Versions**

- [x] Woo 5.9

**Specs Passing**

- [ ] Woo 5.9
