### PR TITLE
Fix PHP 8.2+ dynamic property deprecation warnings

### DIFF
--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -38,6 +38,11 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		public $debug;
 
 		/**
+		 * @var WC_Logger
+		 */
+		public $log;
+
+		/**
 		 * @var WC_Taxjar_Download_Orders
 		 */
 		public $download_orders;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 	public $tests_dir;
 	public $plugins_dir;
 	public $test_wp_dir;
+	public $plugin_dir;
 	public $api_token;
 
 	public function __construct() {
@@ -51,7 +52,12 @@ class TaxJar_WC_Unit_Tests_Bootstrap {
 		update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
 		update_option( 'woocommerce_db_version', WC_VERSION );
 		require_once $this->plugin_dir . 'taxjar-woocommerce-plugin/taxjar-woocommerce.php';
-		include_once $this->plugin_dir . 'woocommerce-subscriptions/woocommerce-subscriptions.php';
+
+		// Load WooCommerce Subscriptions if available
+		$subscriptions_file = $this->plugin_dir . 'woocommerce-subscriptions/woocommerce-subscriptions.php';
+		if ( file_exists( $subscriptions_file ) ) {
+			include_once $subscriptions_file;
+		}
 	}
 
 	public function install_wc() {

--- a/tests/framework/woocommerce-helper.php
+++ b/tests/framework/woocommerce-helper.php
@@ -16,7 +16,6 @@ class TaxJar_Woocommerce_Helper {
 		WC()->session->set( 'customer', null );
 		WC()->session->set( 'chosen_shipping_methods', array() );
 		WC()->cart->remove_coupons();
-		WC()->shipping->shipping_total = 0;
 		WC()->shipping->reset_shipping();
 
 		// Ensure default is tax based on shipping

--- a/tests/specs/test-actions.php
+++ b/tests/specs/test-actions.php
@@ -1,6 +1,11 @@
 <?php
 class TJ_WC_Actions extends WP_UnitTestCase {
 
+	/**
+	 * @var WC_Taxjar_Integration
+	 */
+	public $tj;
+
 	function setUp(): void {
 		TaxJar_Woocommerce_Helper::prepare_woocommerce();
 		$this->tj = TaxJar();
@@ -132,7 +137,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		WC()->cart->add_to_cart( $product );
 
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->shipping->shipping_total = 5;
+		WC()->cart->set_shipping_total( 5 );
 
 		WC()->cart->calculate_totals();
 
@@ -173,7 +178,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		$taxable_product_item_key = WC()->cart->add_to_cart( $taxable_product );
 
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->shipping->shipping_total = 10;
+		WC()->cart->set_shipping_total( 10 );
 
 		WC()->cart->calculate_totals();
 
@@ -321,7 +326,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 
 
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->shipping->shipping_total = 10;
+		WC()->cart->set_shipping_total( 10 );
 
 		WC()->cart->calculate_totals();
 
@@ -1099,7 +1104,7 @@ class TJ_WC_Actions extends WP_UnitTestCase {
 		WC()->cart->add_to_cart( $product );
 
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->shipping->shipping_total = 5;
+		WC()->cart->set_shipping_total( 5 );
 
 		WC()->cart->calculate_totals();
 

--- a/tests/specs/test-customer-sync.php
+++ b/tests/specs/test-customer-sync.php
@@ -350,7 +350,7 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 		WC()->cart->add_to_cart( $product );
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->shipping->shipping_total = 10;
+		WC()->cart->set_shipping_total( 10 );
 		WC()->cart->calculate_totals();
 
 		$this->assertEquals( .43, WC()->cart->get_total_tax(), '', 0.01 );
@@ -388,7 +388,7 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 		WC()->cart->add_to_cart( $product );
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->shipping->shipping_total = 10;
+		WC()->cart->set_shipping_total( 10 );
 
 		// test tax calculation for exempt customer
 		$customer = TaxJar_Customer_Helper::create_exempt_customer();
@@ -417,7 +417,7 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		WC()->cart->empty_cart();
 		WC()->cart->add_to_cart( $product, 2 );
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->shipping->shipping_total = 10;
+		WC()->cart->set_shipping_total( 10 );
 		WC()->customer = $customer;
 		WC()->cart->calculate_totals();
 
@@ -448,7 +448,7 @@ class TJ_WC_Test_Customer_Sync extends WP_UnitTestCase {
 		$product = TaxJar_Product_Helper::create_product( 'simple' )->get_id();
 		WC()->cart->add_to_cart( $product );
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->shipping->shipping_total = 10;
+		WC()->cart->set_shipping_total( 10 );
 		WC()->cart->calculate_totals();
 
 		$this->assertEquals( .43, WC()->cart->get_total_tax(), '', 0.01 );

--- a/tests/specs/test-subscriptions.php
+++ b/tests/specs/test-subscriptions.php
@@ -318,7 +318,7 @@ class TJ_WC_Test_Subscriptions extends WP_HTTP_TestCase {
 		WC()->cart->add_to_cart( $exempt_product );
 
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->shipping->shipping_total = 10;
+		WC()->cart->set_shipping_total( 10 );
 
 		WC()->cart->calculate_totals();
 


### PR DESCRIPTION
- Add explicit property declarations to prevent dynamic property warnings:
  - Add $plugin_dir property to TaxJar_WC_Unit_Tests_Bootstrap class
  - Add $log property to WC_Taxjar_Integration class
  - Add $tj property to TJ_WC_Actions test class

- Fix WooCommerce Subscriptions file loading with existence check in bootstrap.php to prevent file not found warnings

- Replace problematic shipping total assignments with proper WooCommerce methods:
  - Replace WC()->shipping->shipping_total = X with WC()->cart->set_shipping_total(X)
  - Remove redundant shipping_total assignment in woocommerce-helper.php