### PR TITLE
ci: run WordPress test matrix on Debian Bookworm

### DIFF
--- a/.buildkite/Dockerfile.test
+++ b/.buildkite/Dockerfile.test
@@ -1,0 +1,42 @@
+ARG PHP_VERSION=8.2
+FROM php:${PHP_VERSION}-apache-bookworm
+
+ARG WP_VERSION=6.4
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libwebp-dev \
+        libzip-dev \
+        unzip \
+    ; \
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+    ; \
+    docker-php-ext-install -j "$(nproc)" \
+        bcmath \
+        exif \
+        gd \
+        intl \
+        mysqli \
+        zip \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    curl -fL "https://wordpress.org/wordpress-${WP_VERSION}.tar.gz" -o wordpress.tar.gz; \
+    tar -xzf wordpress.tar.gz -C /usr/src/; \
+    rm wordpress.tar.gz; \
+    chown -R www-data:www-data /usr/src/wordpress; \
+    a2enmod rewrite expires
+
+CMD ["apache2-foreground"]

--- a/.buildkite/docker-compose.test.yml
+++ b/.buildkite/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mysql:
     image: mysql:8.0
@@ -18,7 +16,12 @@ services:
       start_period: 10s
 
   wordpress:
-    image: wordpress:${WP_VERSION:-6.4}-php${PHP_VERSION:-8.2}
+    build:
+      context: ..
+      dockerfile: .buildkite/Dockerfile.test
+      args:
+        PHP_VERSION: ${PHP_VERSION:-8.2}
+        WP_VERSION: ${WP_VERSION:-6.4}
     depends_on:
       mysql:
         condition: service_healthy

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,8 +101,10 @@ steps:
           limit: 2
     plugins:
       - docker-compose#v4.14.0:
+          build: wordpress
           run: wordpress
           config: .buildkite/docker-compose.test.yml
+          skip-pull: true
           command: ["/test-scripts/set-test-env.sh"]
           rm: false  # Don't auto-remove container so we can capture logs
           environment:
@@ -209,4 +211,3 @@ steps:
           mount-buildkite-agent: true
           always-pull: true
     timeout_in_minutes: 5
-

--- a/.buildkite/scripts/run-tests-in-container.sh
+++ b/.buildkite/scripts/run-tests-in-container.sh
@@ -46,9 +46,10 @@ fi
 print_status "Starting Apache web server"
 service apache2 start > /dev/null 2>&1
 
-# Install necessary tools
-print_status "Installing system tools"
-apt-get update -qq && apt-get install -qq -y unzip > /dev/null 2>&1
+# Verify tools installed by the test image
+print_status "Verifying system tools"
+command -v git > /dev/null
+command -v unzip > /dev/null
 
 # Wait for WordPress to be ready
 print_status "Waiting for WordPress to be ready"
@@ -80,6 +81,18 @@ if ! command -v wp &> /dev/null; then
 fi
 
 cd /var/www/html
+
+# The custom Bookworm image does not use the WordPress image entrypoint, so
+# create the database configuration before installing WordPress.
+if [ ! -f wp-config.php ]; then
+    print_status "Creating WordPress database configuration"
+    wp config create \
+        --dbname="${WORDPRESS_DB_NAME}" \
+        --dbuser="${WORDPRESS_DB_USER}" \
+        --dbpass="${WORDPRESS_DB_PASSWORD}" \
+        --dbhost="${WORDPRESS_DB_HOST}" \
+        --allow-root > /dev/null 2>&1
+fi
 
 # Install WordPress if needed
 if wp core is-installed --allow-root 2>/dev/null; then


### PR DESCRIPTION
## Summary

Run the Buildkite WordPress test matrix on Debian Bookworm.

## Problem

The pinned WordPress images use Bullseye. Its retired security repository causes `apt-get update` to fail, leaving `unzip` unavailable and breaking the WC 7.x jobs.

## Solution

- Build test containers from official `php:<version>-apache-bookworm` images
- Install the required WordPress extensions and tools in the image
- Download the pinned WordPress version and configure it in the test runner

## Test plan

- [x] Built the WC 7.x image locally and confirmed Debian 12 Bookworm with `unzip`
- [x] [Buildkite #217](https://buildkite.com/taxjar/taxjar-woocommerce-plugin/builds/217) passed for WC 7.x through 10.x