### PR TITLE
Fix conflict with WooCommerce PDF Product Vouchers plugin

### DIFF
--- a/includes/compatibility/class-module-loader.php
+++ b/includes/compatibility/class-module-loader.php
@@ -20,6 +20,7 @@ class Module_Loader {
 	private $extensions = array(
 		'\TaxJar\WooCommerce_Gift_Cards',
 		'\TaxJar\WooCommerce_Smart_Coupons',
+		'\TaxJar\WooCommerce_PDF_Product_Vouchers',
 	);
 
 	/**

--- a/includes/compatibility/modules/class-woocommerce-pdf-product-vouchers.php
+++ b/includes/compatibility/modules/class-woocommerce-pdf-product-vouchers.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Compatibility module for WooCommerce PDF Product Vouchers plugin
+ *
+ * @package TaxJar
+ */
+
+namespace TaxJar;
+
+use WC_Cart;
+
+/**
+ * Class WooCommerce_PDF_Product_Vouchers
+ */
+class WooCommerce_PDF_Product_Vouchers extends Module {
+
+	/**
+	 * Determine if the module should be loaded
+	 *
+	 * @return bool
+	 */
+	public function should_load(): bool {
+		return class_exists( 'WC_PDF_Product_Vouchers' );
+	}
+
+	/**
+	 * Load module
+	 *
+	 * @return void
+	 */
+	public function load() {
+		$redemption_handler = wc_pdf_product_vouchers()->get_redemption_handler_instance();
+
+		remove_filter( 'woocommerce_calculated_total', array( $redemption_handler, 'apply_multi_purpose_vouchers_to_cart' ), 1100 );
+		add_action( 'taxjar_after_calculate_cart_totals', array( $this, 'apply_vouchers' ) );
+	}
+
+	/**
+	 * @param WC_Cart $cart cart
+	 */
+	public function apply_vouchers( $cart ) {
+		$redemption_handler = wc_pdf_product_vouchers()->get_redemption_handler_instance();
+		$total = $cart->get_total( 'edit' );
+		$new_total = $redemption_handler->apply_multi_purpose_vouchers_to_cart( $total, $cart );
+		$cart->set_total( max( 0, $new_total ) );
+	}
+}

--- a/includes/compatibility/modules/class-woocommerce-pdf-product-vouchers.php
+++ b/includes/compatibility/modules/class-woocommerce-pdf-product-vouchers.php
@@ -7,6 +7,7 @@
 
 namespace TaxJar;
 
+use TaxJar_Settings;
 use WC_Cart;
 
 /**
@@ -29,6 +30,10 @@ class WooCommerce_PDF_Product_Vouchers extends Module {
 	 * @return void
 	 */
 	public function load() {
+		if ( ! TaxJar_Settings::is_tax_calculation_enabled() ) {
+			return;
+		}
+
 		$redemption_handler = wc_pdf_product_vouchers()->get_redemption_handler_instance();
 
 		remove_filter( 'woocommerce_calculated_total', array( $redemption_handler, 'apply_multi_purpose_vouchers_to_cart' ), 1100 );

--- a/includes/compatibility/modules/class-woocommerce-pdf-product-vouchers.php
+++ b/includes/compatibility/modules/class-woocommerce-pdf-product-vouchers.php
@@ -32,7 +32,7 @@ class WooCommerce_PDF_Product_Vouchers extends Module {
 		$redemption_handler = wc_pdf_product_vouchers()->get_redemption_handler_instance();
 
 		remove_filter( 'woocommerce_calculated_total', array( $redemption_handler, 'apply_multi_purpose_vouchers_to_cart' ), 1100 );
-		add_action( 'taxjar_after_calculate_cart_totals', array( $this, 'apply_vouchers' ) );
+		add_action( 'woocommerce_after_calculate_totals', array( $this, 'apply_vouchers' ), 21 );
 	}
 
 	/**

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -125,6 +125,7 @@ final class WC_Taxjar {
 			include_once 'includes/compatibility/class-module-loader.php';
 			include_once 'includes/compatibility/modules/class-woocommerce-gift-cards.php';
 			include_once 'includes/compatibility/modules/class-woocommerce-smart-coupons.php';
+			include_once 'includes/compatibility/modules/class-woocommerce-pdf-product-vouchers.php';
 
 			// Register the integration.
 			add_action( 'woocommerce_integrations_init', array( $this, 'add_integration' ), 20 );


### PR DESCRIPTION
This PR resolves the incorrect totals in cart while using the TaxJar and WooCommerce PDF Product Vouchers plugins as reported in https://github.com/taxjar/taxjar-woocommerce-plugin/issues/228.

**Steps to Reproduce**

1. Add an item to the cart and apply a multi use product voucher to the cart.
2. The totals will be incorrect as the voucher won't be factored into the total.

**Expected Result**

After applying the PR, the totals will be as expected.

**Click-Test Versions**

- [X] Woo 6.6
- [X] Woo 6.0

**Specs Passing**

- [X] Woo 6.6
- [X] Woo 6.0
