### PR TITLE
Bump WooCommerce tested up to 10.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.2.8 (2026-06-23)
+* WooCommerce tested up to 10.9.0
+
 # 4.2.7 (2026-01-13)
 * WooCommerce tested up to 10.4.3
 * WordPres 6.9 tested

--- a/readme.txt
+++ b/readme.txt
@@ -3,11 +3,11 @@ Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 5.4
 Tested up to: 6.9
-Stable tag: 4.2.7
+Stable tag: 4.2.8
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 7.0.0
-WC tested up to: 10.4.3
+WC tested up to: 10.9.0
 
 Trusted by more than 20,000 businesses, TaxJar’s award-winning solution makes it easy to automate sales tax reporting and filing, and determine economic nexus with a single click.
 
@@ -94,6 +94,9 @@ Our plans come with filings included, with additional filings available for purc
 3. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 4.2.8 (2026-06-23) =
+* WooCommerce tested up to 10.9.0
 
 = 4.2.7 (2026-01-13) =
 * WooCommerce tested up to 10.4.3

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,11 +3,11 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 4.2.7
+ * Version: 4.2.8
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 7.0.0
- * WC tested up to: 10.4.3
+ * WC tested up to: 10.9.0
  * Requires PHP: 7.0
  *
  * Copyright: © 2014-2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc.
@@ -43,7 +43,7 @@ if ( ! $woocommerce_active || version_compare( get_option( 'woocommerce_db_versi
  */
 final class WC_Taxjar {
 
-	static $version = '4.2.7';
+	static $version = '4.2.8';
 	public static $minimum_woocommerce_version = '7.0.0';
 
 	/**


### PR DESCRIPTION
## Summary
- Bump plugin version to 4.2.8
- Update WooCommerce tested up to 10.9.0 (from 10.4.3)
- Minimum WooCommerce version remains 7.0.0

## Test plan
- [x] Unit tests pass on WooCommerce 10.9.0 (292 tests, 1062 assertions, 21 skipped)
- [x] Unit tests pass on WooCommerce 10.3.0 (oldest supported L6)
- [x] Click-testing passed on WooCommerce 10.9.0
- [x] Click-testing passed on WooCommerce 10.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)