### PR TITLE
Fix taxjar connect flow issue due to UI changes in the new woo versions (9.9.5>=)

### DIFF
--- a/includes/js/wc-taxjar-admin.js
+++ b/includes/js/wc-taxjar-admin.js
@@ -50,7 +50,15 @@ jQuery( document ).ready( function() {
 					window.popup.postMessage( 'Data received', woocommerce_taxjar_admin.app_url );
 					$( '#woocommerce_taxjar-integration_settings\\[api_token\\]' ).val( data.api_token );
 					$( '#woocommerce_taxjar-integration_settings\\[connected_email\\]' ).val( data.email );
-					$( '#mainform .woocommerce-save-button' ).click();
+					var $saveBtn = $('#mainform .woocommerce-save-button');
+					if ($saveBtn.length) {
+					  $saveBtn
+					    .prop('disabled', false)
+					    .removeAttr('disabled')
+					    .removeClass('disabled')
+					    .attr('aria-disabled', 'false');
+					}
+					$saveBtn.click();
 				} else {
 					throw 'Invalid data';
 				}


### PR DESCRIPTION
As part of the latest Woo (10.2.2) and WP (6.8.3) version compatibility testing, found an issue with the taxjar connect flow. 

To my knowledge at least starting from Woo version 9.9.5, when you hit this connect button below it successfully opens up taxjar pop-up and fetches the token but it won't save the form. So it looks as if nothing happened. So, users might repeat the action multiple times but nothing happens. But if you check the api token through the "Edit Api Token" link then it's there. It works fine with the version 8.9.3. 

<img width="436" height="164" alt="image" src="https://github.com/user-attachments/assets/b8eaf301-ba69-4899-8708-f9a6907053be" />

**Root cause:** This connect button works by clicking a hidden "Save" button after fetching the token. But that hidden button got disabled by default in newer Woo versions. So, after fetching the token, the form does not detect any change and the button stays disabled. Clicking it does nothing. 

**Fix:** Using safe JQuery ops try to remove any disable attrs, classes before hitting the button which works fine now for all tested versions. 


**Click-Test Versions**

- [x] Woo 10.2.2
- [x] Woo 9.9.5
- [x] Woo 8.9.3

**Specs Passing**

- [x] Woo 10.2.2
- [x] Woo 9.9.5
- [x] Woo 8.9.3
