### PR TITLE
Update readme.txt to update tested version of WP to 6.7

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 5.4
-Tested up to: 6.6.1
+Tested up to: 6.7
 Stable tag: 4.2.3
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
WordPress 6.7 has been releases on November 12, 2024. But the plugin was not tested for this new version.

<img width="811" alt="image" src="https://github.com/user-attachments/assets/fc6a8a28-447d-47f5-83a5-291834927697">

I've performed tests with this latest version 6.7 of WP and confirmed that the plugin works as expected. Thus updating the readme.txt to reflect this fact. Based on the email linked in the ticket there's nothing else required from our side.

For more details checkout RUN_TJPLAT-1946.