### PR TITLE
Fix transaction sync issue regarding line subtotal precision

### DIFF
--- a/includes/class-taxjar-order-record.php
+++ b/includes/class-taxjar-order-record.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Utilities\NumberUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -267,7 +269,7 @@ class TaxJar_Order_Record extends TaxJar_Record {
 				}
 
 				$quantity = $item->get_quantity();
-				$unit_price = $item->get_subtotal() / $quantity;
+				$unit_price = NumberUtil::round( $item->get_subtotal(), wc_get_price_decimals() ) / $quantity;
 				$discount = $item->get_subtotal() - $item->get_total();
 
 				$tax_code = TaxJar_Tax_Calculation::get_tax_code_from_class( $item->get_tax_class() );


### PR DESCRIPTION
When WooCommerce calculates the subtotal or total of a cart, it first rounds the line item subtotals/totals and then sums them. However it still will store the unrounded subtotal/total of each line.

In an edge case, when a line subtotal uses a higher level of precision then the precision set in the WooCommerce settings, it may prevent a transaction from syncing to TaxJar with the error: "amount must be equal to the sum of line items and shipping, excluding sales tax". This is due to our plugin not rounding the higher precision subtotal before using it to determine the unit price in the transaction request to TaxJar.

For example, an order has two line items with subtotals of 10.005 and a precision set to two decimal places. When WooCommerce calculates the order subtotal it will first round the line subtotals (10.005) using the set precision to get subtotals of 10.01. It will then sum up these rounded subtotals to give an order subtotal of 20.02.

When the TaxJar plugin attempts to create the transaction in TaxJar it has to determine the unit price of each line. It does this by taking the subtotal for the line and dividing it by the quantity. Even though WooCommerce used the rounded line subtotals to determine the order subtotal, when getting the subtotal of each line it returns the original higher precision value (10.005 in this case). So the request sent to TaxJar would use unit prices of 10.005 and a total amount of 20.02 (the plugin uses a total amount calculated by WooCommerce and does not recalculate it based on the line items). In this case the values would not add up. 10.005 + 10.005 != 20.02 and the transaction is rejected by the TaxJar API.

In order to correct this, the plugin now rounds the line item subtotals using the set precision before using that value to determine the unit price. This matches the WooCommerce logic and will ensure that the line item unit prices correctly add up the order amount when a request is sent to TaxJar.

**Steps to Reproduce**

1. Set the number of decimal places to 2 in the WooCommerce settings.
2. Create two products with prices of 10.005
3. Add 1 of each product to the cart and checkout
4. Move the created order to completed status and manually sync the order to TaxJar
5. The order will not be created in TaxJar and an error will be recorded in the logs.

**Expected Result**

After applying the PR, in step 5 the order will be correctly created in TaxJar.

**Click-Test Versions**

- [X] Woo 6.3
- [X] Woo 5.8

**Specs Passing**

- [X] Woo 6.3
- [X] Woo 5.8
