### PR TITLE
PHP 8.x Compliance

### DIFF
--- a/includes/class-taxjar-tax-calculation.php
+++ b/includes/class-taxjar-tax-calculation.php
@@ -19,6 +19,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class TaxJar_Tax_Calculation {
 
+	/* Define props to avoid php 8.x dynamic prop deprecation warnings. */
+	public $cache_time;
+
 	public function __construct() {
 		// Cache rates for 1 hour.
 		$this->cache_time = HOUR_IN_SECONDS;

--- a/includes/class-wc-taxjar-download-orders.php
+++ b/includes/class-wc-taxjar-download-orders.php
@@ -11,6 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Taxjar_Download_Orders {
 
+	/* Define props to avoid php 8.x dynamic prop deprecation warnings. */
+	public $integration;
+	public $taxjar_download;
+
 	public function __construct( $integration ) {
 		$this->integration      = $integration;
 		$this->taxjar_download  = filter_var( $this->integration->get_option( 'taxjar_download' ), FILTER_VALIDATE_BOOLEAN );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -15,6 +15,16 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 
 		protected static $_instance = null;
 
+		/* Define props to avoid php 8.x dynamic prop deprecation warnings. */
+		public $tax_calculations;
+		public $method_title;
+		public $method_description;
+		public $integration_uri;
+		public $debug;
+		public $module_loader;
+		public $customer_sync;
+		public $transaction_sync;
+		public $download_orders;
 		public static $app_uri = 'https://app.taxjar.com/';
 
 		/**


### PR DESCRIPTION
Define some class properties that are currently dynamic because [PHP has deprecated dynamic class props](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties).
```
