### PR TITLE
Support local pickup on orders

### DIFF
--- a/includes/TaxCalculation/class-admin-order-tax-request-body-builder.php
+++ b/includes/TaxCalculation/class-admin-order-tax-request-body-builder.php
@@ -22,6 +22,11 @@ class Admin_Order_Tax_Request_Body_Builder extends Order_Tax_Request_Body_Builde
 	 * Get ship to address from $_POST and set on tax request body.
 	 */
 	protected function get_ship_to_address() {
+		if ( $this->has_local_shipping() ) {
+			$this->set_to_address_from_store_address();
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$to_country = isset( $_POST['country'] ) ? $this->prepare_field( $_POST['country'] ) : false;
 		$to_state   = isset( $_POST['state'] ) ? $this->prepare_field( $_POST['state'] ) : false;


### PR DESCRIPTION
The plugin used the store address as the to_address when using local pickup shipping method in cart and checkout. However. This was not supported with an order created in the admin dashboard or through the WooCommerce REST API.

**Steps to Reproduce**

1. Create a new order in the admin dashboard and use an address different than the store address.
2. Add local pickup shipping method.
3. Recalculate totals
4. Address used in calculation (can be found in logs) will be the shipping address not the store address.

**Expected Result**

After applying the PR, in step for the to address will be the store address.

**Click-Test Versions**

- [X] Woo 6.6
- [X] Woo 6.0

**Specs Passing**

- [X] Woo 6.6
- [X] Woo 6.0
