### PR TITLE
Version 4.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 4.2.9 (2026-09-02)
 * WooCommerce tested up to 11.0.1
+* WordPress 7.1 tested
 
 # 4.2.8 (2026-06-23)
 * WooCommerce tested up to 10.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.2.9 (2026-09-02)
+* WooCommerce tested up to 11.0.1
+
 # 4.2.8 (2026-06-23)
 * WooCommerce tested up to 10.9.0
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,11 +3,11 @@ Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 5.4
 Tested up to: 6.9
-Stable tag: 4.2.8
+Stable tag: 4.2.9
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 7.0.0
-WC tested up to: 10.9.0
+WC tested up to: 11.0.1
 
 Trusted by more than 20,000 businesses, TaxJar’s award-winning solution makes it easy to automate sales tax reporting and filing, and determine economic nexus with a single click.
 
@@ -94,6 +94,9 @@ Our plans come with filings included, with additional filings available for purc
 3. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 4.2.9 (2026-09-02) =
+* WooCommerce tested up to 11.0.1
 
 = 4.2.8 (2026-06-23) =
 * WooCommerce tested up to 10.9.0

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 5.4
-Tested up to: 6.9
+Tested up to: 7.1
 Stable tag: 4.2.9
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -97,6 +97,7 @@ Our plans come with filings included, with additional filings available for purc
 
 = 4.2.9 (2026-09-02) =
 * WooCommerce tested up to 11.0.1
+* WordPress 7.1 tested
 
 = 4.2.8 (2026-06-23) =
 * WooCommerce tested up to 10.9.0

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,11 +3,11 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 4.2.8
+ * Version: 4.2.9
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 7.0.0
- * WC tested up to: 10.9.0
+ * WC tested up to: 11.0.1
  * Requires PHP: 7.0
  *
  * Copyright: © 2014-2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc.
@@ -43,7 +43,7 @@ if ( ! $woocommerce_active || version_compare( get_option( 'woocommerce_db_versi
  */
 final class WC_Taxjar {
 
-	static $version = '4.2.8';
+	static $version = '4.2.9';
 	public static $minimum_woocommerce_version = '7.0.0';
 
 	/**


### PR DESCRIPTION
## Summary
- Bump plugin version to 4.2.9
- Update WooCommerce tested up to 11.0.1 (from 10.9.0)
- Update WordPress tested up to 7.1 (from 6.9)
- Minimum WooCommerce version remains 7.0.0

## Test plan
- [x] Unit tests pass on WooCommerce 11.0.1 (292 tests, 1062 assertions, 21 skipped)
- [x] Unit tests pass on WooCommerce 11.0.0 (292 tests, 1062 assertions, 21 skipped)
- [x] Unit tests pass on WooCommerce 10.9.4 (292 tests, 1062 assertions, 21 skipped)
- [x] Unit tests pass on WooCommerce 10.9.3 (292 tests, 1062 assertions, 21 skipped)
- [x] Unit tests pass on WooCommerce 10.9.2 (292 tests, 1062 assertions, 21 skipped)
- [x] Unit tests pass on WooCommerce 10.9.1 (292 tests, 1062 assertions, 21 skipped)

- [x] Click-testing passed on WooCommerce 11.0.1
- [x] Click-testing passed on WooCommerce 11.0.0
- [x] Click-testing passed on WooCommerce 10.9.4
- [x] Click-testing passed on WooCommerce 10.9.3
- [x] Click-testing passed on WooCommerce 10.9.2
- [x] Click-testing passed on WooCommerce 10.9.1
