### PR TITLE
Separate persisting woo rates from tax application

### DIFF
--- a/includes/TaxCalculation/class-rate-manager.php
+++ b/includes/TaxCalculation/class-rate-manager.php
@@ -9,6 +9,7 @@
 
 namespace TaxJar;
 
+use TaxJar_Settings;
 use WC_Tax;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/TaxCalculation/class-tax-builder.php
+++ b/includes/TaxCalculation/class-tax-builder.php
@@ -49,37 +49,37 @@ class Tax_Builder {
 	}
 
 	/**
-	 * Build line tax from tax details.
+	 * Build WooCommerce tax rate
 	 *
-	 * @param string $tax_details_line_key Key of tax detail line item.
+	 * @param float $rate_percent Rate percent of rate.
 	 * @param string $tax_class Tax class.
 	 *
-	 * @return array
-	 * @throws Exception When line item not found in tax details.
+	 * @return int|mixed
 	 */
-	public function get_line_tax( $tax_details_line_key, $tax_class = '' ): array {
-		$tax_details_line_item = $this->get_line_item_with_key( $tax_details_line_key );
-
+	public function build_woocommerce_tax_rate( $rate_percent, $tax_class = '' ) {
 		if ( $this->save_rates_enabled ) {
-			$rate_percent = $tax_details_line_item->get_tax_rate() * 100;
-			$woo_rate     = $this->create_woocommerce_rate( $rate_percent, $tax_class );
-			return $this->build_line_tax( $tax_details_line_item, $woo_rate['id'] );
+			$woo_rate     = $this->persist_woocommerce_tax_rate( $rate_percent, $tax_class );
+			return $woo_rate['id'];
 		} else {
-			return $this->build_line_tax( $tax_details_line_item );
+			return self::TAX_RATE_ID;
 		}
 	}
 
 	/**
-	 * Builds tax for a line item.
+	 * Build line tax from tax details.
 	 *
-	 * @param Tax_Detail_Line_Item $tax_details_line_item Tax details line item.
-	 * @param int                  $rate_id Rate ID of WooCommerce tax rate.
+	 * @param string $tax_details_line_key Key of tax detail line item.
+	 * @param integer $rate_id ID of WooCommerce tax rate.
 	 *
 	 * @return array
+	 * @throws Exception When line item not found in tax details.
 	 */
-	private function build_line_tax( Tax_Detail_Line_Item $tax_details_line_item, $rate_id = self::TAX_RATE_ID ) {
+	public function get_line_tax( $tax_details_line_key, $rate_id ): array {
+		$tax_details_line_item = $this->tax_details->get_line_item( $tax_details_line_key );
 		$amount_collectable = $tax_details_line_item->get_tax_collectable();
-		return $this->build_applied_tax_array( $rate_id, $amount_collectable );
+		return array(
+			$rate_id => wc_add_number_precision( $amount_collectable ),
+		);
 	}
 
 	/**
@@ -90,7 +90,7 @@ class Tax_Builder {
 	 *
 	 * @return array
 	 */
-	private function create_woocommerce_rate( $rate_percent, $tax_class = '' ) {
+	private function persist_woocommerce_tax_rate( $rate_percent, $tax_class = '' ) {
 		return Rate_Manager::add_rate(
 			$rate_percent,
 			$tax_class,
@@ -100,54 +100,16 @@ class Tax_Builder {
 	}
 
 	/**
-	 * Gets the tax detail line item using the given key.
-	 *
-	 * @param string $tax_details_line_key Key of tax detail line item.
-	 *
-	 * @return Tax_Detail_Line_Item
-	 * @throws Exception When line item not found in tax details.
-	 */
-	private function get_line_item_with_key( $tax_details_line_key ): Tax_Detail_Line_Item {
-		$tax_detail_line_item = $this->tax_details->get_line_item( $tax_details_line_key );
-
-		if ( false === $tax_detail_line_item ) {
-			throw new Exception( 'Line item not present in tax details.' );
-		}
-
-		return $tax_detail_line_item;
-	}
-
-	/**
-	 * Build the applied tax array.
-	 *
-	 * @param mixed $rate_id WooCommerce tax rate ID.
-	 * @param float $tax_amount Amount of tax to apply.
-	 *
-	 * @return array
-	 */
-	private function build_applied_tax_array( $rate_id, $tax_amount ): array {
-		return array(
-			$rate_id => wc_add_number_precision( $tax_amount ),
-		);
-	}
-
-	/**
 	 * Build the applied tax array using a tax rate.
 	 *
 	 * @param float  $applied_rate Tax rate to apply.
 	 * @param float  $taxable_amount Taxable amount.
-	 * @param string $tax_class Tax class.
+	 * @param integer $rate_id WooCommerce tax rate id.
 	 *
 	 * @return array
 	 */
-	public function build_line_tax_from_rate( $applied_rate, $taxable_amount, $tax_class = '' ): array {
-		if ( $this->save_rates_enabled ) {
-			$woo_rate = $this->create_woocommerce_rate( $applied_rate * 100, $tax_class );
-			$wc_rate  = $this->build_woocommerce_rate( $applied_rate * 100, $woo_rate['id'] );
-		} else {
-			$wc_rate = $this->build_woocommerce_rate( $applied_rate * 100 );
-		}
-
+	public function build_line_tax_from_rate( $applied_rate, $taxable_amount, $rate_id ): array {
+		$wc_rate  = $this->build_woocommerce_rate( $applied_rate * 100, $rate_id );
 		return WC_Tax::calc_exclusive_tax( $taxable_amount, $wc_rate );
 	}
 
@@ -180,15 +142,13 @@ class Tax_Builder {
 	 * @return array
 	 */
 	public function build_shipping_tax( $applied_rate, $taxable_amount ) {
-		if ( $this->save_rates_enabled ) {
-			if ( ! empty( $applied_rate ) ) {
-				$woo_rate = $this->create_woocommerce_rate( $applied_rate * 100 );
-				$wc_rate  = $this->build_woocommerce_rate( $applied_rate * 100, $woo_rate['id'] );
-			} else {
-				$wc_rate = [];
-			}
+		if ( ! empty( $applied_rate ) ) {
+			$tax_rate_id = $this->build_woocommerce_tax_rate(
+				$applied_rate * 100
+			);
+			$wc_rate  = $this->build_woocommerce_rate( $applied_rate * 100, $tax_rate_id );
 		} else {
-			$wc_rate = $this->build_woocommerce_rate( $applied_rate * 100 );
+			$wc_rate = [];
 		}
 
 		return WC_Tax::calc_exclusive_tax( $taxable_amount, $wc_rate );

--- a/includes/TaxCalculation/class-tax-details.php
+++ b/includes/TaxCalculation/class-tax-details.php
@@ -9,6 +9,8 @@
 
 namespace TaxJar;
 
+use Exception;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -175,13 +177,14 @@ class Tax_Details {
 	 * @param string $id Id of line item.
 	 *
 	 * @return bool|mixed
+	 * @throws Exception
 	 */
 	public function get_line_item( $id ) {
 		if ( ! empty( $this->line_items[ $id ] ) ) {
 			return $this->line_items[ $id ];
+		} else {
+			throw new Exception( 'Line item not present in tax details.' );
 		}
-
-		return false;
 	}
 
 	/**

--- a/tests/specs/tax-calculation/test-tax-builder.php
+++ b/tests/specs/tax-calculation/test-tax-builder.php
@@ -33,46 +33,69 @@ class Test_Tax_Builder extends WP_UnitTestCase {
 		$tax_details_stub->method( 'get_line_item' )->with( $line_key )->willReturn( $tax_detail_line_item_stub );
 		$tax_builder = new Tax_Builder( $tax_details_stub );
 
-		$tax = $tax_builder->get_line_tax( $line_key );
+		$tax = $tax_builder->get_line_tax( $line_key, Tax_Builder::TAX_RATE_ID );
 
 		$this->assertEquals( [ Tax_Builder::TAX_RATE_ID => wc_add_number_precision( $tax_collectable ) ], $tax );
 	}
 
-	public function test_correct_woocommerce_rate_saved_while_getting_line_tax() {
+	public function test_correct_woocommerce_rate_is_saved() {
 		TaxJar_Woocommerce_Helper::update_taxjar_settings( array( 'save_rates' => 'yes' ) );
-		$line_key = 'test';
-		$tax_collectable = 1.1;
-		$tax_rate = .1;
+		$tax_percent = 10;
+		$tax_class = 'test_class';
 		$location = [
 			'country' => 'US',
 			'state' => 'UT',
 			'city' => 'Payson',
 			'zip' => '84651'
 		];
-		$tax_class = 'test_class';
 		$tax_details_stub = $this->createMock( Tax_Details::class );
-		$tax_detail_line_item_stub = $this->createMock( Tax_Detail_Line_Item::class );
-		$tax_detail_line_item_stub->method( 'get_tax_collectable' )->willReturn( $tax_collectable );
-		$tax_detail_line_item_stub->method( 'get_tax_rate' )->willReturn( $tax_rate );
-		$tax_details_stub->method( 'get_line_item' )->with( $line_key )->willReturn( $tax_detail_line_item_stub );
-		$tax_details_stub->method( 'get_location' )->willReturn( $location );
 		$tax_details_stub->method( 'is_shipping_taxable' )->willReturn( false );
+		$tax_details_stub->method( 'get_location' )->willReturn( $location );
 		$tax_builder = new Tax_Builder( $tax_details_stub );
 
-		$tax = $tax_builder->get_line_tax( $line_key, $tax_class );
+		$created_rate_id = $tax_builder->build_woocommerce_tax_rate( $tax_percent, $tax_class );
 
-		$rates = WC_Tax::find_rates( [
+		$found_rates = WC_Tax::find_rates( [
 			'country'   => $location['country'],
 			'state'     => $location['state'],
 			'postcode'  => $location['zip'],
 			'city'      => $location['city'],
 			'tax_class' => $tax_class,
 		] );
-		$rate = reset( $rates );
-		$rate_id = key( $rates );
+		$rate = reset( $found_rates );
+		$rate_id = key( $found_rates );
 
-		$this->assertEquals( [ $rate_id => wc_add_number_precision( $tax_collectable ) ], $tax );
-		$this->assertEquals( $tax_rate * 100, $rate['rate'] );
+		$this->assertEquals( $created_rate_id, $rate_id );
+		$this->assertEquals( $tax_percent, $rate['rate'] );
+	}
+
+	public function test_correct_rate_is_built_without_saving() {
+		TaxJar_Woocommerce_Helper::update_taxjar_settings( array( 'save_rates' => 'no' ) );
+		$tax_percent = 10;
+		$tax_class = 'test_class';
+		$location = [
+			'country' => 'US',
+			'state' => 'UT',
+			'city' => 'Payson',
+			'zip' => '84651'
+		];
+		$tax_details_stub = $this->createMock( Tax_Details::class );
+		$tax_details_stub->method( 'is_shipping_taxable' )->willReturn( false );
+		$tax_details_stub->method( 'get_location' )->willReturn( $location );
+		$tax_builder = new Tax_Builder( $tax_details_stub );
+
+		$created_rate_id = $tax_builder->build_woocommerce_tax_rate( $tax_percent, $tax_class );
+
+		$found_rates = WC_Tax::find_rates( [
+			'country'   => $location['country'],
+			'state'     => $location['state'],
+			'postcode'  => $location['zip'],
+			'city'      => $location['city'],
+			'tax_class' => $tax_class,
+		] );
+
+		$this->assertEmpty( $found_rates );
+		$this->assertEquals( Tax_Builder::TAX_RATE_ID, $created_rate_id );
 	}
 
 	public function test_build_line_tax_from_rate() {
@@ -81,43 +104,8 @@ class Test_Tax_Builder extends WP_UnitTestCase {
 		$tax_details_stub = $this->createMock( Tax_Details::class );
 		$tax_builder = new Tax_Builder( $tax_details_stub );
 
-		$tax = $tax_builder->build_line_tax_from_rate( $rate, $taxable_amount );
+		$tax = $tax_builder->build_line_tax_from_rate( $rate, $taxable_amount, Tax_Builder::TAX_RATE_ID );
 
 		$this->assertEquals( [ Tax_Builder::TAX_RATE_ID => $rate * $taxable_amount ], $tax );
-	}
-
-	public function test_correct_woocommerce_rate_saved_while_building_line_tax_from_rate() {
-		TaxJar_Woocommerce_Helper::update_taxjar_settings( array( 'save_rates' => 'yes' ) );
-		$line_key = 'test';
-		$tax_rate = .1;
-		$taxable_amount = 100;
-		$location = [
-			'country' => 'US',
-			'state' => 'UT',
-			'city' => 'Payson',
-			'zip' => '84651'
-		];
-		$tax_class = 'test_class';
-		$tax_details_stub = $this->createMock( Tax_Details::class );
-		$tax_detail_line_item_stub = $this->createMock( Tax_Detail_Line_Item::class );
-		$tax_details_stub->method( 'get_line_item' )->with( $line_key )->willReturn( $tax_detail_line_item_stub );
-		$tax_details_stub->method( 'get_location' )->willReturn( $location );
-		$tax_details_stub->method( 'is_shipping_taxable' )->willReturn( false );
-		$tax_builder = new Tax_Builder( $tax_details_stub );
-
-		$tax = $tax_builder->build_line_tax_from_rate( $tax_rate, $taxable_amount, $tax_class );
-
-		$rates = WC_Tax::find_rates( [
-			'country'   => $location['country'],
-			'state'     => $location['state'],
-			'postcode'  => $location['zip'],
-			'city'      => $location['city'],
-			'tax_class' => $tax_class,
-		] );
-		$rate = reset( $rates );
-		$rate_id = key( $rates );
-
-		$this->assertEquals( [ $rate_id => $tax_rate * $taxable_amount ], $tax );
-		$this->assertEquals( $tax_rate * 100, $rate['rate'] );
 	}
 }


### PR DESCRIPTION
This PR resolves https://github.com/taxjar/taxjar-woocommerce-plugin/issues/221. 

The TaxJar API returns an amount to collect for each line item. This amount to collect is used to apply tax to line item total (after discounts have been applied). Tax must also be applied to the line item subtotal (prior to discounts). In order to get the amount to apply to the subtotal, an "applied rate" is determined by dividing the amount collectable by the line item total. This rate was then applied to the subtotal.

When the setting was enabled to save tax rates into the WooCommerce tax rate table, a rate was then created using the "applied rate". This rate overwrote the rate created while applying tax to the line total, and would be slightly different than the actual rate returned by the TaxJar API.

In order to resolve this issue, this PR separates the persisting the rate in the WooCommerce tax table from the actual application of tax to the line items. Now only a single rate will be created for each line item and the correct rate percentage will be persisted. This refactor also makes it easier to follow the logic of what is occurring during the tax application process.

Credit to @welenofsky for discovering this issue and pointing us in the right direction for a fix!

**Steps to Reproduce**

1. Enable the "save rates" and the "debug log" settings.
2. Add an item with an odd amount (for example $117) to the cart and proceed through the checkout process. The shipping address for the cart must be set to an area where nexus has been configured.
3. View the rate created in the WooCommerce tax table and the rate returned by the TaxJar API (can be seen in the logs) for the line item. They will be slightly different. 

**Expected Result**

After applying the PR, in step 3 above the two rates will be identical.

**Click-Test Versions**

- [X] Woo 6.3
- [X] Woo 5.8

**Specs Passing**

- [X] Woo 6.3
- [X] Woo 5.8
