### PR TITLE
Get order tax class from product over line item

### DIFF
--- a/includes/TaxCalculation/class-order-tax-request-body-builder.php
+++ b/includes/TaxCalculation/class-order-tax-request-body-builder.php
@@ -62,7 +62,7 @@ class Order_Tax_Request_Body_Builder extends Tax_Request_Body_Builder {
 			$request_line_item = array(
 				'id'               => $item->get_product_id() . '-' . $item_key,
 				'quantity'         => $item->get_quantity(),
-				'product_tax_code' => $this->get_line_item_tax_code( $item ),
+				'product_tax_code' => $this->get_product_tax_code( $item ),
 				'unit_price'       => $this->get_line_item_unit_price( $item ),
 				'discount'         => $this->get_line_item_discount_amount( $item ),
 			);
@@ -86,6 +86,27 @@ class Order_Tax_Request_Body_Builder extends Tax_Request_Body_Builder {
 
 			$this->tax_request_body->add_line_item( $request_line_item );
 		}
+	}
+
+	/**
+	 * @param WC_Order_Item_Product $item product line item.
+	 *
+	 * @return string
+	 */
+	protected function get_product_tax_code( $item ) {
+		$product = $item->get_product();
+
+		if ( ! $product ) {
+			return $this->get_line_item_tax_code( $item );
+		}
+
+		$tax_code = TaxJar_Tax_Calculation::get_tax_code_from_class( $product->get_tax_class() );
+
+		if ( 'taxable' !== $product->get_tax_status() ) {
+			$tax_code = '99999';
+		}
+
+		return $tax_code;
 	}
 
 	/**


### PR DESCRIPTION
Subscriptions created prior to TaxJar being enabled would not use the TaxJar PTC when added after subscription creation.  This PR resolves the issue by pulling the tax class directly from the product when possible.

**Steps to Reproduce**

1. Create a subscription using a product without a TaxJar PTC, and process a renewal. The TaxJar logs will show no PTC sent to the TaxJar API.
2. Change the product to use a TaxJar PTC. 
3. Process another renewal order. The logs will still show no PTC was sent in the calculation request.

**Expected Result**

After applying the PR, in step 3 the logs will show the newly added PTC was used in the calculation request.

**Click-Test Versions**

- [X] Woo 6.6
- [X] Woo 6.0

**Specs Passing**

- [X] Woo 6.6
- [X] Woo 6.0
