### PR TITLE
Version 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.1 (2023-10-04)
+* WooCommerce tested up to 8.1.0
+* WordPress 6.3.1 tested
+
 # 4.2.0 (2023-09-27)
 * WooCommerce tested up to 7.8.0
 * Updates needed for HPOS compliance

--- a/readme.txt
+++ b/readme.txt
@@ -2,12 +2,12 @@
 Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 5.4
-Tested up to: 6.0.2
-Stable tag: 4.2.0
+Tested up to: 6.3.1
+Stable tag: 4.2.1
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 6.4.0
-WC tested up to: 7.8.0
+WC tested up to: 8.1.0
 
 Trusted by more than 20,000 businesses, TaxJar’s award-winning solution makes it easy to automate sales tax reporting and filing, and determine economic nexus with a single click.
 
@@ -94,6 +94,10 @@ Our plans come with filings included, with additional filings available for purc
 3. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 4.2.1 (2023-10-04)
+* WooCommerce tested up to 8.1.0
+* WordPress 6.3.1 tested
 
 = 4.2.0 (2023-09-27)
 * WooCommerce tested up to 7.8.0

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,11 +3,11 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 4.2.0
+ * Version: 4.2.1
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 6.4.0
- * WC tested up to: 7.8.0
+ * WC tested up to: 8.1.0
  * Requires PHP: 7.0
  *
  * Copyright: © 2014-2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc.
@@ -43,7 +43,7 @@ if ( ! $woocommerce_active || version_compare( get_option( 'woocommerce_db_versi
  */
 final class WC_Taxjar {
 
-	static $version = '4.2.0';
+	static $version = '4.2.1';
 	public static $minimum_woocommerce_version = '6.4.0';
 
 	/**


### PR DESCRIPTION
Updates compatible versions and latest tested version of WooCommerce and WordPress. 
WordPress is tested with version 6.3.1.

**Click-Test Versions**

- [x] Woo 8.1
- [x] Woo 7.9
- [x] Woo 7.8

**Specs Passing**

- [x] Woo 8.1
- [x] Woo 7.9
- [x] Woo 7.8
