### PR TITLE
Fix incorrect shipping tax on exempt products when using saved rates without TaxJar API [RUN_TJPLAT-2656]

### DIFF
--- a/includes/class-taxjar-tax-calculation.php
+++ b/includes/class-taxjar-tax-calculation.php
@@ -84,8 +84,8 @@ class TaxJar_Tax_Calculation {
 		// Rate calculations assume tax not included
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 
-		// Use no special handling on shipping taxes, our API handles that
-		update_option( 'woocommerce_shipping_tax_class', '' );
+		// Set shipping tax class to inherit so it follows item taxability (e.g. exempt items = exempt shipping)
+		update_option( 'woocommerce_shipping_tax_class', 'inherit' );
 
 		// API handles rounding precision
 		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );


### PR DESCRIPTION
## Summary

Shipping is incorrectly taxed when cart contains only tax-exempt products (e.g., PTC 40020), even though the TaxJar API correctly returns `freight_taxable: false` and $0 shipping tax.

**Root Cause:** The TaxJar plugin forces `woocommerce_shipping_tax_class` to `''` (Standard) in `update_tax_options()`. While TaxJar's API correctly calculates shipping tax and saves rates with the appropriate `tax_rate_shipping` flag based on state-specific rules, if WooCommerce recalculates taxes without calling TaxJar (e.g., during order finalization, admin edits, or when TaxJar is disconnected), the forced Standard setting causes WooCommerce to ignore the cart items' tax class and always look up the Standard rate for shipping—even when the cart contains only exempt products.

Link: https://www.taxjar.com/sales-tax/sales-tax-and-shipping 

**Fix:** Change `woocommerce_shipping_tax_class` from `''` (Standard) to `'inherit'`. This allows WooCommerce to derive the shipping tax class from cart items, which then respects TaxJar's saved rates:

- **States where shipping is not taxable if separately stated** (CA, AZ, FL, etc.): TaxJar saves rates with `shipping = false`. With `inherit`, WooCommerce looks up the inherited tax class, finds no rate with `shipping = true`, and correctly applies $0 shipping tax.

- **States where shipping follows product taxability** (TX, WV, NC, etc.): TaxJar saves exempt rates (e.g., PTC 40020) with `shipping = false` and standard rates with `shipping = true`. With `inherit`, WooCommerce uses the cart items' tax class, finds the appropriate rate, and applies the correct shipping tax (0% for exempt, X% for taxable).

**Note:** We believe this fix addresses the issue reported in RUN_TJPLAT-2656, but this should be confirmed with the user once the fix is released in a new plugin version.

## Steps to Reproduce

1. Enable TaxJar with "Save Tax Rates" enabled
2. Process orders to a nexus state - TaxJar creates rates with appropriate `shipping` flags:
   - Standard rate (e.g., 6%) with `shipping = true`
   - PTC 40020 rate (0%) with `shipping = false`
3. Disable/disconnect TaxJar
4. Add only exempt products (PTC 40020) to cart with shipping
5. Place the order

**Broken Behavior (before fix):** WooCommerce forces Standard tax class for shipping, finds the 6% rate, and incorrectly taxes shipping.

**Expected Behavior (after fix):** WooCommerce inherits the 40020 tax class from cart items, finds no shipping rate (since `shipping = false`), and correctly applies $0 shipping tax.

## Click-Test Versions

- [x] Woo 10.3.5
- [ ] Woo 10.2.2
- [ ] Woo 9.9.5
- [ ] Woo 8.9.3

## Specs Passing

- [x] Woo 10.3.5
- [ ] Woo 10.2.2
- [ ] Woo 9.9.5
- [ ] Woo 8.9.3