### PR TITLE
[RUN_TJPLAT-3659] fix PHPCS errors surfaced by quality insights toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.2.10 (2026-09-04)
+* Fix phpcs errors surfaced from external Quality Insights Toolkit run
+
 # 4.2.9 (2026-09-02)
 * WooCommerce tested up to 11.0.1
 * WordPress 7.1 tested

--- a/includes/TaxCalculation/class-admin-order-tax-request-body-builder.php
+++ b/includes/TaxCalculation/class-admin-order-tax-request-body-builder.php
@@ -28,11 +28,11 @@ class Admin_Order_Tax_Request_Body_Builder extends Order_Tax_Request_Body_Builde
 		}
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		$to_country = isset( $_POST['country'] ) ? $this->prepare_field( $_POST['country'] ) : false;
-		$to_state   = isset( $_POST['state'] ) ? $this->prepare_field( $_POST['state'] ) : false;
-		$to_zip     = isset( $_POST['postcode'] ) ? $this->prepare_field( $_POST['postcode'] ) : false;
-		$to_city    = isset( $_POST['city'] ) ? $this->prepare_field( $_POST['city'] ) : false;
-		$to_street  = isset( $_POST['street'] ) ? $this->prepare_field( $_POST['street'] ) : false;
+		$to_country = isset( $_POST['country'] ) ? $this->prepare_field( sanitize_text_field( wp_unslash( $_POST['country'] ) ) ) : false;
+		$to_state   = isset( $_POST['state'] ) ? $this->prepare_field( sanitize_text_field( wp_unslash( $_POST['state'] ) ) ) : false;
+		$to_zip     = isset( $_POST['postcode'] ) ? $this->prepare_field( sanitize_text_field( wp_unslash( $_POST['postcode'] ) ) ) : false;
+		$to_city    = isset( $_POST['city'] ) ? $this->prepare_field( sanitize_text_field( wp_unslash( $_POST['city'] ) ) ) : false;
+		$to_street  = isset( $_POST['street'] ) ? $this->prepare_field( sanitize_text_field( wp_unslash( $_POST['street'] ) ) ) : false;
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		$this->tax_request_body->set_to_country( $to_country );
@@ -43,14 +43,14 @@ class Admin_Order_Tax_Request_Body_Builder extends Order_Tax_Request_Body_Builde
 	}
 
 	/**
-	 * Sanitize, uppercase and remove + signs from the field.
+	 * Uppercase and remove + signs from the field.
 	 *
 	 * @param string $field Field to prepare.
 	 *
 	 * @return string
 	 */
 	private function prepare_field( $field ) {
-		$sanitized_field = strtoupper( sanitize_text_field( wp_unslash( $field ) ) );
+		$sanitized_field = strtoupper( $field );
 		return str_replace( '+', ' ', $sanitized_field );
 	}
 

--- a/includes/abstract-class-taxjar-record.php
+++ b/includes/abstract-class-taxjar-record.php
@@ -52,8 +52,8 @@ abstract class TaxJar_Record {
 		}
 
 		$table_name = self::get_queue_table_name();
-		$query = "SELECT * FROM {$table_name} WHERE queue_id = {$queue_id}";
-		$results = $wpdb->get_results( $query,  ARRAY_A );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, it is derived from a hardcoded table name.
+		$results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE queue_id = %d", $queue_id ), ARRAY_A );
 
 		if ( empty( $results ) || ! is_array( $results ) ) {
 			return false;
@@ -359,8 +359,8 @@ abstract class TaxJar_Record {
 
 		$table_name = self::get_queue_table_name();
 		$record_type = static::get_record_type();
-		$query = "SELECT queue_id FROM {$table_name} WHERE record_id = {$record_id} AND record_type = '{$record_type}' AND status IN ( 'new', 'awaiting' )";
-		$results = $wpdb->get_results( $query,  ARRAY_A );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, it is derived from a hardcoded table name.
+		$results = $wpdb->get_results( $wpdb->prepare( "SELECT queue_id FROM {$table_name} WHERE record_id = %d AND record_type = %s AND status IN ( 'new', 'awaiting' )", $record_id, $record_type ), ARRAY_A );
 
 		if ( empty( $results ) || ! is_array( $results ) ) {
 			return false;

--- a/includes/class-wc-taxjar-ajax.php
+++ b/includes/class-wc-taxjar-ajax.php
@@ -50,7 +50,7 @@ class WC_Taxjar_AJAX {
 
 		$start_date = current_time( $date_format );
 		if ( isset( $_POST[ 'start_date' ] ) ) {
-			$start_datetime = DateTime::createFromFormat( $date_format, $_POST[ 'start_date' ] );
+			$start_datetime = DateTime::createFromFormat( $date_format, sanitize_text_field( wp_unslash( $_POST[ 'start_date' ] ) ) );
 			if ( $start_datetime ) {
 				$start_date = $start_datetime->format( $date_format ) . ' 00:00:00';
 			} else {
@@ -60,7 +60,7 @@ class WC_Taxjar_AJAX {
 
 		$end_date = date( $date_format, strtotime( '+1 day', current_time( 'timestamp' ) ) );
 		if ( isset( $_POST[ 'end_date' ] ) ) {
-			$end_datetime = DateTime::createFromFormat( $date_format, $_POST[ 'end_date' ] );
+			$end_datetime = DateTime::createFromFormat( $date_format, sanitize_text_field( wp_unslash( $_POST[ 'end_date' ] ) ) );
 			if ( $end_datetime ) {
 				$end_date = date( $date_format, strtotime( $end_datetime->format( $date_format ) . ' + 1 day' ) ) .' 00:00:00';
 			} else {

--- a/includes/class-wc-taxjar-customer-sync.php
+++ b/includes/class-wc-taxjar-customer-sync.php
@@ -114,7 +114,7 @@ class WC_Taxjar_Customer_Sync {
 
 		foreach ( $show_fields as $fieldset_key => $fieldset ) :
 			?>
-			<h2><?php echo $fieldset['title']; ?></h2>
+			<h2><?php echo esc_html( $fieldset['title'] ); ?></h2>
 			<table class="form-table" id="<?php echo esc_attr( 'fieldset-' . $fieldset_key ); ?>">
 				<?php foreach ( $fieldset['fields'] as $key => $field ) : ?>
 					<tr>

--- a/includes/class-wc-taxjar-download-orders.php
+++ b/includes/class-wc-taxjar-download-orders.php
@@ -191,11 +191,14 @@ class WC_Taxjar_Download_Orders {
 	 */
 	private function existing_api_key() {
 		global $wpdb;
-		return ( $wpdb->get_var( "SELECT count(key_id)
+		$count = $wpdb->get_var(
+			"SELECT count(key_id)
 			FROM {$wpdb->prefix}woocommerce_api_keys
 			LEFT JOIN $wpdb->users
 			ON {$wpdb->prefix}woocommerce_api_keys.user_id={$wpdb->users}.ID
-			WHERE ({$wpdb->users}.user_login LIKE '%taxjar%' OR {$wpdb->prefix}woocommerce_api_keys.description LIKE '%taxjar%');" ) > 0 );
+			WHERE ({$wpdb->users}.user_login LIKE '%taxjar%' OR {$wpdb->prefix}woocommerce_api_keys.description LIKE '%taxjar%');"
+		);
+		return ( $count > 0 );
 	}
 
 	/**

--- a/includes/class-wc-taxjar-download-orders.php
+++ b/includes/class-wc-taxjar-download-orders.php
@@ -191,12 +191,11 @@ class WC_Taxjar_Download_Orders {
 	 */
 	private function existing_api_key() {
 		global $wpdb;
-		$sql = "SELECT count(key_id)
+		return ( $wpdb->get_var( "SELECT count(key_id)
 			FROM {$wpdb->prefix}woocommerce_api_keys
 			LEFT JOIN $wpdb->users
 			ON {$wpdb->prefix}woocommerce_api_keys.user_id={$wpdb->users}.ID
-			WHERE ({$wpdb->users}.user_login LIKE '%taxjar%' OR {$wpdb->prefix}woocommerce_api_keys.description LIKE '%taxjar%');";
-		return ( $wpdb->get_var( $sql ) > 0 );
+			WHERE ({$wpdb->users}.user_login LIKE '%taxjar%' OR {$wpdb->prefix}woocommerce_api_keys.description LIKE '%taxjar%');" ) > 0 );
 	}
 
 	/**

--- a/includes/class-wc-taxjar-install.php
+++ b/includes/class-wc-taxjar-install.php
@@ -200,6 +200,7 @@ CREATE TABLE {$wpdb->prefix}taxjar_record_queue (
 		$tables = self::get_tables();
 
 		foreach ( $tables as $table ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is not user input, it comes from a hardcoded list of table names.
 			$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
 		}
 	}

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -252,6 +252,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		private function on_edit_order_page() {
 			global $pagenow;
 			if ( 'post.php' === $pagenow ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only page-type detection, no data is processed or saved.
 				if ( isset( $_GET['post'] ) && $this->is_order_post_type( OrderUtil::get_order_type( absint( $_GET['post'] ) ) ) ) {
 					return true;
 				}

--- a/includes/class-wc-taxjar-integration.php
+++ b/includes/class-wc-taxjar-integration.php
@@ -177,13 +177,13 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 			<tr valign="top">
 				<th scope="row" class="titledesc">
 					<label for="<?php echo esc_attr( $field ); ?>"><?php echo wp_kses_post( $data['title'] ); ?></label>
-					<?php echo $this->get_tooltip_html( $data ); ?>
+					<?php echo $this->get_tooltip_html( $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_tooltip_html() already escapes its output. ?>
 				</th>
 				<td class="forminp">
 					<fieldset>
 						<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
-						<button class="<?php echo esc_attr( $data['class'] ); ?>" type="button" name="<?php echo esc_attr( $field ); ?>" id="<?php echo esc_attr( $field ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>" <?php echo $this->get_custom_attribute_html( $data ); ?>><?php echo wp_kses_post( $data['title'] ); ?></button>
-						<?php echo $this->get_description_html( $data ); ?>
+						<button class="<?php echo esc_attr( $data['class'] ); ?>" type="button" name="<?php echo esc_attr( $field ); ?>" id="<?php echo esc_attr( $field ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>" <?php echo $this->get_custom_attribute_html( $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_custom_attribute_html() already escapes its output. ?>><?php echo wp_kses_post( $data['title'] ); ?></button>
+						<?php echo $this->get_description_html( $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_description_html() already escapes its output. ?>
 					</fieldset>
 				</td>
 			</tr>
@@ -199,7 +199,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		 */
 		public function get_value_from_post( $key ) {
 			if ( isset( $_POST[ $this->plugin_id . $this->id . '_settings' ][ $key ] ) ) {
-				return $_POST[ $this->plugin_id . $this->id . '_settings' ][ $key ];
+				return sanitize_text_field( wp_unslash( $_POST[ $this->plugin_id . $this->id . '_settings' ][ $key ] ) );
 			} else {
 				return false;
 			}
@@ -216,7 +216,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 
 			foreach ( $this->errors as $key => $value ) {
 				$message = $error_key_values[ $value ];
-				echo "<div class=\"error\"><p>$message</p></div>";
+				echo '<div class="error"><p>' . esc_html( $message ) . '</p></div>';
 			}
 		}
 
@@ -237,7 +237,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		private function on_new_order_page() {
 			global $pagenow;
 			if ( 'post-new.php' === $pagenow ) {
-				if ( isset( $_GET['post_type'] ) && $this->is_order_post_type( $_GET['post_type'] ) ) {
+				if ( isset( $_GET['post_type'] ) && $this->is_order_post_type( sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) ) ) {
 					return true;
 				}
 			}
@@ -252,7 +252,7 @@ if ( ! class_exists( 'WC_Taxjar_Integration' ) ) :
 		private function on_edit_order_page() {
 			global $pagenow;
 			if ( 'post.php' === $pagenow ) {
-				if ( $this->is_order_post_type( OrderUtil::get_order_type($_GET['post']) ) ) {
+				if ( isset( $_GET['post'] ) && $this->is_order_post_type( OrderUtil::get_order_type( absint( $_GET['post'] ) ) ) ) {
 					return true;
 				}
 			}

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -167,7 +167,7 @@ class WC_Taxjar_Nexus {
 		$placeholders     = implode( ',', array_fill( 0, count( $states_for_query ), '%s' ) );
 		$results          = $wpdb->query(
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_country = 'US' AND tax_rate_state NOT IN ({$placeholders})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders only contains %s placeholders, not user input.
+				"DELETE FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_country = 'US' AND tax_rate_state NOT IN ({$placeholders})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $placeholders only contains %s placeholders, not user input.
 				$states_for_query
 			)
 		);

--- a/includes/class-wc-taxjar-nexus.php
+++ b/includes/class-wc-taxjar-nexus.php
@@ -163,9 +163,14 @@ class WC_Taxjar_Nexus {
 			}
 		}
 
-		$nexus_states_string = join( "','", $nexus_states );
-		$query = "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_country = 'US' AND tax_rate_state NOT IN ('{$nexus_states_string}')";
-		$results = $wpdb->query( $query );
+		$states_for_query = empty( $nexus_states ) ? array( '' ) : $nexus_states;
+		$placeholders     = implode( ',', array_fill( 0, count( $states_for_query ), '%s' ) );
+		$results          = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_country = 'US' AND tax_rate_state NOT IN ({$placeholders})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders only contains %s placeholders, not user input.
+				$states_for_query
+			)
+		);
 	}
 
 } // End WC_Taxjar_Nexus.

--- a/includes/class-wc-taxjar-queue-list.php
+++ b/includes/class-wc-taxjar-queue-list.php
@@ -200,38 +200,50 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 		global $wpdb;
 		$table_name = WC_Taxjar_Record_Queue::get_queue_table_name();
 		$where = " WHERE 1=1 " ;
-		$query = "SELECT * FROM {$table_name}";
+		$where_args = array();
 
 		if ( isset( $_REQUEST[ 'taxjar_record_status' ] ) ) {
-			if ( $_REQUEST[ 'taxjar_record_status' ] == 'completed' ) {
+			$record_status = sanitize_text_field( wp_unslash( $_REQUEST[ 'taxjar_record_status' ] ) );
+			if ( $record_status == 'completed' ) {
 				$where .= "AND status = 'completed' ";
-			} else if ( $_REQUEST[ 'taxjar_record_status' ] == 'awaiting' ) {
+			} else if ( $record_status == 'awaiting' ) {
 				$where .= "AND status IN ( 'new', 'awaiting' ) ";
-			} else if ( $_REQUEST[ 'taxjar_record_status' ] == 'failed' ) {
+			} else if ( $record_status == 'failed' ) {
 				$where .= "AND status = 'failed' ";
 			}
         }
 
 		if ( isset( $_REQUEST[ 'taxjar_record_type' ] ) ) {
-			if ( $_REQUEST[ 'taxjar_record_type' ] == 'order' ) {
+			$record_type = sanitize_text_field( wp_unslash( $_REQUEST[ 'taxjar_record_type' ] ) );
+			if ( $record_type == 'order' ) {
 				$where .= "AND record_type = 'order' ";
-			} else if ( $_REQUEST[ 'taxjar_record_type' ] == 'refund' ) {
+			} else if ( $record_type == 'refund' ) {
 				$where .= "AND record_type = 'refund' ";
-			} else if ( $_REQUEST[ 'taxjar_record_type' ] == 'customer' ) {
+			} else if ( $record_type == 'customer' ) {
 				$where .= "AND record_type = 'customer' ";
 			}
 		}
 
 		if ( isset( $_REQUEST[ 's' ] ) && ! empty( $_REQUEST[ 's' ] ) ) {
-		    $search = sanitize_text_field(  $_REQUEST[ 's' ] );
-			$where .= "AND record_id = '{$search}' ";
+		    $search = sanitize_text_field( wp_unslash( $_REQUEST[ 's' ] ) );
+			$where .= 'AND record_id = %s ';
+			$where_args[] = $search;
 		}
 
-        $query .= $where . "ORDER BY queue_id DESC LIMIT {$offset}, {$per_page}";
-		$this->items = $wpdb->get_results( $query );
+		$total_query_args = $where_args;
+		$where_args[] = $offset;
+		$where_args[] = $per_page;
 
-		$total_query = "SELECT COUNT(*) FROM {$table_name}" . $where;
-		$total_records = $wpdb->get_var( $total_query );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $table_name and $where are not user input; $where only contains hardcoded SQL fragments and a %s placeholder for the sanitized search term.
+		$this->items = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name}" . $where . "ORDER BY queue_id DESC LIMIT %d, %d", $where_args ) );
+
+		if ( empty( $total_query_args ) ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $table_name and $where are not user input; $where only contains hardcoded SQL fragments.
+			$total_records = $wpdb->get_var( "SELECT COUNT(*) FROM {$table_name}" . $where );
+		} else {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $table_name and $where are not user input; $where only contains hardcoded SQL fragments and a %s placeholder for the sanitized search term.
+			$total_records = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table_name}" . $where, $total_query_args ) );
+		}
 
 		$this->set_pagination_args(
 			array(
@@ -263,11 +275,13 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 				'customer'      => _x( 'Customers', 'A record type', 'wc-taxjar' ),
 			) );
 
+			$current_record_type = isset( $_REQUEST['taxjar_record_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['taxjar_record_type'] ) ) : '';
+
 			foreach ( $record_types as $record_type_key => $record_type_description ) {
 				echo '<option value="' . esc_attr( $record_type_key ) . '"';
 
-				if ( isset( $_REQUEST['taxjar_record_type'] ) && $_REQUEST['taxjar_record_type'] ) {
-					selected( $record_type_key, $_REQUEST['taxjar_record_type'] );
+				if ( $current_record_type ) {
+					selected( $record_type_key, $current_record_type );
 				}
 
 				echo '>' . esc_html( $record_type_description ) . '</option>';
@@ -284,11 +298,13 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 				'failed'      => _x( 'Failed', 'A sync status', 'wc-taxjar' ),
 			) );
 
+			$current_record_status = isset( $_REQUEST['taxjar_record_status'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['taxjar_record_status'] ) ) : '';
+
 			foreach ( $record_statuses as $record_status_key => $record_status_description ) {
 				echo '<option value="' . esc_attr( $record_status_key ) . '"';
 
-				if ( isset( $_REQUEST['taxjar_record_status'] ) && $_REQUEST['taxjar_record_status'] ) {
-					selected( $record_status_key, $_REQUEST['taxjar_record_status'] );
+				if ( $current_record_status ) {
+					selected( $record_status_key, $current_record_status );
 				}
 
 				echo '>' . esc_html( $record_status_description ) . '</option>';

--- a/includes/class-wc-taxjar-queue-list.php
+++ b/includes/class-wc-taxjar-queue-list.php
@@ -225,23 +225,23 @@ class WC_Taxjar_Queue_List extends WP_List_Table {
 		}
 
 		if ( isset( $_REQUEST[ 's' ] ) && ! empty( $_REQUEST[ 's' ] ) ) {
-		    $search = sanitize_text_field( wp_unslash( $_REQUEST[ 's' ] ) );
-			$where .= 'AND record_id = %s ';
+		    $search       = sanitize_text_field( wp_unslash( $_REQUEST[ 's' ] ) );
+			$where       .= 'AND record_id = %s ';
 			$where_args[] = $search;
 		}
 
 		$total_query_args = $where_args;
-		$where_args[] = $offset;
-		$where_args[] = $per_page;
+		$where_args[]     = $offset;
+		$where_args[]     = $per_page;
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $table_name and $where are not user input; $where only contains hardcoded SQL fragments and a %s placeholder for the sanitized search term.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $table_name and $where are not user input; $where_args is an array of replacements for the %s placeholder in $where plus %d, %d for LIMIT, which $wpdb->prepare() accepts as a single array argument.
 		$this->items = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name}" . $where . "ORDER BY queue_id DESC LIMIT %d, %d", $where_args ) );
 
 		if ( empty( $total_query_args ) ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $table_name and $where are not user input; $where only contains hardcoded SQL fragments.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $table_name and $where are not user input; $where only contains hardcoded SQL fragments.
 			$total_records = $wpdb->get_var( "SELECT COUNT(*) FROM {$table_name}" . $where );
 		} else {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $table_name and $where are not user input; $where only contains hardcoded SQL fragments and a %s placeholder for the sanitized search term.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $table_name and $where are not user input; $where only contains hardcoded SQL fragments and a %s placeholder for the sanitized search term.
 			$total_records = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table_name}" . $where, $total_query_args ) );
 		}
 

--- a/includes/class-wc-taxjar-record-queue.php
+++ b/includes/class-wc-taxjar-record-queue.php
@@ -31,8 +31,8 @@ class WC_Taxjar_Record_Queue {
 
 		$table_name = self::get_queue_table_name();
 
-		$query = "SELECT queue_id FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )";
-		$results = $wpdb->get_results( $query, ARRAY_A );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, it is derived from a hardcoded table name.
+		$results = $wpdb->get_results( "SELECT queue_id FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )", ARRAY_A );
 
 		return $results;
 	}
@@ -48,8 +48,8 @@ class WC_Taxjar_Record_Queue {
 
 		$table_name = self::get_queue_table_name();
 
-		$query = "SELECT * FROM {$table_name} WHERE status IN ( 'new', 'awaiting' ) LIMIT {$number_to_process}";
-		$results = $wpdb->get_results( $query, ARRAY_A );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, it is derived from a hardcoded table name.
+		$results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE status IN ( 'new', 'awaiting' ) LIMIT %d", $number_to_process ), ARRAY_A );
 
 		return $results;
 	}
@@ -64,8 +64,8 @@ class WC_Taxjar_Record_Queue {
 
 		$table_name = self::get_queue_table_name();
 
-		$query = "SELECT COUNT(*) FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )";
-		$results = $wpdb->get_var( $query );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, it is derived from a hardcoded table name.
+		$results = $wpdb->get_var( "SELECT COUNT(*) FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )" );
 
 		return $results;
 	}
@@ -80,8 +80,8 @@ class WC_Taxjar_Record_Queue {
 
 		$table_name = self::get_queue_table_name();
 
-		$query = "SELECT * FROM {$table_name} ORDER BY queue_id DESC LIMIT 0, 20";
-		$results = $wpdb->get_results( $query );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, it is derived from a hardcoded table name.
+		$results = $wpdb->get_results( "SELECT * FROM {$table_name} ORDER BY queue_id DESC LIMIT 0, 20" );
 		return $results;
 	}
 
@@ -95,8 +95,8 @@ class WC_Taxjar_Record_Queue {
 
 		$table_name = self::get_queue_table_name();
 
-		$query = "SELECT queue_id, record_id FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )";
-		$results = $wpdb->get_results( $query, ARRAY_A );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, it is derived from a hardcoded table name.
+		$results = $wpdb->get_results( "SELECT queue_id, record_id FROM {$table_name} WHERE status IN ( 'new', 'awaiting' )", ARRAY_A );
 
 		return $results;
 	}
@@ -110,10 +110,11 @@ class WC_Taxjar_Record_Queue {
 		global $wpdb;
 
 		$table_name = self::get_queue_table_name();
-		$queue_ids_string = join( "','", $queue_ids );
+		$ids_for_query = empty( $queue_ids ) ? array( '' ) : $queue_ids;
+		$placeholders = implode( ',', array_fill( 0, count( $ids_for_query ), '%s' ) );
 
-		$query = "SELECT * FROM {$table_name} WHERE queue_id IN ('{$queue_ids_string}')";
-		$results = $wpdb->get_results( $query, ARRAY_A );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, and $placeholders only contains %s placeholders.
+		$results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE queue_id IN ({$placeholders})", $ids_for_query ), ARRAY_A );
 
 		return $results;
 	}
@@ -126,8 +127,8 @@ class WC_Taxjar_Record_Queue {
 	static function clear_queue() {
 		global $wpdb;
 		$table_name = self::get_queue_table_name();
-		$query = "TRUNCATE TABLE {$table_name}";
-		$result = $wpdb->query( $query );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, it is derived from a hardcoded table name.
+		$result = $wpdb->query( "TRUNCATE TABLE {$table_name}" );
 		return $result;
 	}
 
@@ -139,8 +140,8 @@ class WC_Taxjar_Record_Queue {
 
 		$table_name = self::get_queue_table_name();
 
-		$query = "DELETE FROM {$table_name} WHERE status IN ( 'new', 'awaiting' ) AND record_type IN ( 'order', 'refund' )";
-		$results = $wpdb->query( $query );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, it is derived from a hardcoded table name.
+		$results = $wpdb->query( "DELETE FROM {$table_name} WHERE status IN ( 'new', 'awaiting' ) AND record_type IN ( 'order', 'refund' )" );
 
 		return $results;
 	}
@@ -159,10 +160,10 @@ class WC_Taxjar_Record_Queue {
 		);
 		$active_batches = as_get_scheduled_actions( $args, 'ids' );
 		$active_batches[] = 0;
-		$active_batches_string = join( "','", $active_batches );
+		$placeholders = implode( ',', array_fill( 0, count( $active_batches ), '%d' ) );
 
-		$query = "UPDATE {$table_name} SET batch_id = 0 WHERE batch_id NOT IN ('{$active_batches_string}') AND status IN ('new', 'awaiting')";
-		$results = $wpdb->get_results( $query );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, and $placeholders only contains %d placeholders.
+		$results = $wpdb->get_results( $wpdb->prepare( "UPDATE {$table_name} SET batch_id = 0 WHERE batch_id NOT IN ({$placeholders}) AND status IN ('new', 'awaiting')", $active_batches ) );
 	}
 
 }

--- a/includes/class-wc-taxjar-record-queue.php
+++ b/includes/class-wc-taxjar-record-queue.php
@@ -111,9 +111,9 @@ class WC_Taxjar_Record_Queue {
 
 		$table_name    = self::get_queue_table_name();
 		$ids_for_query = empty( $queue_ids ) ? array( '' ) : $queue_ids;
-		$placeholders  = implode( ',', array_fill( 0, count( $ids_for_query ), '%s' ) );
+		$placeholders  = implode( ',', array_fill( 0, count( $ids_for_query ), '%d' ) );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $table_name is not user input, and $placeholders only contains %s placeholders.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $table_name is not user input, and $placeholders only contains %d placeholders.
 		$results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE queue_id IN ({$placeholders})", $ids_for_query ), ARRAY_A );
 
 		return $results;

--- a/includes/class-wc-taxjar-record-queue.php
+++ b/includes/class-wc-taxjar-record-queue.php
@@ -109,11 +109,11 @@ class WC_Taxjar_Record_Queue {
 	static function get_data_for_batch( $queue_ids ) {
 		global $wpdb;
 
-		$table_name = self::get_queue_table_name();
+		$table_name    = self::get_queue_table_name();
 		$ids_for_query = empty( $queue_ids ) ? array( '' ) : $queue_ids;
-		$placeholders = implode( ',', array_fill( 0, count( $ids_for_query ), '%s' ) );
+		$placeholders  = implode( ',', array_fill( 0, count( $ids_for_query ), '%s' ) );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, and $placeholders only contains %s placeholders.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $table_name is not user input, and $placeholders only contains %s placeholders.
 		$results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE queue_id IN ({$placeholders})", $ids_for_query ), ARRAY_A );
 
 		return $results;
@@ -153,7 +153,7 @@ class WC_Taxjar_Record_Queue {
 		global $wpdb;
 		$table_name = self::get_queue_table_name();
 
-		$args = array(
+		$args             = array(
 			'hook' => WC_Taxjar_Transaction_Sync::PROCESS_BATCH_HOOK,
 			'status' => ActionScheduler_Store::STATUS_PENDING,
 			'per_page' => 0,
@@ -162,7 +162,7 @@ class WC_Taxjar_Record_Queue {
 		$active_batches[] = 0;
 		$placeholders = implode( ',', array_fill( 0, count( $active_batches ), '%d' ) );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is not user input, and $placeholders only contains %d placeholders.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $table_name is not user input, and $placeholders only contains %d placeholders.
 		$results = $wpdb->get_results( $wpdb->prepare( "UPDATE {$table_name} SET batch_id = 0 WHERE batch_id NOT IN ({$placeholders}) AND status IN ('new', 'awaiting')", $active_batches ) );
 	}
 

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -502,31 +502,26 @@ class WC_Taxjar_Transaction_Sync {
 		$diff = array_diff( $order_ids, $record_ids );
 
 		if ( ! empty( $diff ) ) {
-			if ( $force ) {
-				$query = "INSERT INTO {$queue_table} (record_id, record_type, force_push, status, created_datetime) VALUES";
-				$count = 0;
-				foreach( $diff as $order_id ) {
-					if ( ! $count ) {
-						$query .= " ( {$order_id}, 'order', 1, 'awaiting', '{$current_datetime}' )";
-					} else {
-						$query .= ", ( {$order_id}, 'order', 1,  'awaiting', '{$current_datetime}' )";
-					}
-					$count++;
+			$values = array();
+			$args   = array();
+			foreach ( $diff as $order_id ) {
+				if ( $force ) {
+					$values[] = '( %d, %s, 1, %s, %s )';
+				} else {
+					$values[] = '( %d, %s, %s, %s )';
 				}
-			} else {
-				$query = "INSERT INTO {$queue_table} (record_id, record_type, status, created_datetime) VALUES";
-				$count = 0;
-				foreach( $diff as $order_id ) {
-					if ( ! $count ) {
-						$query .= " ( {$order_id}, 'order', 'awaiting', '{$current_datetime}' )";
-					} else {
-						$query .= ", ( {$order_id}, 'order', 'awaiting', '{$current_datetime}' )";
-					}
-					$count++;
-				}
+				$args[] = $order_id;
+				$args[] = 'order';
+				$args[] = 'awaiting';
+				$args[] = $current_datetime;
 			}
 
-			$wpdb->query( $query );
+			$columns = $force
+				? '(record_id, record_type, force_push, status, created_datetime)'
+				: '(record_id, record_type, status, created_datetime)';
+
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $queue_table is not user input, and $values only contains %d/%s placeholders, not data.
+			$wpdb->query( $wpdb->prepare( "INSERT INTO {$queue_table} {$columns} VALUES " . implode( ', ', $values ), $args ) );
 
 			if ( $wpdb->last_error === "Table 'wordpress.wp_taxjar_record_queue' doesn't exist" ) {
 				return 'record queue table does not exist';
@@ -537,30 +532,26 @@ class WC_Taxjar_Transaction_Sync {
 		$refunds_diff = array_diff( $refund_ids, $record_ids );
 
 		if ( ! empty( $refunds_diff ) ) {
-			if ( $force ) {
-				$query = "INSERT INTO {$queue_table} (record_id, record_type, force_push, status, created_datetime) VALUES";
-				$count = 0;
-				foreach( $refunds_diff as $refund_id ) {
-					if ( ! $count ) {
-						$query .= " ( {$refund_id}, 'refund', 1, 'awaiting', '{$current_datetime}' )";
-					} else {
-						$query .= ", ( {$refund_id}, 'refund', 1,  'awaiting', '{$current_datetime}' )";
-					}
-					$count++;
+			$values = array();
+			$args   = array();
+			foreach ( $refunds_diff as $refund_id ) {
+				if ( $force ) {
+					$values[] = '( %d, %s, 1, %s, %s )';
+				} else {
+					$values[] = '( %d, %s, %s, %s )';
 				}
-			} else {
-				$query = "INSERT INTO {$queue_table} (record_id, record_type, status, created_datetime) VALUES";
-				$count = 0;
-				foreach( $refunds_diff as $refund_id ) {
-					if ( ! $count ) {
-						$query .= " ( {$refund_id}, 'refund', 'awaiting', '{$current_datetime}' )";
-					} else {
-						$query .= ", ( {$refund_id}, 'refund', 'awaiting', '{$current_datetime}' )";
-					}
-					$count++;
-				}
+				$args[] = $refund_id;
+				$args[] = 'refund';
+				$args[] = 'awaiting';
+				$args[] = $current_datetime;
 			}
-			$wpdb->query( $query );
+
+			$columns = $force
+				? '(record_id, record_type, force_push, status, created_datetime)'
+				: '(record_id, record_type, status, created_datetime)';
+
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $queue_table is not user input, and $values only contains %d/%s placeholders, not data.
+			$wpdb->query( $wpdb->prepare( "INSERT INTO {$queue_table} {$columns} VALUES " . implode( ', ', $values ), $args ) );
 		}
 
 		if ( $force ) {
@@ -571,9 +562,9 @@ class WC_Taxjar_Transaction_Sync {
 
 			$in_queue = array_values( array_intersect_key( $records, array_flip( $transaction_ids ) ) );
 			if ( ! empty( $in_queue ) ) {
-				$in_queue_string = implode( ', ', $in_queue );
-				$query = "UPDATE {$queue_table} SET force_push = 1 WHERE queue_id in ( {$in_queue_string} )";
-				$wpdb->query( $query );
+				$placeholders = implode( ', ', array_fill( 0, count( $in_queue ), '%d' ) );
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $queue_table is not user input, and $placeholders only contains %d placeholders.
+				$wpdb->query( $wpdb->prepare( "UPDATE {$queue_table} SET force_push = 1 WHERE queue_id in ( {$placeholders} )", $in_queue ) );
 			}
 		}
 
@@ -599,7 +590,8 @@ class WC_Taxjar_Transaction_Sync {
 		}
 
 		$valid_post_statuses = apply_filters( 'taxjar_valid_post_statuses_for_sync', array( 'wc-completed', 'wc-refunded' ) );
-		$post_status_string = "( '" . implode( "', '", $valid_post_statuses ) . " ')";
+		$post_status_placeholders = implode( ', ', array_fill( 0, count( $valid_post_statuses ), '%s' ) );
+		$args = array_merge( $valid_post_statuses, array( $start_date, $end_date ) );
 
 		$should_validate_completed_date = WC_Taxjar_Transaction_Sync::should_validate_order_completed_date();
 
@@ -612,7 +604,7 @@ class WC_Taxjar_Transaction_Sync {
 					$query .= "INNER JOIN {$wpdb->wc_orders_meta} AS order_meta_completed_date ON ( o.id = order_meta_completed_date.order_id ) AND ( order_meta_completed_date.meta_key = '_completed_date' ) ";
 				}
 
-				$query .= "WHERE o.type = 'shop_order' AND o.status IN {$post_status_string} AND o.date_created_gmt >= '{$start_date}' AND o.date_created_gmt < '{$end_date}' ";
+				$query .= "WHERE o.type = 'shop_order' AND o.status IN ( {$post_status_placeholders} ) AND o.date_created_gmt >= %s AND o.date_created_gmt < %s ";
 
 				if ( $should_validate_completed_date ) {
 					$query .= "AND order_meta_completed_date.meta_value IS NOT NULL AND order_meta_completed_date.meta_value != '' ";
@@ -627,7 +619,7 @@ class WC_Taxjar_Transaction_Sync {
 				}
 
 				$query .= "LEFT JOIN {$wpdb->wc_order_meta} AS order_meta_last_sync ON ( o.id = order_meta_last_sync.order_id ) AND ( order_meta_last_sync.meta_key = '_taxjar_last_sync' ) ";
-				$query .= "WHERE o.type = 'shop_order' AND o.status IN {$post_status_string} AND o.date_created_gmt >= '{$start_date}' AND o.date_created_gmt < '{$end_date}' ";
+				$query .= "WHERE o.type = 'shop_order' AND o.status IN ( {$post_status_placeholders} ) AND o.date_created_gmt >= %s AND o.date_created_gmt < %s ";
 
 				if ( $should_validate_completed_date ) {
 					$query .= "AND order_meta_completed_date.meta_value IS NOT NULL AND order_meta_completed_date.meta_value != '' ";
@@ -644,7 +636,7 @@ class WC_Taxjar_Transaction_Sync {
 					$query .= "INNER JOIN {$wpdb->postmeta} AS order_meta_completed_date ON ( p.id = order_meta_completed_date.post_id ) AND ( order_meta_completed_date.meta_key = '_completed_date' ) ";
 				}
 
-				$query .= "WHERE p.post_type = 'shop_order' AND p.post_status IN {$post_status_string} AND p.post_date >= '{$start_date}' AND p.post_date < '{$end_date}' ";
+				$query .= "WHERE p.post_type = 'shop_order' AND p.post_status IN ( {$post_status_placeholders} ) AND p.post_date >= %s AND p.post_date < %s ";
 
 				if ( $should_validate_completed_date ) {
 					$query .= "AND order_meta_completed_date.meta_value IS NOT NULL AND order_meta_completed_date.meta_value != '' ";
@@ -659,7 +651,7 @@ class WC_Taxjar_Transaction_Sync {
 				}
 
 				$query .= "LEFT JOIN {$wpdb->postmeta} AS order_meta_last_sync ON ( p.id = order_meta_last_sync.post_id ) AND ( order_meta_last_sync.meta_key = '_taxjar_last_sync' ) ";
-				$query .= "WHERE p.post_type = 'shop_order' AND p.post_status IN {$post_status_string} AND p.post_date >= '{$start_date}' AND p.post_date < '{$end_date}' ";
+				$query .= "WHERE p.post_type = 'shop_order' AND p.post_status IN ( {$post_status_placeholders} ) AND p.post_date >= %s AND p.post_date < %s ";
 
 				if ( $should_validate_completed_date ) {
 					$query .= "AND order_meta_completed_date.meta_value IS NOT NULL AND order_meta_completed_date.meta_value != '' ";
@@ -669,7 +661,8 @@ class WC_Taxjar_Transaction_Sync {
 			}
 		}
 
-		$posts = $wpdb->get_results( $query, ARRAY_N );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $query is built from static fragments and table names are wpdb properties, not user input; $post_status_placeholders only contains %s placeholders.
+		$posts = $wpdb->get_results( $wpdb->prepare( $query, $args ), ARRAY_N );
 
 		if ( empty( $posts ) ) {
 			return array();
@@ -689,32 +682,16 @@ class WC_Taxjar_Transaction_Sync {
 		}
 
 		global $wpdb;
-		$order_ids_string = implode( ',', $order_ids );
+		$placeholders = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
 
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			// HPOS usage is enabled.
-			$posts = $wpdb->get_results(
-				"
-			SELECT o.id
-			FROM {$wpdb->wc_orders} AS o
-			WHERE o.type = 'shop_order_refund'
-			AND o.status = 'wc-completed'
-			AND o.parent IN ( {$order_ids_string} )
-			ORDER BY o.date_created_gmt ASC
-			", ARRAY_N
-			);
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $wpdb->wc_orders is not user input, and $placeholders only contains %d placeholders.
+			$posts = $wpdb->get_results( $wpdb->prepare( "SELECT o.id FROM {$wpdb->wc_orders} AS o WHERE o.type = 'shop_order_refund' AND o.status = 'wc-completed' AND o.parent IN ( {$placeholders} ) ORDER BY o.date_created_gmt ASC", $order_ids ), ARRAY_N );
 		} else {
 			// Traditional CPT-based orders are in use.
-			$posts = $wpdb->get_results(
-				"
-			SELECT p.id
-			FROM {$wpdb->posts} AS p
-			WHERE p.post_type = 'shop_order_refund'
-			AND p.post_status = 'wc-completed'
-			AND p.post_parent IN ( {$order_ids_string} )
-			ORDER BY p.post_date ASC
-			", ARRAY_N
-			);
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $wpdb->posts is not user input, and $placeholders only contains %d placeholders.
+			$posts = $wpdb->get_results( $wpdb->prepare( "SELECT p.id FROM {$wpdb->posts} AS p WHERE p.post_type = 'shop_order_refund' AND p.post_status = 'wc-completed' AND p.post_parent IN ( {$placeholders} ) ORDER BY p.post_date ASC", $order_ids ), ARRAY_N );
 		}
 
 		if ( empty( $posts ) ) {
@@ -748,7 +725,7 @@ class WC_Taxjar_Transaction_Sync {
 		$notice .= '<a target="_blank" href="https://support.taxjar.com/article/309-overriding-tax-rates-and-exempting-products-in-woocommerce">';
 		$notice .= __( 'this article', 'wc-taxjar' );
 		$notice .= '</a>.</p>';
-		echo $notice;
+		echo wp_kses_post( $notice );
 	}
 
 	/**

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -520,7 +520,7 @@ class WC_Taxjar_Transaction_Sync {
 				? '(record_id, record_type, force_push, status, created_datetime)'
 				: '(record_id, record_type, status, created_datetime)';
 
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $queue_table is not user input, and $values only contains %d/%s placeholders, not data.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $queue_table is not user input, and $values only contains %d/%s placeholders, not data.
 			$wpdb->query( $wpdb->prepare( "INSERT INTO {$queue_table} {$columns} VALUES " . implode( ', ', $values ), $args ) );
 
 			if ( $wpdb->last_error === "Table 'wordpress.wp_taxjar_record_queue' doesn't exist" ) {
@@ -550,7 +550,7 @@ class WC_Taxjar_Transaction_Sync {
 				? '(record_id, record_type, force_push, status, created_datetime)'
 				: '(record_id, record_type, status, created_datetime)';
 
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $queue_table is not user input, and $values only contains %d/%s placeholders, not data.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $queue_table is not user input, and $values only contains %d/%s placeholders, not data.
 			$wpdb->query( $wpdb->prepare( "INSERT INTO {$queue_table} {$columns} VALUES " . implode( ', ', $values ), $args ) );
 		}
 
@@ -563,7 +563,7 @@ class WC_Taxjar_Transaction_Sync {
 			$in_queue = array_values( array_intersect_key( $records, array_flip( $transaction_ids ) ) );
 			if ( ! empty( $in_queue ) ) {
 				$placeholders = implode( ', ', array_fill( 0, count( $in_queue ), '%d' ) );
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $queue_table is not user input, and $placeholders only contains %d placeholders.
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $queue_table is not user input, and $placeholders only contains %d placeholders.
 				$wpdb->query( $wpdb->prepare( "UPDATE {$queue_table} SET force_push = 1 WHERE queue_id in ( {$placeholders} )", $in_queue ) );
 			}
 		}
@@ -589,9 +589,9 @@ class WC_Taxjar_Transaction_Sync {
 			$end_date = date( 'Y-m-d H:i:s', strtotime( '+1 day, midnight', current_time( 'timestamp' ) ) );
 		}
 
-		$valid_post_statuses = apply_filters( 'taxjar_valid_post_statuses_for_sync', array( 'wc-completed', 'wc-refunded' ) );
+		$valid_post_statuses      = apply_filters( 'taxjar_valid_post_statuses_for_sync', array( 'wc-completed', 'wc-refunded' ) );
 		$post_status_placeholders = implode( ', ', array_fill( 0, count( $valid_post_statuses ), '%s' ) );
-		$args = array_merge( $valid_post_statuses, array( $start_date, $end_date ) );
+		$args                     = array_merge( $valid_post_statuses, array( $start_date, $end_date ) );
 
 		$should_validate_completed_date = WC_Taxjar_Transaction_Sync::should_validate_order_completed_date();
 
@@ -686,11 +686,11 @@ class WC_Taxjar_Transaction_Sync {
 
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			// HPOS usage is enabled.
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $wpdb->wc_orders is not user input, and $placeholders only contains %d placeholders.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $wpdb->wc_orders is not user input, and $placeholders only contains %d placeholders.
 			$posts = $wpdb->get_results( $wpdb->prepare( "SELECT o.id FROM {$wpdb->wc_orders} AS o WHERE o.type = 'shop_order_refund' AND o.status = 'wc-completed' AND o.parent IN ( {$placeholders} ) ORDER BY o.date_created_gmt ASC", $order_ids ), ARRAY_N );
 		} else {
 			// Traditional CPT-based orders are in use.
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $wpdb->posts is not user input, and $placeholders only contains %d placeholders.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $wpdb->posts is not user input, and $placeholders only contains %d placeholders.
 			$posts = $wpdb->get_results( $wpdb->prepare( "SELECT p.id FROM {$wpdb->posts} AS p WHERE p.post_type = 'shop_order_refund' AND p.post_status = 'wc-completed' AND p.post_parent IN ( {$placeholders} ) ORDER BY p.post_date ASC", $order_ids ), ARRAY_N );
 		}
 

--- a/includes/class-wc-taxjar-transaction-sync.php
+++ b/includes/class-wc-taxjar-transaction-sync.php
@@ -589,7 +589,12 @@ class WC_Taxjar_Transaction_Sync {
 			$end_date = date( 'Y-m-d H:i:s', strtotime( '+1 day, midnight', current_time( 'timestamp' ) ) );
 		}
 
-		$valid_post_statuses      = apply_filters( 'taxjar_valid_post_statuses_for_sync', array( 'wc-completed', 'wc-refunded' ) );
+		$valid_post_statuses = apply_filters( 'taxjar_valid_post_statuses_for_sync', array( 'wc-completed', 'wc-refunded' ) );
+
+		if ( empty( $valid_post_statuses ) ) {
+			return array();
+		}
+
 		$post_status_placeholders = implode( ', ', array_fill( 0, count( $valid_post_statuses ), '%s' ) );
 		$args                     = array_merge( $valid_post_statuses, array( $start_date, $end_date ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: taxjar, tonkapark, fastdivision
 Tags: woocommerce, taxjar, tax, taxes, sales tax, tax calculation, sales tax compliance, sales tax filing
 Requires at least: 5.4
 Tested up to: 7.1
-Stable tag: 4.2.9
+Stable tag: 4.2.10
 License: GPLv2 or later
 URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 7.0.0
@@ -94,6 +94,9 @@ Our plans come with filings included, with additional filings available for purc
 3. TaxJar for WooCommerce Plugin Settings
 
 == Changelog ==
+
+= 4.2.10 (2026-09-04) =
+* Fix phpcs errors surfaced from external Quality Insights Toolkit run
 
 = 4.2.9 (2026-09-02) =
 * WooCommerce tested up to 11.0.1

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -186,17 +186,31 @@ final class WC_Taxjar {
 		 *
 		 * Based on code inside core's upgrade_network() function.
 		 */
-		$rows = $wpdb->query( $wpdb->prepare( "DELETE a, b FROM $wpdb->options a, $wpdb->options b
-			WHERE a.option_name LIKE %s
-			AND a.option_name NOT LIKE %s
-			AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
-			AND b.option_value < %d", $wpdb->esc_like( '_transient_' ) . '%', $wpdb->esc_like( '_transient_timeout_' ) . '%', time() ) );
+		$rows = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE a, b FROM $wpdb->options a, $wpdb->options b
+				WHERE a.option_name LIKE %s
+				AND a.option_name NOT LIKE %s
+				AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
+				AND b.option_value < %d",
+				$wpdb->esc_like( '_transient_' ) . '%',
+				$wpdb->esc_like( '_transient_timeout_' ) . '%',
+				time()
+			)
+		);
 
-		$rows2 = $wpdb->query( $wpdb->prepare( "DELETE a, b FROM $wpdb->options a, $wpdb->options b
-			WHERE a.option_name LIKE %s
-			AND a.option_name NOT LIKE %s
-			AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
-			AND b.option_value < %d", $wpdb->esc_like( '_site_transient_' ) . '%', $wpdb->esc_like( '_site_transient_timeout_' ) . '%', time() ) );
+		$rows2 = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE a, b FROM $wpdb->options a, $wpdb->options b
+				WHERE a.option_name LIKE %s
+				AND a.option_name NOT LIKE %s
+				AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
+				AND b.option_value < %d",
+				$wpdb->esc_like( '_site_transient_' ) . '%',
+				$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+				time()
+			)
+		);
 
 		// Export Tax Rates
 		$current_class = '';

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -152,7 +152,7 @@ final class WC_Taxjar {
 			$admin_notice_content = sprintf( esc_html__( '%1$sTaxJar is inactive.%2$s This version of TaxJar requires WooCommerce %3$s or newer. Please install or update WooCommerce to version %3$s or newer.', 'wc-taxjar' ), '<strong>', '</strong>', self::$minimum_woocommerce_version );
 			?>
 			<div class="error">
-				<p><?php echo $admin_notice_content; ?></p>
+				<p><?php echo wp_kses_post( $admin_notice_content ); ?></p>
 			</div>
 			<?php
 		}
@@ -186,19 +186,17 @@ final class WC_Taxjar {
 		 *
 		 * Based on code inside core's upgrade_network() function.
 		 */
-		$sql = "DELETE a, b FROM $wpdb->options a, $wpdb->options b
+		$rows = $wpdb->query( $wpdb->prepare( "DELETE a, b FROM $wpdb->options a, $wpdb->options b
 			WHERE a.option_name LIKE %s
 			AND a.option_name NOT LIKE %s
 			AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
-			AND b.option_value < %d";
-		$rows = $wpdb->query( $wpdb->prepare( $sql, $wpdb->esc_like( '_transient_' ) . '%', $wpdb->esc_like( '_transient_timeout_' ) . '%', time() ) );
+			AND b.option_value < %d", $wpdb->esc_like( '_transient_' ) . '%', $wpdb->esc_like( '_transient_timeout_' ) . '%', time() ) );
 
-		$sql = "DELETE a, b FROM $wpdb->options a, $wpdb->options b
+		$rows2 = $wpdb->query( $wpdb->prepare( "DELETE a, b FROM $wpdb->options a, $wpdb->options b
 			WHERE a.option_name LIKE %s
 			AND a.option_name NOT LIKE %s
 			AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
-			AND b.option_value < %d";
-		$rows2 = $wpdb->query( $wpdb->prepare( $sql, $wpdb->esc_like( '_site_transient_' ) . '%', $wpdb->esc_like( '_site_transient_timeout_' ) . '%', time() ) );
+			AND b.option_value < %d", $wpdb->esc_like( '_site_transient_' ) . '%', $wpdb->esc_like( '_site_transient_timeout_' ) . '%', time() ) );
 
 		// Export Tax Rates
 		$current_class = '';
@@ -224,6 +222,7 @@ final class WC_Taxjar {
 			__( 'Shipping', 'woocommerce' ) . ',' .
 			__( 'Tax Class', 'woocommerce' ) . "\n";
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSV export data, not HTML output.
 		echo $header;
 
 		foreach ( $rates as $rate ) {
@@ -328,7 +327,7 @@ final class WC_Taxjar {
 		if ( '' == $api_token && apply_filters( 'taxjar_should_display_connect_notice', true ) ) {
 			$url = $this->get_settings_url();
 			// translators: Installation admin notice
-			echo '<div class="updated fade"><p>' . sprintf( __( '%1$sTaxJar for WooCommerce is almost ready. %2$sTo get started, %3$sconnect your TaxJar account%4$s.', 'wc-taxjar' ), '<strong>', '</strong>', '<a href="' . esc_url( $url ) . '">', '</a>' ) . '</p></div>' . "\n";
+			echo wp_kses_post( '<div class="updated fade"><p>' . sprintf( __( '%1$sTaxJar for WooCommerce is almost ready. %2$sTo get started, %3$sconnect your TaxJar account%4$s.', 'wc-taxjar' ), '<strong>', '</strong>', '<a href="' . esc_url( $url ) . '">', '</a>' ) . '</p></div>' . "\n" );
 		}
 	}
 

--- a/taxjar-woocommerce.php
+++ b/taxjar-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: TaxJar - Sales Tax Automation for WooCommerce
  * Plugin URI: https://www.taxjar.com/woocommerce-sales-tax-plugin/
  * Description: Save hours every month by putting your sales tax on autopilot. Automated, multi-state sales tax calculation, collection, and filing.
- * Version: 4.2.9
+ * Version: 4.2.10
  * Author: TaxJar
  * Author URI: https://www.taxjar.com
  * WC requires at least: 7.0.0
@@ -43,7 +43,7 @@ if ( ! $woocommerce_active || version_compare( get_option( 'woocommerce_db_versi
  */
 final class WC_Taxjar {
 
-	static $version = '4.2.9';
+	static $version = '4.2.10';
 	public static $minimum_woocommerce_version = '7.0.0';
 
 	/**


### PR DESCRIPTION
# Summary

In an external notification on a Quality Insights Toolkit run we were notified that we had 47 PHPCS failures in our TaxJar WooCommerce Plugin code. This PR looks to resolve those 47 PHPCS failures. We'll also bump up the version of our TaxJar WooCommerce Plugin to 4.2.10.

The 47 failures are summarized here: https://docs.google.com/spreadsheets/d/1lit9_08gpTcGOcdxpsaJMG2NRKkfF95AjJEUCgtnVZM/edit?gid=0#gid=0

# Test Plan

- [x] Run the following script locally to surface PHPCS errors, confirm the 47 listed above are fixed:
  - `vendor/bin/phpcs --standard=phpcs.ruleset.xml includes/`

| Branch | Errors | Warnings | Total |
| ------- | ------ | ---------- | ---- |
| master | 479 | 493 | 972 |
| jackcobb/resolve-identified-phpcs-errors | 401 | 459 | 860 |

Appears my changes resolved in total 112 errors + warnings, including the 47 PHPCS failures surfaced in the Quality Insights Toolkit run.

Checked out to my branch in the local setup. Confirmed WooCommerce picked up the new changes for the TaxJar WooCommerce Plugin:

<img width="1728" height="1084" alt="evidence-click-testing-picked-up-tj-woocommerce-plugin-changes" src="https://github.com/user-attachments/assets/9e8559c3-1755-4763-b833-98bad2ea4ae6" />

- [x] Unit tests pass

<img width="884" height="171" alt="verified-unit-tests-passed" src="https://github.com/user-attachments/assets/8c3e36fb-781c-4773-bf4d-923546b3a1c7" />

- [x] Click-testing passed on the new changes

<img width="1728" height="1084" alt="verified-click-testing" src="https://github.com/user-attachments/assets/431370da-6f28-4035-8ff3-a4e398469364" />
