### PR TITLE
#258 Stop displaying the metabox when the order can't be found

### DIFF
--- a/includes/admin/class-admin-meta-boxes.php
+++ b/includes/admin/class-admin-meta-boxes.php
@@ -24,13 +24,22 @@ class Admin_Meta_Boxes {
 	 * Admin_Meta_Boxes Constructor.
 	 */
 	public function __construct() {
-		add_action( 'add_meta_boxes', array( $this, 'add_order_meta_box' ), 30 );
+		add_action( 'add_meta_boxes', array( $this, 'add_order_meta_box' ), 30, 2 );
 	}
 
 	/**
 	 * Add meta box to order post types.
+	 *
+	 * @param string   $post_type Post type.
+	 * @param \WP_Post $post Post object.
 	 */
-	public function add_order_meta_box() {
+	public function add_order_meta_box( $post_type, $post ) {
+		$wc_order = wc_get_order( $post->ID );
+
+		if ( ! $wc_order ) {
+			return;
+		}
+
 		foreach ( wc_get_order_types( 'order-meta-boxes' ) as $type ) {
 			add_meta_box(
 				'taxjar',
@@ -38,7 +47,8 @@ class Admin_Meta_Boxes {
 				'\TaxJar\Order_Meta_Box::output',
 				$this->get_page_screen_id( $type ),
 				'normal',
-				'low'
+				'low',
+				array( 'order' => $wc_order )
 			);
 		}
 	}

--- a/includes/admin/class-order-meta-box.php
+++ b/includes/admin/class-order-meta-box.php
@@ -25,10 +25,11 @@ class Order_Meta_Box {
 	 * Output meta box contents.
 	 *
 	 * @param mixed $post WP Post.
+	 * @param array $additional_data Additional data.
 	 */
-	public static function output( $post ) {
-		$order_id = $post->ID;
-		$order    = wc_get_order( $order_id );
+	public static function output( $post, $additional_data ) {
+		$order = $additional_data['args']['order'];
+
 		$metadata = self::get_order_tax_calculation_metadata( $order );
 		wp_enqueue_script( 'accordion' );
 


### PR DESCRIPTION
**This PR:**
- Adds a fix for the issue number [#258](https://github.com/taxjar/taxjar-woocommerce-plugin/issues/258)

**Steps to reproduce**
- Go to WordPress admin -> WooCommerce -> Settings -> Advanced -> Features -> enable HPOS
- Go to an admin product page and scroll to the bottom of the page

**Expected Result**
- The TaxJar metabox not being displayed, as this is not an order page

**After applying the PR, this should happen.**
- The TaxJar metabox will be displayed only for the order pages

**Click-Test Versions**
- [ ] Woo 9.0


**Specs Passing**
- [ ] Woo 9.0
