### PR TITLE
Php 8.x compliance

### DIFF
--- a/includes/class-taxjar-tax-calculation.php
+++ b/includes/class-taxjar-tax-calculation.php
@@ -19,6 +19,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class TaxJar_Tax_Calculation {
 
+	/* Define props to avoid php 8.x dynamic prop deprecation warnings. */
+	public $cache_time;
+
 	public function __construct() {
 		// Cache rates for 1 hour.
 		$this->cache_time = HOUR_IN_SECONDS;

--- a/includes/class-wc-taxjar-download-orders.php
+++ b/includes/class-wc-taxjar-download-orders.php
@@ -11,6 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Taxjar_Download_Orders {
 
+	/* Define props to avoid php 8.x dynamic prop deprecation warnings. */
+	public $integration;
+	public $taxjar_download;
+
 	public function __construct( $integration ) {
 		$this->integration      = $integration;
 		$this->taxjar_download  = filter_var( $this->integration->get_option( 'taxjar_download' ), FILTER_VALIDATE_BOOLEAN );

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -15,6 +15,16 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 
 		protected static $_instance = null;
 
+		/* Define props to avoid php 8.x dynamic prop deprecation warnings. */
+		public $tax_calculations;
+		public $method_title;
+		public $method_description;
+		public $integration_uri;
+		public $debug;
+		public $module_loader;
+		public $customer_sync;
+		public $transaction_sync;
+		public $download_orders;
 		public static $app_uri = 'https://app.taxjar.com/';
 
 		/**


### PR DESCRIPTION
Warning messages show up in the php error log. e.g.
```
 PHP Deprecated:  Creation of dynamic property WC_Taxjar_Integration::$method_description is deprecated in /var/www/html/wp-content/plugins/taxjar-simplified-taxes-for-woocommerce/includes/class-wc-taxjar-integration.php on line 39
```
This PR will prevent these warning messages.

**Steps to Reproduce**

- Access any site page.

**Expected Result**

Clean php error log.

**Applies to any instance running PHP 8.2 and up**

**Solves the problem for all installations**

