### PR TITLE
Update class-wc-taxjar-nexus.php

### DIFF
--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -21,7 +21,7 @@ class WC_Taxjar_Nexus {
 		$desc_text = '';
 		//$desc_text .= '<h3>Nexus Information</h3>';
 
-		if ( count( $this->nexus ) > 0 ) {
+		if ( !is_null( $this->nexus ) && count( $this->nexus ) > 0 ) {
 			$desc_text .= '<p>Sales tax will be calculated on orders delivered into the following regions: </p>';
 
 			foreach ( $this->nexus as $key => $nexus ) {


### PR DESCRIPTION
_Describe the problem ([reference the issue](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) if applicable) and what the PR accomplishes._

**Steps to Reproduce**

Receiving this error in a WPEngine hosting environment. We do not know what triggered it but we did see that sometimes $this->nexus can be null in this function in certain instances. Added a simply null check:

Error Details
=============
An error of type E_ERROR was caused in line 24 of the file /nas/content/live/oursite/wp-content/plugins/taxjar-simplified-taxes-for-woocommerce/includes/class-wc-taxjar-nexus.php. Error message: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /nas/content/live/oursite/wp-content/plugins/taxjar-simplified-taxes-for-woocommerce/includes/class-wc-taxjar-nexus.php:24 Stack trace:
#0 /nas/content/live/oursite/wp-content/plugins/taxjar-simplified-taxes-for-woocommerce/includes/class-taxjar-settings.php(330): WC_Taxjar_Nexus->get_form_settings_field() #1 /nas/content/live/oursite/wp-content/plugins/taxjar-simplified-taxes-for-woocommerce/includes/class-taxjar-settings.php(208): TaxJar_Settings::get_nexus_settings_display() #2 /nas/content/live/oursite/wp-content/plugins/taxjar-simplified-taxes-for-woocommerce/includes/class-taxjar-settings.php(645): TaxJar_Settings::get_settings() #3 /nas/content/live/oursite/wp-includes/class-wp-hook.php(310): TaxJar_Settings::save('') #4 /nas/content/live/oursite/wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters('', Array) #5 /nas/content/live/oursite/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #6 /nas/content/live/oursite/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-settings.php(77): do_action('woocommerce_set...') #7 /nas/content/live/oursite/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-menus.php(153): WC_Admin_Settings::save() #8 /nas/content/live/oursite/wp-includes/class-wp-hook.php(310): WC_Admin_Menus->save_settings('') #9 /nas/content/live/oursite/wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters(NULL, Array) #10 /nas/content/live/oursite/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #11 /nas/content/live/oursite/wp-settings.php(654): do_action('wp_loaded') #12 /nas/content/live/oursite/wp-config.php(121): require_once('/nas/content/li...') #13 /nas/content/live/oursite/wp-load.php(50): require_once('/nas/content/li...') #14 /nas/content/live/oursite/wp-admin/admin.php(34): require_once('/nas/content/li...') #15 {main}
  thrown

**Expected Result**

No error should be thrown when $this->nexus is null and the admin page with settings is visited.

**Click-Test Versions**

- [x ] Woo 4.0
- [ ] Woo 3.9
- [ ] Woo 3.8
- [ ] Woo 3.7
- [ ] Woo 3.6
- [ ] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0

**Specs Passing**

- [ ] Woo 4.0
- [ ] Woo 3.9
- [ ] Woo 3.8
- [ ] Woo 3.7
- [ ] Woo 3.6
- [ ] Woo 3.5
- [ ] Woo 3.4
- [ ] Woo 3.3
- [ ] Woo 3.2
- [ ] Woo 3.1
- [ ] Woo 3.0
